### PR TITLE
Branding changes updates

### DIFF
--- a/app/config.json
+++ b/app/config.json
@@ -1,3 +1,8 @@
 {
-  "serviceName": "Apply for a marine licence"
+  "serviceName": "Apply for a marine licence",
+  "plugins": {
+    "govuk-frontend": {
+      "rebrand": true
+    }
+  }
 }

--- a/app/views/about-the-prototype.html
+++ b/app/views/about-the-prototype.html
@@ -1,11 +1,15 @@
 {% extends "layouts/main.html" %}
 
 {% block header %}
+{% from "govuk/components/header/macro.njk" import govukHeader %}
+{% from "govuk/components/service-navigation/macro.njk" import govukServiceNavigation %}
+
 {{ govukHeader({
-    homepageUrl: "/",
-    serviceName: "Marine Management Organisation",
-    serviceUrl: ""
-  }) }}
+  classes: "govuk-header--full-width-border"
+}) }}
+{{ govukServiceNavigation({
+  serviceName: "MMO"
+}) }}
 {% endblock %}
 
 <!-- Setting the big main heading at the top of the page -->

--- a/app/views/alpha-2024.html
+++ b/app/views/alpha-2024.html
@@ -1,12 +1,6 @@
 {% extends "layouts/main.html" %}
 
-{% block header %}
-{{ govukHeader({
-    homepageUrl: "/",
-    serviceName: "Marine Management Organisation",
-    serviceUrl: ""
-  }) }}
-{% endblock %}
+
 
 <!-- Setting the big main heading at the top of the page -->
 {% set pageHeadingTextHTML %}

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -1,12 +1,6 @@
 {% extends "layouts/main.html" %}
 
-{% block header %}
-{{ govukHeader({
-    homepageUrl: "/",
-    serviceName: "Marine Management Organisation",
-    serviceUrl: ""
-  }) }}
-{% endblock %}
+
 
 <!-- Setting the big main heading at the top of the page -->
 {% set pageHeadingTextHTML %}

--- a/app/views/layouts/main.html
+++ b/app/views/layouts/main.html
@@ -3,9 +3,19 @@ For guidance on how to use layouts see:
 https://prototype-kit.service.gov.uk/docs/how-to-use-layouts
 #}
 
-
-
 {% extends "govuk-prototype-kit/layouts/govuk-branded.njk" %}
+
+{% block header %}
+{% from "govuk/components/header/macro.njk" import govukHeader %}
+{% from "govuk/components/service-navigation/macro.njk" import govukServiceNavigation %}
+
+{{ govukHeader({
+  classes: "govuk-header--full-width-border"
+}) }}
+{{ govukServiceNavigation({
+  serviceName: "MMO"
+}) }}
+{% endblock %}
 
 {% block beforeContent %}
 

--- a/app/views/versions/multiple-sites/check/exemption.html
+++ b/app/views/versions/multiple-sites/check/exemption.html
@@ -1,15 +1,7 @@
 {% extends "../layouts/main.html" %}
 
-<!--Start of Remove this after UR-->
-{% block header %}
-	{{ govukHeader({
-		homepageUrl: "/",
-		serviceName: "MMO",
-		serviceUrl: "/versions/2025-03-03/check/start"
-	}) }}
-{% endblock %}
-
 {% block beforeContent %}
+	{% include "../includes/phase-banner.html" %} 
 	{% include "../includes/back-link.html" %}
 {% endblock %}
 <!--End of Remove this after UR-->
@@ -24,9 +16,8 @@ You need to provide more information, but you do not need a marine licence
     {{ pageHeadingTextHTML }} - {{ data['headerName'] }}
 {% endblock %}
 
+
 {% block content %}
-
-
 <div class="govuk-grid-row">
 
 	<div class="govuk-grid-column-two-thirds">

--- a/app/views/versions/multiple-sites/exemption/check-answers-internal.html
+++ b/app/views/versions/multiple-sites/exemption/check-answers-internal.html
@@ -1,11 +1,15 @@
 {% extends "../layouts/exemption.html" %}
   
 {% block header %}
+{% from "govuk/components/header/macro.njk" import govukHeader %}
+{% from "govuk/components/service-navigation/macro.njk" import govukServiceNavigation %}
+
 {{ govukHeader({
-    homepageUrl: "/",
-    serviceName: "Marine Management Organisation",
-    serviceUrl: ""
-  }) }}
+  classes: "govuk-header--full-width-border"
+}) }}
+{{ govukServiceNavigation({
+  serviceName: "MMO"
+}) }}
 {% endblock %}
 
 {% block beforeContent %}

--- a/app/views/versions/multiple-sites/exemption/sign-in.html
+++ b/app/views/versions/multiple-sites/exemption/sign-in.html
@@ -1,11 +1,15 @@
 {% extends "../layouts/exemption.html" %}
 
 {% block header %}
-	{{ govukHeader({
-		homepageUrl: "/",
-		serviceName: "Government Gateway",
-		serviceUrl: "/versions/2025-03-03/check/start"
-	}) }}
+{% from "govuk/components/header/macro.njk" import govukHeader %}
+{% from "govuk/components/service-navigation/macro.njk" import govukServiceNavigation %}
+
+{{ govukHeader({
+  classes: "govuk-header--full-width-border"
+}) }}
+{{ govukServiceNavigation({
+  serviceName: "Government Gateway"
+}) }}
 {% endblock %}
 
 {% block beforeContent %}

