### PR TITLE
Update disposal site redirect and search results summary

### DIFF
--- a/app/routes/versions/multiple-sites-v2/sample-plans-v1-disposal-site-locations.js
+++ b/app/routes/versions/multiple-sites-v2/sample-plans-v1-disposal-site-locations.js
@@ -113,10 +113,10 @@ module.exports = function (router) {
       res.redirect('find-existing-disposal-site?disposal-site-code=&disposal-site-name=&disposal-site-location=&marine-area=&disposal-site-status=');
     } else if (disposalSelection === 'New disposal site') {
       // TODO: Create and redirect to new disposal site page
-      res.redirect('../sample-plan-start-page');
+      res.redirect('where-dispose-of-material');
     } else {
       // Fallback
-      res.redirect('../sample-plan-start-page');
+      res.redirect('where-dispose-of-material');
     }
   });
 

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/disposal-site-locations/search-results.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/disposal-site-locations/search-results.html
@@ -53,6 +53,8 @@ Search results for disposal sites
 
         <p class="govuk-body" id="results-count">We found <strong id="total-results">{{ totalResults }}</strong> disposal sites matching your search criteria.</p>
 
+        <p class="govuk-body govuk-!-margin-top-4" id="results-summary">Showing {{ startResult }} to {{ endResult }}.</p>
+
         <!-- Search results table -->
         <div class="govuk-table-overflow">
             <table class="govuk-table" id="disposal-sites-table" data-module="moj-sortable-table">
@@ -72,8 +74,6 @@ Search results for disposal sites
                 </tbody>
             </table>
         </div>
-
-        <p class="govuk-body govuk-!-margin-top-4" id="results-summary">Showing {{ startResult }} to {{ endResult }} of {{ totalResults }} results.</p>
 
         <nav class="govuk-pagination" aria-label="Pagination" id="pagination-nav">
             <!-- Pagination will be populated by JavaScript -->


### PR DESCRIPTION
Changed redirect routes for disposal site selection to 'where-dispose-of-material' for consistency. Updated search results summary in the view to display only the range of results shown, removing the total results from the summary paragraph.