### PR TITLE
Update site labels and terminology for clarity

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -398,7 +398,7 @@ window.GOVUKPrototypeKit.documentReady(() => {
           <td class="govuk-table__cell">${site.seaArea}</td>
           <td class="govuk-table__cell">${getStatusTag(site.status)}</td>
           <td class="govuk-table__cell">
-            <a class="govuk-link govuk-link--no-visited-state govuk-!-white-space-nowrap" href="review-disposal-site-details?code=${encodeURIComponent(site.code)}&name=${encodeURIComponent(site.name)}&country=${encodeURIComponent(site.country)}&seaArea=${encodeURIComponent(site.seaArea)}&status=${encodeURIComponent(site.status)}">Select site</a>
+            <a class="govuk-link govuk-link--no-visited-state govuk-!-white-space-nowrap" href="review-disposal-site-details?code=${encodeURIComponent(site.code)}&name=${encodeURIComponent(site.name)}&country=${encodeURIComponent(site.country)}&seaArea=${encodeURIComponent(site.seaArea)}&status=${encodeURIComponent(site.status)}">Select</a>
           </td>
         `
         tableBody.appendChild(row)

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/disposal-site-locations/disposal-details-site-1.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/disposal-site-locations/disposal-details-site-1.html
@@ -46,7 +46,7 @@ Disposal details
         }) }}
         {% endif %}
 
-        <span class="govuk-caption-l">{{ data['sample-plan-project-name-text-input'] }}<span class="govuk-!-display-block">Site 1</span></span>
+        <span class="govuk-caption-l">{{ data['sample-plan-project-name-text-input'] }}<span class="govuk-!-display-block">Disposal site 1</span></span>
         <h1 class="govuk-heading-l">
             {{ pageHeadingTextHTML }}
         </h1>

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/disposal-site-locations/disposal-details-site-2.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/disposal-site-locations/disposal-details-site-2.html
@@ -46,7 +46,7 @@ Disposal details
         }) }}
         {% endif %}
 
-        <span class="govuk-caption-l">{{ data['sample-plan-project-name-text-input'] }}<span class="govuk-!-display-block">Site 2</span></span>
+        <span class="govuk-caption-l">{{ data['sample-plan-project-name-text-input'] }}<span class="govuk-!-display-block">Disposal site 2</span></span>
         <h1 class="govuk-heading-l">
             {{ pageHeadingTextHTML }}
         </h1>

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/disposal-site-locations/review-disposal-site-details.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/disposal-site-locations/review-disposal-site-details.html
@@ -230,7 +230,7 @@ Review disposal site details
                     
                     <div class="govuk-summary-list__row">
                         <dt class="govuk-summary-list__key">
-                            Country
+                            Site location
                         </dt>
                         <dd class="govuk-summary-list__value">
                             {{ data['selected-disposal-site-2-country'] or 'No country available' }}
@@ -239,7 +239,7 @@ Review disposal site details
                     
                     <div class="govuk-summary-list__row">
                         <dt class="govuk-summary-list__key">
-                            Sea area
+                            Marine area
                         </dt>
                         <dd class="govuk-summary-list__value">
                             {{ data['selected-disposal-site-2-sea-area'] or 'No sea area available' }}
@@ -347,7 +347,7 @@ Review disposal site details
 
         <div class="govuk-button-group govuk-!-margin-bottom-6">
             <a href="where-dispose-of-material?disposal-site-code=&disposal-site-name=&disposal-site-location=&marine-area=&disposal-site-status=&sample-plan-where-dispose-material=" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button">
-                Add another disposal site
+                Save and add another disposal site
             </a>
         </div>
 

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/disposal-site-locations/search-results.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/disposal-site-locations/search-results.html
@@ -63,8 +63,8 @@ Search results for disposal sites
                     <tr class="govuk-table__row">
                         <th scope="col" class="govuk-table__header" aria-sort="ascending">Site code</th>
                         <th scope="col" class="govuk-table__header" aria-sort="none">Site name</th>
-                        <th scope="col" class="govuk-table__header" aria-sort="none">Country</th>
-                        <th scope="col" class="govuk-table__header" aria-sort="none">Sea area</th>
+                        <th scope="col" class="govuk-table__header" aria-sort="none">Site location</th>
+                        <th scope="col" class="govuk-table__header" aria-sort="none">Marine area</th>
                         <th scope="col" class="govuk-table__header" aria-sort="none">Status</th>
                         <th scope="col" class="govuk-table__header">Action</th>
                     </tr>
@@ -84,7 +84,7 @@ Search results for disposal sites
         </p>
 
         <div class="govuk-button-group govuk-!-margin-top-4">
-            <a class="govuk-link govuk-link--no-visited-state" href="../sample-plan-start-page">Cancel and return to task list</a>
+            <a class="govuk-link govuk-link--no-visited-state" href="../sample-plan-start-page">Cancel and return to sample plan start page</a>
         </div>
 
     </div>

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/dredging-details-site-1.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/dredging-details-site-1.html
@@ -50,7 +50,7 @@ Dredging details
         }) }}
         {% endif %}
 
-        <span class="govuk-caption-l">{{ data['sample-plan-project-name-text-input'] }}<span class="govuk-!-display-block">Site 1</span></span>
+        <span class="govuk-caption-l">{{ data['sample-plan-project-name-text-input'] }}<span class="govuk-!-display-block">Dredge site 1</span></span>
         <h1 class="govuk-heading-l">
             {{ pageHeadingTextHTML }}
         </h1>

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/dredging-details-site-2.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/dredging-details-site-2.html
@@ -50,7 +50,7 @@ Dredging details
         }) }}
         {% endif %}
 
-        <span class="govuk-caption-l">{{ data['sample-plan-project-name-text-input'] }}<span class="govuk-!-display-block">Site 2</span></span>
+        <span class="govuk-caption-l">{{ data['sample-plan-project-name-text-input'] }}<span class="govuk-!-display-block">Dredge site 2</span></span>
         <h1 class="govuk-heading-l">
             {{ pageHeadingTextHTML }}
         </h1>

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/site-history-site-1.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/site-history-site-1.html
@@ -220,7 +220,7 @@ What is the history of the site?
                 name: "site-history-site-1",
                 fieldset: {
                     legend: {
-                        html: '<span class="govuk-caption-l">' + data['sample-plan-project-name-text-input'] + '<span class="govuk-!-display-block">Site 1</span></span>' + pageHeadingTextHTML,
+                        html: '<span class="govuk-caption-l">' + data['sample-plan-project-name-text-input'] + '<span class="govuk-!-display-block">Dredge site 1</span></span>' + pageHeadingTextHTML,
                         isPageHeading: true,
                         classes: "govuk-fieldset__legend--l"
                     }

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/site-history-site-2.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/site-history-site-2.html
@@ -220,7 +220,7 @@ What is the history of the site?
                 name: "site-history-site-2",
                 fieldset: {
                     legend: {
-                        html: '<span class="govuk-caption-l">' + data['sample-plan-project-name-text-input'] + '<span class="govuk-!-display-block">Site 2</span></span>' + pageHeadingTextHTML,
+                        html: '<span class="govuk-caption-l">' + data['sample-plan-project-name-text-input'] + '<span class="govuk-!-display-block">Dredge site 2</span></span>' + pageHeadingTextHTML,
                         isPageHeading: true,
                         classes: "govuk-fieldset__legend--l"
                     }


### PR DESCRIPTION
Revised captions and headings to use 'Disposal site' and 'Dredge site' instead of generic 'Site' labels. Updated table headers and summary list keys to use 'Site location' and 'Marine area' for improved consistency. Changed button and link text for clearer user actions.