### PR TITLE
Add projects page and related routes for sample plans

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -313,7 +313,7 @@
 }
 
 // Page-specific overrides
-.page-home {
+.page-home, .page-sample-plans-projects {
   .govuk-width-container,
   .govuk-header__container,
   .govuk-header__navigation,
@@ -445,6 +445,12 @@ body.page-cookie-banner {
   flex-shrink: 0;
 }
 
+.page-header-buttons {
+  display: flex;
+  gap: 15px; // govuk-spacing(3)
+  flex-shrink: 0;
+}
+
 // Mobile responsive behavior
 @media (max-width: 40.0525em) {
   .page-header-with-button {
@@ -460,6 +466,12 @@ body.page-cookie-banner {
   .page-header-button {
     align-self: stretch; // Full width on mobile
     text-align: center;
+  }
+  
+  .page-header-buttons {
+    flex-direction: column;
+    width: 100%;
+    gap: 10px; // govuk-spacing(2) for mobile
   }
 }
 

--- a/app/routes/versions/multiple-sites-v2/sample-plans-v1.js
+++ b/app/routes/versions/multiple-sites-v2/sample-plans-v1.js
@@ -4,6 +4,38 @@ module.exports = function (router) {
   const section = "sample-plans-v1";
 
   ///////////////////////////////////////////
+  // Projects page
+  ///////////////////////////////////////////
+
+  router.get(`/versions/${version}/${section}/projects`, function (req, res) {
+    req.session.data['isSamplePlansSection'] = true;
+    res.render(`versions/${version}/${section}/projects`);
+  });
+
+  // Delete project route
+  router.get(`/versions/${version}/${section}/delete`, function (req, res) {
+    const projectToDelete = req.query.project;
+    
+    if (projectToDelete === 'sample-plan-user') {
+      req.session.data['userSamplePlanProjectDeleted'] = "true";
+      // Clear the user's sample plan project data
+      req.session.data['sample-plan-project-name-text-input'] = '';
+      req.session.data['sample-plan-which-activity'] = '';
+      req.session.data['sample-plan-new-or-existing-licence'] = '';
+      req.session.data['sample-plan-dredging-volumes-completed'] = "false";
+      req.session.data['sample-plan-fee-estimate-completed'] = "false";
+    } else if (projectToDelete === 'south-coast') {
+      // Handle deletion of the South coast sample project
+      // Could set a flag to hide this project in the view
+    } else if (projectToDelete === 'my-sample-plan') {
+      // Handle deletion of the My sample plan project
+      // Could set a flag to hide this project in the view
+    }
+    
+    res.redirect('projects');
+  });
+
+  ///////////////////////////////////////////
   // Sample plan information page
   ///////////////////////////////////////////
 

--- a/app/views/versions/multiple-sites-v2/includes/organisation-switcher.html
+++ b/app/views/versions/multiple-sites-v2/includes/organisation-switcher.html
@@ -1,6 +1,6 @@
 <div class="app-organisation-switcher">
 	<span class="govuk-body-s govuk-!-font-weight-bold app-organisation-switcher__name">{{ data['organisation-name'] }}</span>
-	{% if currentPageId === "home" %}
+	{% if currentPageId === "home" or currentPageId === "sample-plans-projects" %}
 		{% if data['component_type'] === 'autocomplete' %}
 			<a class="govuk-link app-organisation-switcher__link govuk-link--no-visited-state" href="organisation-selector-autocomplete?change=true">
 				Change organisation

--- a/app/views/versions/multiple-sites-v2/layouts/exemption.html
+++ b/app/views/versions/multiple-sites-v2/layouts/exemption.html
@@ -20,7 +20,7 @@ https://prototype-kit.service.gov.uk/docs/how-to-use-layouts
   serviceName: "Get a plan for sediment sample analysis",
   navigation: [
     {
-      href: "#",
+      href: "/versions/multiple-sites-v2/sample-plans-v1/projects",
       text: "Projects"
     },
     {

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/projects.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/projects.html
@@ -1,0 +1,281 @@
+{% extends "../layouts/exemption.html" %}
+
+{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+
+<!-- Set a variable to identify this specific page -->
+{% set currentPageId = "sample-plans-projects" %}
+
+{% block header %}
+{% from "govuk/components/header/macro.njk" import govukHeader %}
+{% from "govuk/components/service-navigation/macro.njk" import govukServiceNavigation %}
+
+{{ govukHeader({
+  classes: "govuk-header--full-width-border"
+}) }}
+{{ govukServiceNavigation({
+  serviceName: "Get permission for marine work",
+  navigation: [
+    {
+      href: "projects",
+      text: "Projects",
+	  active: true
+    },
+    {
+      href: "#",
+      text: "Defra account",
+      active: false
+    },
+    {
+      href: "/versions/multiple-sites-v2/sample-plans-v1/sign-in.html?goto=home",
+      text: "Sign out"
+    }
+  ]
+}) }}
+{% endblock %}
+
+{% block beforeContent %}
+	  	{% include "../includes/phase-banner.html" %}
+    {{ super() }}
+{% endblock %}
+
+<!-- Setting the big main heading at the top of the page -->
+{% set pageHeadingTextHTML %}
+Projects
+{% endset %}
+
+<!-- Text that show in the browser tab. Does NOT need changing -->
+{% block pageTitle %}
+    {{ pageHeadingTextHTML }} - {{ data['headerNameExemption'] }}
+{% endblock %}
+
+{% block content %}
+
+<!-- Notification banner -->
+{% set notificationHtml %}
+  <p class="govuk-notification-banner__heading govuk-!-margin-bottom-3" style="width: 100%; max-width: none; margin: 0;">
+    You may need to log in to a different system to access some of your applications
+  </p>
+  <p class="govuk-body" style="width: 100%; max-width: none; margin: 0;">
+    <a class="govuk-notification-banner__link" href="#">Sign in to the Marine Case Management System</a> to view or manage information that is not available in this system.
+  </p>
+{% endset %}
+
+<div style="width: 100%; max-width: 1280px; margin: 0 auto;">
+{{ govukNotificationBanner({
+  html: notificationHtml
+}) }}
+</div>
+
+<div class="govuk-grid-row">
+	<div class="govuk-grid-column-full">
+		<div class="page-header-with-button govuk-!-margin-bottom-6">
+			<div class="page-header-text-container">
+				<span class="govuk-caption-l">{{ data['organisation-name'] }}</span>
+				<h1 class="govuk-heading-l page-header-title">
+					{{ pageHeadingTextHTML }}
+				</h1>
+			</div>
+			<div class="page-header-buttons">
+				<a href="/versions/multiple-sites-v2/start-improved" role="button" draggable="false" class="govuk-button govuk-button--secondary page-header-button govuk-!-margin-right-3" data-module="govuk-button">
+					Create new project
+				</a>
+				<a href="" role="button" draggable="false" class="govuk-button govuk-button--secondary page-header-button" data-module="govuk-button">
+					Get new sample plan
+				</a>
+			</div>
+		</div>
+
+		{% set isDeleteProject = data['deleteSamplePlanProject'] == "true" %}
+		{% set isUserSamplePlanProjectDeleted = data['userSamplePlanProjectDeleted'] == "true" %}
+		{% set isAlternativeView = data['alternativeSamplePlanProjectView'] == "true" %}
+
+		{% if isDeleteProject %}
+
+		<p>You currently have no projects.</p>
+
+		{% else %}
+
+		<table class="govuk-table" data-module="moj-sortable-table">
+			<caption class="govuk-table__caption govuk-visually-hidden">{{ pageHeadingTextHTML }}</caption>
+			<thead class="govuk-table__head">
+			  <tr class="govuk-table__row">
+				<th scope="col" class="govuk-table__header" aria-sort="none">Project name</th>
+				<th scope="col" class="govuk-table__header" aria-sort="none">Type</th>
+				<th scope="col" class="govuk-table__header" aria-sort="none">Reference</th>
+				<th scope="col" class="govuk-table__header" aria-sort="descending">Status</th>
+				<th scope="col" class="govuk-table__header" aria-sort="none">Date submitted</th>
+				<th scope="col" class="govuk-table__header" aria-sort="none">Actions</th>
+			  </tr>
+			</thead>
+			<tbody class="govuk-table__body">
+				{% if not isDeleteProject and not isAlternativeView %}
+				<tr class="govuk-table__row">
+					<th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Tynemouth navigation dredge</th>
+					<td class="govuk-table__cell">
+						Sediment sample plan
+					</td>
+					<td class="govuk-table__cell" data-sort-value="001">
+						SAM/2025/00023
+					</td>
+					
+					<td class="govuk-table__cell" data-sort-value="001">
+						{{ govukTag({
+							text: "Sent"
+						}) }}
+					</td>
+					<td class="govuk-table__cell" data-sort-value="250820">20 Aug 2025</td>
+					<td class="govuk-table__cell" data-sort-value="View details">	
+						<a href="#" class="govuk-link--no-visited-state">View details</a>
+					</td>
+				</tr>
+				{% endif %}
+
+				{% if not isDeleteProject and not isAlternativeView %}
+				<tr class="govuk-table__row">
+					<th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Branscombe bore holes</th>
+					<td class="govuk-table__cell">
+						Exempt activity notification
+					</td>
+					<td class="govuk-table__cell" data-sort-value="001">
+						-
+					</td>
+					
+					<td class="govuk-table__cell" data-sort-value="005">
+						{{ govukTag({
+							text: "Draft",
+							classes: "govuk-tag--light-blue"
+						}) }}
+					</td>
+					<td class="govuk-table__cell" data-sort-value="-">-</td>
+					<td class="govuk-table__cell" data-sort-value="Continue">	
+						<a href="#" class="govuk-link--no-visited-state govuk-!-margin-right-4">Continue</a> <a href="delete?project=south-coast" class="govuk-link--no-visited-state">Delete</a>
+					</td>
+				</tr>
+				{% endif %}
+
+				{% if not isDeleteProject and not isAlternativeView %}
+				<tr class="govuk-table__row">
+					<th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Worthing sediment samples</th>
+					<td class="govuk-table__cell">
+						Exempt activity notification
+					</td>
+					<td class="govuk-table__cell" data-sort-value="003">
+						EXE/2025/00002
+					</td>
+					
+					<td class="govuk-table__cell" data-sort-value="004">
+						{{ govukTag({
+							text: "Active",
+							classes: "govuk-tag--green"
+						}) }}
+					</td>
+					<td class="govuk-table__cell" data-sort-value="-">12 May 2025</td>
+					<td class="govuk-table__cell" data-sort-value="Continue">	
+						<a href="#" class="govuk-link--no-visited-state govuk-!-margin-right-4">View details</a>
+					</td>
+				</tr>
+				{% endif %}
+
+				{% if not isDeleteProject and isAlternativeView %}
+				<tr class="govuk-table__row">
+					<th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Worthing sediment sample</th>
+					<td class="govuk-table__cell">
+						Sediment sample plan
+					</td>
+					<td class="govuk-table__cell" data-sort-value="003">
+						EXE/2025/00002
+					</td>
+					
+					<td class="govuk-table__cell" data-sort-value="002">
+						{{ govukTag({
+							text: "Sent"
+						}) }}
+					</td>
+					<td class="govuk-table__cell" data-sort-value="250512">12 May 2025</td>
+					<td class="govuk-table__cell" data-sort-value="View details">	
+						<a href="#" class="govuk-link--no-visited-state">View details</a>
+					</td>
+				</tr>
+				{% endif %}
+
+				{% if not isDeleteProject and isAlternativeView %}
+				<tr class="govuk-table__row">
+					<th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Tynemouth navigation dredge</th>
+					<td class="govuk-table__cell">
+						Sediment sample plan
+					</td>
+					<td class="govuk-table__cell" data-sort-value="004">
+						SAM/2025/00023
+					</td>
+					
+					<td class="govuk-table__cell" data-sort-value="001">
+						{{ govukTag({
+							text: "Sent"
+						}) }}
+					</td>
+					<td class="govuk-table__cell" data-sort-value="250820">20 Aug 2025</td>
+					<td class="govuk-table__cell" data-sort-value="View details">	
+						<a href="#" class="govuk-link--no-visited-state">View details</a>
+					</td>
+				</tr>
+				{% endif %}
+
+				{% if not isUserSamplePlanProjectDeleted and not isDeleteProject and data['sample-plan-project-name-text-input'] %}
+				<tr class="govuk-table__row">
+					<th scope="row" class="govuk-table__header govuk-!-font-weight-regular">{{ data['sample-plan-project-name-text-input'] }}</th>
+					<td class="govuk-table__cell">
+						Sediment sample plan
+					</td>
+
+					{% if data['samplePlanApplicationSubmitted'] == "true" %}
+					<td class="govuk-table__cell" data-sort-value="005">
+						SAM/2025/00005
+					</td>
+					{% else %}
+					<td class="govuk-table__cell" data-sort-value="-">
+						-
+					</td>
+					{% endif %}
+				
+					{% if data['samplePlanApplicationSubmitted'] == "true" %}	
+						<td class="govuk-table__cell" data-sort-value="001">
+							{{ govukTag({
+								text: "Sent",
+								classes: "govuk-tag--grey"
+							}) }}
+						</td>
+						<td class="govuk-table__cell" data-sort-value="250716">
+						{{ "today" | govukDate(truncate=true) }}
+						</td>
+					{% else %}
+						<td class="govuk-table__cell" data-sort-value="005">
+							{{ govukTag({
+								text: "Draft",
+								classes: "govuk-tag--light-blue"
+							}) }}
+						</td>
+						<td class="govuk-table__cell" data-sort-value="-">
+						-
+						</td>
+					{% endif %}
+					
+					{% if data['samplePlanApplicationSubmitted'] == "true" %}	
+						<td class="govuk-table__cell" data-sort-value="View details">
+							<a href="#" class="govuk-link--no-visited-state">View details</a>
+						</td>
+					{% else %}
+						<td class="govuk-table__cell" data-sort-value="Continue">
+							<a href="sample-plan-start-page" class="govuk-link--no-visited-state govuk-!-margin-right-4">Continue</a> <a href="delete?project=sample-plan-user" class="govuk-link--no-visited-state">Delete</a>
+						</td>
+					{% endif %}
+				</tr>
+				{% endif %}			  
+			</tbody>
+		</table>
+
+		{% endif %}
+
+	</div>
+</div>
+{% endblock %}


### PR DESCRIPTION
Introduces a new projects page for the sample plans section, including its view template, route handling, and project deletion logic. Updates styles for header buttons and organisation switcher logic to support the new page. Also updates navigation in the exemption layout to link to the projects page.