### PR TITLE
Update dredging and site history forms for clarity

### DIFF
--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/check-answers.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/check-answers.html
@@ -58,9 +58,9 @@ Check your answers before sending your information
             </div>
         </div>
 
-        <h2 class="govuk-heading-m">Now send your information</h2>
+        <h2 class="govuk-heading-m">Send your information</h2>
         
-        <p class="govuk-body">By submitting this information you're confirming that, to the best of your knowledge, the details you're providing are correct.</p>
+        <p class="govuk-body">By sending this information you're confirming that, to the best of your knowledge, the details you're providing are correct.</p>
 
         <form action="check-answers-router" method="post" novalidate>
             <div class="govuk-button-group">

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/dredging-details-site-1.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/dredging-details-site-1.html
@@ -35,9 +35,9 @@ Dredging details
             titleText: "There is a problem",
             errorList: [
                 {
-                    text: data['dredging-details-site-1-material-type-other-error'] or data['dredging-details-site-1-material-type-error'] or "Select the type of material that will be dredged at this site",
-                    href: "#dredging-details-site-1-material-type-other" if data['dredging-details-site-1-material-type-other-error'] else "#dredging-details-site-1-material-type"
-                } if data['dredging-details-site-1-material-type-error'] or data['dredging-details-site-1-material-type-other-error'],
+                    text: data['dredging-details-site-1-material-type-error'] or "Select the type of material that will be dredged at this site",
+                    href: "#dredging-details-site-1-material-type"
+                } if data['dredging-details-site-1-material-type-error'],
                 {
                     text: data['dredging-details-site-1-method-other-error'] or data['dredging-details-site-1-method-error'] or "Select the proposed method of dredging",
                     href: "#dredging-details-site-1-method-other" if data['dredging-details-site-1-method-other-error'] else "#dredging-details-site-1-method"
@@ -58,22 +58,6 @@ Dredging details
         <form action="dredging-details-site-1-router" method="post" novalidate>
             
             <!-- Question 1: What type of material will be dredged at this site? -->
-            {% set materialTypeOtherHtml %}
-            {{ govukInput({
-                id: "dredging-details-site-1-material-type-other",
-                name: "dredging-details-site-1-material-type-other",
-                type: "text",
-                classes: "govuk-!-width-full",
-                label: {
-                    text: "Describe the other material"
-                },
-                value: data['dredging-details-site-1-material-type-other'],
-                errorMessage: {
-                    text: data['dredging-details-site-1-material-type-other-error']
-                } if data['dredging-details-site-1-material-type-other-error']
-            }) }}
-            {% endset -%}
-
             {{ govukCheckboxes({
                 idPrefix: "dredging-details-site-1-material-type",
                 name: "dredging-details-site-1-material-type",
@@ -108,22 +92,12 @@ Dredging details
                         checked: true if data['dredging-details-site-1-material-type'] and "maintenance-dredged-material" in data['dredging-details-site-1-material-type']
                     },
                     {
-                        value: "non-dredged-sediments",
-                        text: "Non-dredged sediments",
-                        checked: true if data['dredging-details-site-1-material-type'] and "non-dredged-sediments" in data['dredging-details-site-1-material-type']
-                    },
-                    {
-                        value: "organic-material",
-                        text: "Organic material of natural origin (for example, seaweed)",
-                        checked: true if data['dredging-details-site-1-material-type'] and "organic-material" in data['dredging-details-site-1-material-type']
-                    },
-                    {
-                        value: "other",
-                        text: "Other",
-                        checked: true if data['dredging-details-site-1-material-type'] and "other" in data['dredging-details-site-1-material-type'],
-                        conditional: {
-                            html: materialTypeOtherHtml
-                        }
+                        value: "remediation-dredged-material",
+                        text: "Remediation (environmental) dredged material",
+                        hint: {
+                            text: "Removal of contaminated or polluted material to protect the environment"
+                        },
+                        checked: true if data['dredging-details-site-1-material-type'] and "remediation-dredged-material" in data['dredging-details-site-1-material-type']
                     }
                 ]
             }) }}
