### PR TITLE
Update layout and content in sample plan views

### DIFF
--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/fee-estimate.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/fee-estimate.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/main.html" %}
+{% extends "../layouts/exemption.html" %}
 
 {% block beforeContent %}
 	{% include "../includes/phase-banner.html" %} 
@@ -41,7 +41,7 @@ Fee estimate
 
 <div class="govuk-grid-row">
 
-	<div class="govuk-grid-column-two-thirds">
+	<div class="govuk-grid-column-full">
 
 		<span class="govuk-caption-l">{{ data['sample-plan-project-name-text-input'] }}</span>
 		<h1 class="govuk-heading-l">
@@ -105,7 +105,7 @@ Fee estimate
 
 	</div>
 
-	<div class="govuk-grid-column-two-thirds">
+	<div class="govuk-grid-column-full">
 
 		<form action="fee-estimate-router" method="post">
 

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/sample-plan-start-page.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/sample-plan-start-page.html
@@ -30,17 +30,8 @@ Sample plan start page
 
 		<p><a href="https://www.gov.uk/guidance/marine-licensing-sediment-analysis-and-sample-plans" rel="noreferrer noopener" target="_blank" class="govuk-link">Read the guidance on sampling requirements (opens in new tab)</a>.</p>
 
-		<h2 class="govuk-heading-m">Information you need to provide to get a sample plan</h2>
+		<h2 class="govuk-heading-m">When you provide your information you'll need to:</h2>
 
-		<p>This includes:</p>
-		<ul class="govuk-list govuk-list--bullet">
-			<li>type of activity</li>
-			<li>if it's a new or existing licence</li>
-			<li>details of the site where the dredging or disposal will take place</li>
-			<li>what the activity involves, including dredging amounts and depths</li>
-		</ul>
-
-		<h3 class="govuk-heading-s">When you provide your information you'll need to:</h3>
 		<ul class="govuk-list govuk-list--bullet">
 			<li>complete the type of activity before you can start some tasks as depending on your answers you may not need to complete them</li>
 			<li>save your progress at the end of each section if you need to come back later</li>


### PR DESCRIPTION
Changed fee-estimate.html to extend the exemption layout and updated grid columns to full width for better presentation. Revised sample-plan-start-page.html to simplify and clarify information requirements, removing redundant details and improving guidance for users.