### PR TITLE
Review site details Save and Cancel links fix

### DIFF
--- a/app/views/versions/multiple-sites/exemption/review-site-details.html
+++ b/app/views/versions/multiple-sites/exemption/review-site-details.html
@@ -85,7 +85,7 @@ Review site details
                             Upload a file with the coordinates of the site
                         </dd>
                         <dd class="govuk-summary-list__actions">
-                            <a href="how-do-you-want-to-provide-the-coordinates?fromreview=true#site-location" class="govuk-link">
+                            <a href="how-do-you-want-to-provide-the-coordinates?returnTo=review-site-details#site-location" class="govuk-link">
                                 Change<span class="govuk-visually-hidden"> method of providing site location</span>
                             </a>
                         </dd>
@@ -314,7 +314,7 @@ Review site details
                 {{ govukButton({
                     text: "Save and continue"
                 }) }}
-                <a class="govuk-link govuk-link--no-visited-state" href="cancel-site-details">Cancel</a>
+                <a class="govuk-link govuk-link--no-visited-state" href="cancel-from-review-site-details">Cancel</a>
             </div>
         </form>
     </div>


### PR DESCRIPTION
The fixes I've made will:

Fix the slow Save and continue button on review-site-details by removing duplicate code and fixing the syntax errors in the route handler.

Fix the non-working cancel link on review-site-details by:

Creating a new dedicated handler for canceling from review-site-details Updating the cancel link to use this new handler
Ensuring the correct redirect based on where the user came from (check-answers-multiple-sites, site-details-added, or task-list) These changes should resolve both issues:

The Save and continue button should now be much faster as we've removed duplicate code and fixed syntax issues. The cancel link should now work correctly, sending the user to the appropriate page based on their journey context.