@@ -211,7 +185,7 @@ Dredging details
                     classes: "govuk-label--s"
                 },
                 hint: {
-                    text: "This is calculated by using the current depth of the sea or river bed and how much you need to deepen it by"
+                    text: "This is calculated by using the current depth of the sea or river bed and how much you need to deepen it by, for example if the current depth is 10m chart datum and you're deepening it to 12m chart datum, the dredge depth is 2m of sediment"
                 },
                 suffix: {
                     text: "m"

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/dredging-details-site-2.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/dredging-details-site-2.html
@@ -35,9 +35,9 @@ Dredging details
             titleText: "There is a problem",
             errorList: [
                 {
-                    text: data['dredging-details-site-2-material-type-other-error'] or data['dredging-details-site-2-material-type-error'] or "Select the type of material that will be dredged at this site",
-                    href: "#dredging-details-site-2-material-type-other" if data['dredging-details-site-2-material-type-other-error'] else "#dredging-details-site-2-material-type"
-                } if data['dredging-details-site-2-material-type-error'] or data['dredging-details-site-2-material-type-other-error'],
+                    text: data['dredging-details-site-2-material-type-error'] or "Select the type of material that will be dredged at this site",
+                    href: "#dredging-details-site-2-material-type"
+                } if data['dredging-details-site-2-material-type-error'],
                 {
                     text: data['dredging-details-site-2-method-other-error'] or data['dredging-details-site-2-method-error'] or "Select the proposed method of dredging",
                     href: "#dredging-details-site-2-method-other" if data['dredging-details-site-2-method-other-error'] else "#dredging-details-site-2-method"
@@ -58,22 +58,6 @@ Dredging details
         <form action="dredging-details-site-2-router" method="post" novalidate>
             
             <!-- Question 1: What type of material will be dredged at this site? -->
-            {% set materialTypeOtherHtml %}
-            {{ govukInput({
-                id: "dredging-details-site-2-material-type-other",
-                name: "dredging-details-site-2-material-type-other",
-                type: "text",
-                classes: "govuk-!-width-full",
-                label: {
-                    text: "Describe the other material"
-                },
-                value: data['dredging-details-site-2-material-type-other'],
-                errorMessage: {
-                    text: data['dredging-details-site-2-material-type-other-error']
-                } if data['dredging-details-site-2-material-type-other-error']
-            }) }}
-            {% endset -%}
-
             {{ govukCheckboxes({
                 idPrefix: "dredging-details-site-2-material-type",
                 name: "dredging-details-site-2-material-type",
@@ -108,22 +92,12 @@ Dredging details
                         checked: true if data['dredging-details-site-2-material-type'] and "maintenance-dredged-material" in data['dredging-details-site-2-material-type']
                     },
                     {
-                        value: "non-dredged-sediments",
-                        text: "Non-dredged sediments",
-                        checked: true if data['dredging-details-site-2-material-type'] and "non-dredged-sediments" in data['dredging-details-site-2-material-type']
-                    },
-                    {
-                        value: "organic-material",
-                        text: "Organic material of natural origin (for example, seaweed)",
-                        checked: true if data['dredging-details-site-2-material-type'] and "organic-material" in data['dredging-details-site-2-material-type']
-                    },
-                    {
-                        value: "other",
-                        text: "Other",
-                        checked: true if data['dredging-details-site-2-material-type'] and "other" in data['dredging-details-site-2-material-type'],
-                        conditional: {
-                            html: materialTypeOtherHtml
-                        }
+                        value: "remediation-dredged-material",
+                        text: "Remediation (environmental) dredged material",
+                        hint: {
+                            text: "Removal of contaminated or polluted material to protect the environment"
+                        },
+                        checked: true if data['dredging-details-site-2-material-type'] and "remediation-dredged-material" in data['dredging-details-site-2-material-type']
                     }
                 ]
             }) }}
