### PR TITLE
Add project background page to sample plans

### DIFF
--- a/app/routes/versions/multiple-sites-v2/sample-plans-v1.js
+++ b/app/routes/versions/multiple-sites-v2/sample-plans-v1.js
@@ -102,6 +102,51 @@ module.exports = function (router) {
   });
 
   ///////////////////////////////////////////
+  // Project background page
+  ///////////////////////////////////////////
+
+  router.get(`/versions/${version}/${section}/project-background`, function (req, res) {
+    req.session.data['isSamplePlansSection'] = true;
+    req.session.data['sample-plan-errorthispage'] = "false";
+    req.session.data['sample-plan-errortypeone'] = "false";
+    req.session.data['sample-plan-errortypetwo'] = "false";
+    req.session.data['sample-plan-errortypethree'] = "false";
+    res.render(`versions/${version}/${section}/project-background`);
+  });
+
+  router.post(`/versions/${version}/${section}/project-background`, function (req, res) {
+    const projectBackground = req.body['sample-plan-project-background'];
+    const otherContact = req.body['sample-plan-other-contact'];
+    const otherContactDetails = req.body['sample-plan-other-contact-details'];
+    let hasError = false;
+    
+    if (!projectBackground || projectBackground.trim() === '') {
+      req.session.data['sample-plan-errorthispage'] = "true";
+      req.session.data['sample-plan-errortypeone'] = "true";
+      hasError = true;
+    }
+
+    if (!otherContact) {
+      req.session.data['sample-plan-errorthispage'] = "true";
+      req.session.data['sample-plan-errortypetwo'] = "true";
+      hasError = true;
+    }
+
+    if (otherContact === 'Yes' && (!otherContactDetails || otherContactDetails.trim() === '')) {
+      req.session.data['sample-plan-errorthispage'] = "true";
+      req.session.data['sample-plan-errortypethree'] = "true";
+      hasError = true;
+    }
+
+    if (hasError) {
+      return res.redirect('project-background');
+    }
+
+    req.session.data['sample-plan-project-background-completed'] = "true";
+    res.redirect('sample-plan-start-page');
+  });
+
+  ///////////////////////////////////////////
   // Which activity page
   ///////////////////////////////////////////
 

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/project-background.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/project-background.html
@@ -1,0 +1,130 @@
+{% extends "../layouts/exemption.html" %}
+
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+
+{% block beforeContent %}
+    {% include "../includes/phase-banner.html" %}
+    {% if data['user_type'] === 'organisation' %}
+        {% include "../includes/organisation-switcher.html" %}
+    {% endif %}
+    <a class="govuk-back-link" href="javascript:window.history.back()">Back</a>
+{% endblock %}
+
+{% set pageHeadingTextHTML %}
+    Project background
+{% endset %}
+
+{% block pageTitle %}
+    {{ pageHeadingTextHTML }} - {{ data['headerNameExemption'] }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+	<div class="govuk-grid-column-two-thirds">
+
+    {% if data['sample-plan-errorthispage'] == "true" %}
+        {{ govukErrorSummary({
+            titleText: "There is a problem",
+            errorList: [
+                {
+                    text: "Enter the project background",
+                    href: "#sample-plan-project-background"
+                } if data['sample-plan-errortypeone'] == "true",
+                {
+                    text: "Select if there been any other contact with the MMO in relation to this project",
+                    href: "#sample-plan-other-contact"
+                } if data['sample-plan-errortypetwo'] == "true",
+                {
+                    text: "Enter details",
+                    href: "#sample-plan-other-contact-details"
+                } if data['sample-plan-errortypethree'] == "true"
+            ]
+        }) }}
+    {% endif %}
+
+    <form action="project-background" method="post">
+        
+        {% set labelHTML %}
+            <span class="govuk-caption-l">{{ data['sample-plan-project-name-text-input'] }}</span>
+            {{ pageHeadingTextHTML }}
+        {% endset %}
+
+        {{ govukTextarea({
+            name: "sample-plan-project-background",
+            id: "sample-plan-project-background",
+            label: {
+                html: labelHTML,
+                classes: "govuk-label--l",
+                isPageHeading: true
+            },
+            hint: {
+                text: "Provide a brief background to the project including the need for, and aim of, the project and if it’s part of a larger project. Also include if there have been any previous licences or dredging activity in the area."
+            },
+            value: data['sample-plan-project-background'],
+            errorMessage: {
+                text: "Enter the project background"
+            } if data['sample-plan-errorthispage'] == "true" and data['sample-plan-errortypeone'] == "true"
+        }) }}
+
+        {% set otherContactHTML %}
+            {{ govukTextarea({
+                name: "sample-plan-other-contact-details",
+                id: "sample-plan-other-contact-details",
+                label: {
+                    text: "Provide details"
+                },
+                value: data['sample-plan-other-contact-details'],
+                errorMessage: {
+                    text: "Enter details"
+                } if data['sample-plan-errorthispage'] == "true" and data['sample-plan-errortypethree'] == "true"
+            }) }}
+        {% endset %}
+
+        {{ govukRadios({
+            name: "sample-plan-other-contact",
+            id: "sample-plan-other-contact",
+            fieldset: {
+                legend: {
+                    text: "Has there been any other contact with the Marine Management Organisation (MMO) in relation to this project?",
+                    isPageHeading: false,
+                    classes: "govuk-fieldset__legend--s"
+                }
+            },
+            errorMessage: {
+                text: "Select if there been any other contact with the MMO in relation to this project"
+            } if data['sample-plan-errorthispage'] == "true" and data['sample-plan-errortypetwo'] == "true",
+            items: [
+                {
+                    value: "Yes",
+                    text: "Yes",
+                    conditional: {
+                        html: otherContactHTML
+                    },
+                    checked: true if data['sample-plan-other-contact'] == "Yes"
+                },
+                {
+                    value: "No",
+                    text: "No",
+                    checked: true if data['sample-plan-other-contact'] == "No"
+                }
+            ]
+        }) }}
+
+        <div class="govuk-button-group">
+            {{ govukButton({
+                text: "Save and continue"
+            }) }}
+    
+            <a class="govuk-link govuk-link--no-visited-state" href="">Cancel</a>
+        </div>
+
+    </form>
+    
+    </div>
+</div>
+
+{% endblock %}

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/sample-plan-start-page.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/sample-plan-start-page.html
@@ -53,6 +53,24 @@ Sample plan start page
 
 			<li class="govuk-task-list__item govuk-task-list__item--with-link">
 			  <div class="govuk-task-list__name-and-hint">
+				<a class="govuk-link govuk-task-list__link govuk-link--no-visited-state" href="project-background" aria-describedby="project-background-status">
+				  Project background
+				</a>
+			  </div>
+			  
+			  <div class="govuk-task-list__status" id="project-background-status">
+				{% if data['sample-plan-project-background-completed'] %}
+				Completed
+				{% else %}
+				<strong class="govuk-tag govuk-tag--blue">
+					Not yet started
+				</strong>
+				{% endif %}
+			  </div>
+			</li>
+
+			<li class="govuk-task-list__item govuk-task-list__item--with-link">
+			  <div class="govuk-task-list__name-and-hint">
 				<a class="govuk-link govuk-task-list__link govuk-link--no-visited-state" href="which-activity" aria-describedby="type-of-activity-status">
 				  Type of activity
 				</a>
@@ -300,7 +318,7 @@ Sample plan start page
 		{% set allTasksCompleted = false %}
 		
 		<!-- Check if all always-required tasks are completed -->
-		{% if data['sample-plan-which-activity'] and data['sample-plan-new-or-existing-licence'] and data['sample-plan-fee-estimate-completed'] == "true" and data['fee-terms-checkbox'] == "agree" and data['fee-acceptance'] == "yes" %}
+		{% if data['sample-plan-project-background-completed'] and data['sample-plan-which-activity'] and data['sample-plan-new-or-existing-licence'] and data['sample-plan-fee-estimate-completed'] == "true" and data['fee-terms-checkbox'] == "agree" and data['fee-acceptance'] == "yes" %}
 			
 			<!-- Check activity-specific tasks -->
 			{% if data['sample-plan-which-activity'] == "Marine disposal" %}


### PR DESCRIPTION
Introduces a new 'Project background' page with GET and POST routes, form validation, and error handling. Updates the sample plan start page to include the new task and completion status, integrating it into the overall task list flow.