--- a/app/views/versions/multiple-sites/layouts/main.html
+++ b/app/views/versions/multiple-sites/layouts/main.html
@@ -6,12 +6,18 @@ https://prototype-kit.service.gov.uk/docs/how-to-use-layouts
 {% extends "govuk-prototype-kit/layouts/govuk-branded.njk" %}
 
 {% block header %}
+{% from "govuk/components/header/macro.njk" import govukHeader %}
+{% from "govuk/components/service-navigation/macro.njk" import govukServiceNavigation %}
+
 {{ govukHeader({
-    homepageUrl: "/",
-    serviceName: "Check if you need a marine licence",
-    serviceUrl: "/versions/mvp/check/start"
-  }) }}
+  classes: "govuk-header--full-width-border"
+}) }}
+{{ govukServiceNavigation({
+  serviceName: "MMO"
+}) }}
 {% endblock %}
+
+
 
 {% block beforeContent %}
 

--- a/app/views/versions/mvp/check/exemption.html
+++ b/app/views/versions/mvp/check/exemption.html
@@ -1,15 +1,8 @@
 {% extends "../layouts/main.html" %}
 
-<!--Start of Remove this after UR-->
-{% block header %}
-	{{ govukHeader({
-		homepageUrl: "/",
-		serviceName: "MMO",
-		serviceUrl: "/versions/2025-03-03/check/start"
-	}) }}
-{% endblock %}
 
 {% block beforeContent %}
+{% include "../includes/phase-banner.html" %} 		
 	{% include "../includes/back-link.html" %}
 {% endblock %}
 <!--End of Remove this after UR-->

--- a/app/views/versions/mvp/exemption/check-answers-internal.html
+++ b/app/views/versions/mvp/exemption/check-answers-internal.html
@@ -1,11 +1,15 @@
 {% extends "../layouts/exemption.html" %}
   
 {% block header %}
+{% from "govuk/components/header/macro.njk" import govukHeader %}
+{% from "govuk/components/service-navigation/macro.njk" import govukServiceNavigation %}
+
 {{ govukHeader({
-    homepageUrl: "/",
-    serviceName: "Marine Management Organisation",
-    serviceUrl: ""
-  }) }}
+  classes: "govuk-header--full-width-border"
+}) }}
+{{ govukServiceNavigation({
+  serviceName: "MMO"
+}) }}
 {% endblock %}
 
 {% block beforeContent %}

--- a/app/views/versions/mvp/exemption/sign-in.html
+++ b/app/views/versions/mvp/exemption/sign-in.html
@@ -1,11 +1,15 @@
 {% extends "../layouts/exemption.html" %}
 
 {% block header %}
-	{{ govukHeader({
-		homepageUrl: "/",
-		serviceName: "Government Gateway",
-		serviceUrl: "/versions/2025-03-03/check/start"
-	}) }}
+{% from "govuk/components/header/macro.njk" import govukHeader %}
+{% from "govuk/components/service-navigation/macro.njk" import govukServiceNavigation %}
+
+{{ govukHeader({
+  classes: "govuk-header--full-width-border"
+}) }}
+{{ govukServiceNavigation({
+  serviceName: "Government Gateway"
+}) }}
 {% endblock %}
 
 {% block beforeContent %}

--- a/app/views/versions/mvp/layouts/main.html
+++ b/app/views/versions/mvp/layouts/main.html
@@ -6,11 +6,15 @@ https://prototype-kit.service.gov.uk/docs/how-to-use-layouts
 {% extends "govuk-prototype-kit/layouts/govuk-branded.njk" %}
 
 {% block header %}
+{% from "govuk/components/header/macro.njk" import govukHeader %}
+{% from "govuk/components/service-navigation/macro.njk" import govukServiceNavigation %}
+
 {{ govukHeader({
-    homepageUrl: "/",
-    serviceName: "Check if you need a marine licence",
-    serviceUrl: "/versions/mvp/check/start"
-  }) }}
+  classes: "govuk-header--full-width-border"
+}) }}
+{{ govukServiceNavigation({
+  serviceName: "MMO"
+}) }}
 {% endblock %}
 
 {% block beforeContent %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
         "@govuk-prototype-kit/task-list": "2.0.0",
         "@ministryofjustice/frontend": "^5.1.2",
         "@x-govuk/govuk-prototype-filters": "2.0.0",
-        "govuk-frontend": "5.9.0",
+        "govuk-frontend": "^5.10.0",
         "govuk-prototype-kit": "^13.16.2",
         "hmrc-frontend": "6.59.0"
       }
@@ -1893,9 +1893,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.9.0.tgz",
-      "integrity": "sha512-8NzmyoDtRFYyHs413DfNPR8Zo6qw6Q02Mruxml/Yfy+EueaOI/JZ4gVM8d0pqzJmTiMcJuHhvxqYEgBRmqeoyA==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.10.0.tgz",
+      "integrity": "sha512-9tjpB8PDwsDqutkQPJXfDalLvNOeKxzFhV7me21s/oyn7HcTg/ei/GC3Y4JvNsXauzjOkxv4eeCHntKeySkdMg==",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@govuk-prototype-kit/task-list": "2.0.0",
     "@ministryofjustice/frontend": "^5.1.2",
     "@x-govuk/govuk-prototype-filters": "2.0.0",
-    "govuk-frontend": "5.9.0",
+    "govuk-frontend": "^5.10.0",
     "govuk-prototype-kit": "^13.16.2",
     "hmrc-frontend": "6.59.0"
   }


### PR DESCRIPTION
Some of the older versions of the prototype (v1 - v4) have the branding but the Service name is still in the header. As we are now only looking at, and testing, MVP and multiple-sites versions I don't think this is a problem.