### PR TITLE
Add delete confirmation for Branscombe project

### DIFF
--- a/app/routes/versions/multiple-sites-v2/sample-plans-v1.js
+++ b/app/routes/versions/multiple-sites-v2/sample-plans-v1.js
@@ -12,8 +12,22 @@ module.exports = function (router) {
     res.render(`versions/${version}/${section}/projects`);
   });
 
-  // Delete project route
+  ///////////////////////////////////////////
+  // Delete project confirmation page
+  ///////////////////////////////////////////
+
   router.get(`/versions/${version}/${section}/delete`, function (req, res) {
+    req.session.data['isSamplePlansSection'] = true;
+    
+    // Store the project parameter to be passed to the template
+    const projectToDelete = req.query.project;
+    req.session.data['project'] = projectToDelete;
+    
+    res.render(`versions/${version}/${section}/delete`);
+  });
+
+  // Delete project router (POST)
+  router.post(`/versions/${version}/${section}/delete-router`, function (req, res) {
     const projectToDelete = req.query.project;
     
     if (projectToDelete === 'sample-plan-user') {
@@ -24,13 +38,13 @@ module.exports = function (router) {
       req.session.data['sample-plan-new-or-existing-licence'] = '';
       req.session.data['sample-plan-dredging-volumes-completed'] = "false";
       req.session.data['sample-plan-fee-estimate-completed'] = "false";
-    } else if (projectToDelete === 'south-coast') {
-      // Handle deletion of the South coast sample project
-      // Could set a flag to hide this project in the view
-    } else if (projectToDelete === 'my-sample-plan') {
-      // Handle deletion of the My sample plan project
-      // Could set a flag to hide this project in the view
+    } else if (projectToDelete === 'branscombe-bore-holes') {
+      // Handle deletion of the Branscombe bore holes project
+      req.session.data['branscombeProjectDeleted'] = "true";
     }
+    
+    // Clear the project parameter from session
+    delete req.session.data['project'];
     
     res.redirect('projects');
   });

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/delete.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/delete.html
@@ -1,0 +1,43 @@
+{% extends "../layouts/exemption.html" %}
+
+{% block beforeContent %}
+    {% include "../includes/phase-banner.html" %}
+    {% include "../includes/back-link.html" %}
+{% endblock %}
+
+{% set pageHeadingTextHTML %}
+Are you sure you want to delete this project?
+{% endset %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-l">
+      {{ pageHeadingTextHTML }}
+    </h1>
+
+    <div class="govuk-inset-text">
+      {% if data['project'] == 'branscombe-bore-holes' %}
+        Branscombe bore holes
+      {% else %}
+        {{ data['sample-plan-project-name-text-input'] }}
+      {% endif %}
+    </div>
+ 
+    <form action="delete-router?project={{ data['project'] }}" method="post" novalidate>
+      <div class="govuk-button-group govuk-!-margin-top-7">
+        {{ govukButton({
+          text: "Yes, delete project",
+		  classes: "govuk-button--warning"
+        }) }}
+        <a class="govuk-link govuk-link--no-visited-state" href="javascript:window.history.back()">Cancel</a>
+    </div>
+    </form>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/projects.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/projects.html
@@ -88,6 +88,7 @@ Projects
 
 		{% set isDeleteProject = data['deleteSamplePlanProject'] == "true" %}
 		{% set isUserSamplePlanProjectDeleted = data['userSamplePlanProjectDeleted'] == "true" %}
+		{% set isBranscombeProjectDeleted = data['branscombeProjectDeleted'] == "true" %}
 		{% set isAlternativeView = data['alternativeSamplePlanProjectView'] == "true" %}
 
 		{% if isDeleteProject %}
@@ -131,7 +132,7 @@ Projects
 				</tr>
 				{% endif %}
 
-				{% if not isDeleteProject and not isAlternativeView %}
+				{% if not isBranscombeProjectDeleted and not isDeleteProject and not isAlternativeView %}
 				<tr class="govuk-table__row">
 					<th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Branscombe bore holes</th>
 					<td class="govuk-table__cell">
@@ -149,7 +150,7 @@ Projects
 					</td>
 					<td class="govuk-table__cell" data-sort-value="-">-</td>
 					<td class="govuk-table__cell" data-sort-value="Continue">	
-						<a href="#" class="govuk-link--no-visited-state govuk-!-margin-right-4">Continue</a> <a href="delete?project=south-coast" class="govuk-link--no-visited-state">Delete</a>
+						<a href="#" class="govuk-link--no-visited-state govuk-!-margin-right-4">Continue</a> <a href="delete?project=branscombe-bore-holes" class="govuk-link--no-visited-state">Delete</a>
 					</td>
 				</tr>
 				{% endif %}


### PR DESCRIPTION
Introduces a delete confirmation page for projects, specifically handling the deletion of the Branscombe bore holes project. Updates routing and session logic to support project deletion and ensures the project is hidden from the projects list after deletion.