### PR TITLE
Update activity03 notification to exclude applicant details

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -81,7 +81,7 @@ Private beta prototype
             <ul class="govuk-list govuk-list--spaced">
               <li><a href="versions/multiple-sites-v2/exemption/notifications/activity01" class="govuk-link--no-visited-state">Exempt activity notification 1 - individual applicant</a></li>
               <li><a href="versions/multiple-sites-v2/exemption/notifications/activity02" class="govuk-link--no-visited-state">Exempt activity notification 2 - individual applicant</a></li>
-              <li><a href="versions/multiple-sites-v2/exemption/notifications/activity03" class="govuk-link--no-visited-state">Exempt activity notification 3 - individual applicant</a></li>
+              <li><a href="versions/multiple-sites-v2/exemption/notifications/activity03" class="govuk-link--no-visited-state">Exempt activity notification 3 - individual applicant – no applicant details</a></li>
               <li><a href="versions/multiple-sites-v2/exemption/notifications/activity04" class="govuk-link--no-visited-state">Exempt activity notification 4 - organisation applicant</a></li>
             </ul>
           </div>

--- a/app/views/versions/multiple-sites-v2/exemption/notifications/activity03.html
+++ b/app/views/versions/multiple-sites-v2/exemption/notifications/activity03.html
@@ -84,7 +84,7 @@
 	  </div>
 	  <!-- End of application details section -->
   
-	  <!-- Applicant details section -->
+	  <!-- Applicant details section 
 	  <div class="govuk-summary-card">
 		<div class="govuk-summary-card__title-wrapper">
 		  <h2 class="govuk-summary-card__title">
@@ -135,7 +135,7 @@
 		  </dl>
 		</div>
 	  </div>
-	  <!-- End of applicant details section -->
+	  End of applicant details section -->
 
 	  <!-- Project summary section -->
 	  <div class="govuk-summary-card">


### PR DESCRIPTION
The index page link for activity03 now clarifies that no applicant details are included. The applicant details section in activity03.html has been commented out to reflect this change.