@@ -211,7 +185,7 @@ Dredging details
                     classes: "govuk-label--s"
                 },
                 hint: {
-                    text: "This is calculated by using the current depth of the sea or river bed and how much you need to deepen it by"
+                    text: "This is calculated by using the current depth of the sea or river bed and how much you need to deepen it by, for example if the current depth is 10m chart datum and you're deepening it to 12m chart datum, the dredge depth is 2m of sediment"
                 },
                 suffix: {
                     text: "m"

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/site-history-site-1.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/site-history-site-1.html
@@ -86,7 +86,7 @@ What is the history of the site?
                 id: "site-history-site-1-chemicals-manufacturing-details",
                 name: "site-history-site-1-chemicals-manufacturing-details",
                 label: {
-                    text: "Provide details"
+                    text: "Include how long ago this activity took place, or if it’s still active, and how close it is to the area"
                 },
                 value: data['site-history-site-1-chemicals-manufacturing-details'],
                 errorMessage: {
@@ -101,7 +101,7 @@ What is the history of the site?
                 id: "site-history-site-1-electronics-manufacturing-details",
                 name: "site-history-site-1-electronics-manufacturing-details",
                 label: {
-                    text: "Provide details"
+                    text: "Include how long ago this activity took place, or if it’s still active, and how close it is to the area"
                 },
                 value: data['site-history-site-1-electronics-manufacturing-details'],
                 errorMessage: {
@@ -116,7 +116,7 @@ What is the history of the site?
                 id: "site-history-site-1-major-port-infrastructure-details",
                 name: "site-history-site-1-major-port-infrastructure-details",
                 label: {
-                    text: "Provide details"
+                    text: "Include how long ago this activity took place, or if it’s still active, and how close it is to the area"
                 },
                 value: data['site-history-site-1-major-port-infrastructure-details'],
                 errorMessage: {
@@ -131,7 +131,7 @@ What is the history of the site?
                 id: "site-history-site-1-mining-details",
                 name: "site-history-site-1-mining-details",
                 label: {
-                    text: "Provide details"
+                    text: "Include how long ago this activity took place, or if it’s still active, and how close it is to the area"
                 },
                 value: data['site-history-site-1-mining-details'],
                 errorMessage: {
@@ -146,7 +146,7 @@ What is the history of the site?
                 id: "site-history-site-1-oil-processing-details",
                 name: "site-history-site-1-oil-processing-details",
                 label: {
-                    text: "Provide details"
+                    text: "Include how long ago this activity took place, or if it’s still active, and how close it is to the area"
                 },
                 value: data['site-history-site-1-oil-processing-details'],
                 errorMessage: {
@@ -161,7 +161,7 @@ What is the history of the site?
                 id: "site-history-site-1-pollution-incidents-details",
                 name: "site-history-site-1-pollution-incidents-details",
                 label: {
-                    text: "Provide details"
+                    text: "Include how long ago this activity took place, or if it’s still active, and how close it is to the area"
                 },
                 value: data['site-history-site-1-pollution-incidents-details'],
                 errorMessage: {
@@ -176,7 +176,7 @@ What is the history of the site?
                 id: "site-history-site-1-ship-building-details",
                 name: "site-history-site-1-ship-building-details",
                 label: {
-                    text: "Provide details"
+                    text: "Include how long ago this activity took place, or if it’s still active, and how close it is to the area"
                 },
                 value: data['site-history-site-1-ship-building-details'],
                 errorMessage: {
@@ -191,7 +191,7 @@ What is the history of the site?
                 id: "site-history-site-1-steelworks-details",
                 name: "site-history-site-1-steelworks-details",
                 label: {
-                    text: "Provide details"
+                    text: "Include how long ago this activity took place, or if it’s still active, and how close it is to the area"
                 },
                 value: data['site-history-site-1-steelworks-details'],
                 errorMessage: {
@@ -206,7 +206,7 @@ What is the history of the site?
                 id: "site-history-site-1-other-details",
                 name: "site-history-site-1-other-details",
                 label: {
-                    text: "Provide details"
+                    text: "Include how long ago this activity took place, or if it’s still active, and how close it is to the area"
                 },
                 value: data['site-history-site-1-other-details'],
                 errorMessage: {
@@ -308,9 +308,9 @@ What is the history of the site?
                         divider: "or"
                     },
                     {
-                        value: "not-previously-used",
-                        text: "Not previously used for anything",
-                        checked: true if data['site-history-site-1'] and "not-previously-used" in data['site-history-site-1']
+                        value: "no-history-industrial-use",
+                        text: "No history of industrial use",
+                        checked: true if data['site-history-site-1'] and "no-history-industrial-use" in data['site-history-site-1']
                     }
                 ]
             }) }}

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/site-history-site-2.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/site-history-site-2.html
@@ -86,7 +86,7 @@ What is the history of the site?
                 id: "site-history-site-2-chemicals-manufacturing-details",
                 name: "site-history-site-2-chemicals-manufacturing-details",
                 label: {
-                    text: "Provide details"
+                    text: "Include how long ago this activity took place, or if it’s still active, and how close it is to the area"
                 },
                 value: data['site-history-site-2-chemicals-manufacturing-details'],
                 errorMessage: {
@@ -101,7 +101,7 @@ What is the history of the site?
                 id: "site-history-site-2-electronics-manufacturing-details",
                 name: "site-history-site-2-electronics-manufacturing-details",
                 label: {
-                    text: "Provide details"
+                    text: "Include how long ago this activity took place, or if it’s still active, and how close it is to the area"
                 },
                 value: data['site-history-site-2-electronics-manufacturing-details'],
                 errorMessage: {
@@ -116,7 +116,7 @@ What is the history of the site?
                 id: "site-history-site-2-major-port-infrastructure-details",
                 name: "site-history-site-2-major-port-infrastructure-details",
                 label: {
-                    text: "Provide details"
+                    text: "Include how long ago this activity took place, or if it’s still active, and how close it is to the area"
                 },
                 value: data['site-history-site-2-major-port-infrastructure-details'],
                 errorMessage: {
@@ -131,7 +131,7 @@ What is the history of the site?
                 id: "site-history-site-2-mining-details",
                 name: "site-history-site-2-mining-details",
                 label: {
-                    text: "Provide details"
+                    text: "Include how long ago this activity took place, or if it’s still active, and how close it is to the area"
                 },
                 value: data['site-history-site-2-mining-details'],
                 errorMessage: {
@@ -146,7 +146,7 @@ What is the history of the site?
                 id: "site-history-site-2-oil-processing-details",
                 name: "site-history-site-2-oil-processing-details",
                 label: {
-                    text: "Provide details"
+                    text: "Include how long ago this activity took place, or if it’s still active, and how close it is to the area"
                 },
                 value: data['site-history-site-2-oil-processing-details'],
                 errorMessage: {
@@ -161,7 +161,7 @@ What is the history of the site?
                 id: "site-history-site-2-pollution-incidents-details",
                 name: "site-history-site-2-pollution-incidents-details",
                 label: {
-                    text: "Provide details"
+                    text: "Include how long ago this activity took place, or if it’s still active, and how close it is to the area"
                 },
                 value: data['site-history-site-2-pollution-incidents-details'],
                 errorMessage: {
@@ -176,7 +176,7 @@ What is the history of the site?
                 id: "site-history-site-2-ship-building-details",
                 name: "site-history-site-2-ship-building-details",
                 label: {
-                    text: "Provide details"
+                    text: "Include how long ago this activity took place, or if it’s still active, and how close it is to the area"
                 },
                 value: data['site-history-site-2-ship-building-details'],
                 errorMessage: {
@@ -191,7 +191,7 @@ What is the history of the site?
                 id: "site-history-site-2-steelworks-details",
                 name: "site-history-site-2-steelworks-details",
                 label: {
-                    text: "Provide details"
+                    text: "Include how long ago this activity took place, or if it’s still active, and how close it is to the area"
                 },
                 value: data['site-history-site-2-steelworks-details'],
                 errorMessage: {
@@ -206,7 +206,7 @@ What is the history of the site?
                 id: "site-history-site-2-other-details",
                 name: "site-history-site-2-other-details",
                 label: {
-                    text: "Provide details"
+                    text: "Include how long ago this activity took place, or if it’s still active, and how close it is to the area"
                 },
                 value: data['site-history-site-2-other-details'],
                 errorMessage: {
@@ -308,9 +308,9 @@ What is the history of the site?
                         divider: "or"
                     },
                     {
-                        value: "not-previously-used",
-                        text: "Not previously used for anything",
-                        checked: true if data['site-history-site-2'] and "not-previously-used" in data['site-history-site-2']
+                        value: "no-history-industrial-use",
+                        text: "No history of industrial use",
+                        checked: true if data['site-history-site-2'] and "no-history-industrial-use" in data['site-history-site-2']
                     }
                 ]
             }) }}


### PR DESCRIPTION
Revised material type options for dredging details, removing 'other', 'non-dredged sediments', and 'organic material', and adding 'remediation (environmental) dredged material' with explanatory hint. Improved error handling logic and updated dredge depth hint for clarity. Site history detail labels now request more specific information about timing and proximity of activities, and the 'Not previously used' option is replaced with 'No history of industrial use'. Minor wording changes for consistency in check answers page.