### PR TITLE
TM-Sample-Plans-Introduce dedicated layout for sample plans section

### DIFF
--- a/app/routes/versions/multiple-sites-v2/sample-plans-v1-disposal-site-locations.js
+++ b/app/routes/versions/multiple-sites-v2/sample-plans-v1-disposal-site-locations.js
@@ -45,7 +45,12 @@ module.exports = function (router) {
   ///////////////////////////////////////////
 
   router.get(`/versions/${version}/${section}/${subSection}/before-you-start`, function (req, res) {
-    req.session.data['isSamplePlansSection'] = true;
+    // Clear any incomplete journey states when starting fresh
+    // Only clear if they haven't completed and saved the journey
+    if (!req.session.data['has-visited-disposal-site-locations']) {
+      clearSite1CompletionFlags(req.session);
+    }
+    
     res.render(`versions/${version}/${section}/${subSection}/before-you-start`);
   });
 
@@ -60,7 +65,6 @@ module.exports = function (router) {
   ///////////////////////////////////////////
 
   router.get(`/versions/${version}/${section}/${subSection}/find-existing-disposal-site`, function (req, res) {
-    req.session.data['isSamplePlansSection'] = true;
     
     // Set form data from URL parameters (this will clear if empty parameters are passed)
     if (req.query.hasOwnProperty('disposal-site-code')) {
@@ -105,7 +109,7 @@ module.exports = function (router) {
   ///////////////////////////////////////////
 
   router.get(`/versions/${version}/${section}/${subSection}/search-results`, function (req, res) {
-    req.session.data['isSamplePlansSection'] = true;
+    
     // Store page parameter in session data for template access
     req.session.data['page'] = req.query.page || '1';
     
@@ -131,7 +135,6 @@ module.exports = function (router) {
     // Clear any existing error flags when user navigates to the page
     req.session.data['sample-plan-errorthispage'] = "false";
     req.session.data['sample-plan-errortypeone'] = "false";
-    req.session.data['isSamplePlansSection'] = true;
     
     // If URL parameter is provided to clear the radio selection
     if (req.query.hasOwnProperty('sample-plan-where-dispose-material')) {
@@ -176,7 +179,6 @@ module.exports = function (router) {
   ///////////////////////////////////////////
 
   router.get(`/versions/${version}/${section}/${subSection}/review-disposal-site-details`, function (req, res) {
-    req.session.data['isSamplePlansSection'] = true;
     
     // If URL parameters are provided (coming from site selection), store them and redirect
     if (req.query.code || req.query.name || req.query.country || req.query.seaArea || req.query.status) {
@@ -248,7 +250,6 @@ module.exports = function (router) {
   ///////////////////////////////////////////
 
   router.get(`/versions/${version}/${section}/${subSection}/disposal-details-site-1`, function (req, res) {
-    req.session.data['isSamplePlansSection'] = true;
     
     // Clear any existing error flags when user navigates to the page
     req.session.data['sample-disposal-details-site-1-errorthispage'] = "false";
@@ -312,7 +313,6 @@ module.exports = function (router) {
   ///////////////////////////////////////////
 
   router.get(`/versions/${version}/${section}/${subSection}/maximum-disposal-volume`, function (req, res) {
-    req.session.data['isSamplePlansSection'] = true;
     
     // Clear any existing error flags when user navigates to the page
     req.session.data['sample-disposal-site-1-maximum-volume-errorthispage'] = "false";
@@ -389,7 +389,6 @@ module.exports = function (router) {
   ///////////////////////////////////////////
 
   router.get(`/versions/${version}/${section}/${subSection}/beneficial-use`, function (req, res) {
-    req.session.data['isSamplePlansSection'] = true;
     
     // Clear any existing error flags when user navigates to the page
     req.session.data['sample-disposal-site-1-beneficial-use-errorthispage'] = "false";
@@ -442,7 +441,6 @@ module.exports = function (router) {
   ///////////////////////////////////////////
 
   router.get(`/versions/${version}/${section}/${subSection}/disposal-details-site-2`, function (req, res) {
-    req.session.data['isSamplePlansSection'] = true;
     
     // Clear any existing error flags when user navigates to the page
     req.session.data['sample-disposal-details-site-2-errorthispage'] = "false";

--- a/app/routes/versions/multiple-sites-v2/sample-plans-v1-dredging-site-locations.js
+++ b/app/routes/versions/multiple-sites-v2/sample-plans-v1-dredging-site-locations.js
@@ -8,7 +8,6 @@ module.exports = function (router) {
   //////// Before you start page
   /////////////////////////////////////////////////////////
   router.get(`/versions/${version}/${section}/${subsection}/before-you-start`, function (req, res) {
-    req.session.data['isSamplePlansSection'] = true;
     
     // Clear any incomplete journey states when starting fresh
     // Only clear if they haven't completed and saved the journey
@@ -31,7 +30,6 @@ module.exports = function (router) {
   //////// How do you want to provide site location page
   /////////////////////////////////////////////////////////
   router.get(`/versions/${version}/${section}/${subsection}/how-do-you-want-to-provide-site-location`, function (req, res) {
-    req.session.data['isSamplePlansSection'] = true;
     res.render(`versions/${version}/${section}/${subsection}/how-do-you-want-to-provide-site-location`);
   });
 
@@ -60,7 +58,6 @@ module.exports = function (router) {
   //////// Which type of file page
   /////////////////////////////////////////////////////////
   router.get(`/versions/${version}/${section}/${subsection}/which-type-of-file`, function (req, res) {
-    req.session.data['isSamplePlansSection'] = true;
     res.render(`versions/${version}/${section}/${subsection}/which-type-of-file`);
   });
 
@@ -84,7 +81,6 @@ module.exports = function (router) {
   //////// Upload file page
   /////////////////////////////////////////////////////////
   router.get(`/versions/${version}/${section}/${subsection}/upload-file`, function (req, res) {
-    req.session.data['isSamplePlansSection'] = true;
     res.render(`versions/${version}/${section}/${subsection}/upload-file`);
   });
 
@@ -99,7 +95,6 @@ module.exports = function (router) {
   //////// Review site details page
   /////////////////////////////////////////////////////////
   router.get(`/versions/${version}/${section}/${subsection}/review-dredging-site-details`, function (req, res) {
-    req.session.data['isSamplePlansSection'] = true;
     res.render(`versions/${version}/${section}/${subsection}/review-dredging-site-details`);
   });
 
@@ -129,7 +124,6 @@ module.exports = function (router) {
   //////// Dredging details Site 1 page
   /////////////////////////////////////////////////////////
   router.get(`/versions/${version}/${section}/${subsection}/dredging-details-site-1`, function (req, res) {
-    req.session.data['isSamplePlansSection'] = true;
     
     // Clear incomplete data if user navigates away and comes back without completing
     if (!req.session.data['dredging-details-site-1-completed']) {
@@ -200,7 +194,6 @@ module.exports = function (router) {
   //////// Dredging details Site 2 page
   /////////////////////////////////////////////////////////
   router.get(`/versions/${version}/${section}/${subsection}/dredging-details-site-2`, function (req, res) {
-    req.session.data['isSamplePlansSection'] = true;
     
     // Clear incomplete data if user navigates away and comes back without completing
     if (!req.session.data['dredging-details-site-2-completed']) {
@@ -278,7 +271,6 @@ module.exports = function (router) {
   //////// Site history Site 1 page
   /////////////////////////////////////////////////////////
   router.get(`/versions/${version}/${section}/${subsection}/site-history-site-1`, function (req, res) {
-    req.session.data['isSamplePlansSection'] = true;
     
     // Clear incomplete data if user navigates away and comes back without completing
     if (!req.session.data['site-history-site-1-completed']) {
@@ -414,7 +406,6 @@ module.exports = function (router) {
   //////// Dredge depth Site 1 page
   /////////////////////////////////////////////////////////
   router.get(`/versions/${version}/${section}/${subsection}/dredge-depth-site-1`, function (req, res) {
-    req.session.data['isSamplePlansSection'] = true;
     
     // Clear incomplete data if user navigates away and comes back without completing
     if (!req.session.data['dredging-details-site-1-depth-completed']) {
@@ -456,7 +447,6 @@ module.exports = function (router) {
   //////// Maximum dredge volume page
   /////////////////////////////////////////////////////////
   router.get(`/versions/${version}/${section}/${subsection}/maximum-dredge-volume`, function (req, res) {
-    req.session.data['isSamplePlansSection'] = true;
     
     // Clear incomplete data if user navigates away and comes back without completing
     if (!req.session.data['maximum-dredge-volume-completed']) {

--- a/app/routes/versions/multiple-sites-v2/sample-plans-v1.js
+++ b/app/routes/versions/multiple-sites-v2/sample-plans-v1.js
@@ -8,7 +8,6 @@ module.exports = function (router) {
   ///////////////////////////////////////////
 
   router.get(`/versions/${version}/${section}/projects`, function (req, res) {
-    req.session.data['isSamplePlansSection'] = true;
     res.render(`versions/${version}/${section}/projects`);
   });
 
@@ -17,7 +16,6 @@ module.exports = function (router) {
   ///////////////////////////////////////////
 
   router.get(`/versions/${version}/${section}/delete`, function (req, res) {
-    req.session.data['isSamplePlansSection'] = true;
     
     // Store the project parameter to be passed to the template
     const projectToDelete = req.query.project;
@@ -54,7 +52,6 @@ module.exports = function (router) {
   ///////////////////////////////////////////
 
   router.get(`/versions/${version}/${section}/get-a-plan-for-sediment-sample-analysis`, function (req, res) {
-    req.session.data['isSamplePlansSection'] = true;
     
     // if a user is an org user then store it in the session
     if (req.query.user_type === 'organisation') {
@@ -69,7 +66,6 @@ module.exports = function (router) {
   ///////////////////////////////////////////
 
   router.get(`/versions/${version}/${section}/sign-in`, function (req, res) {
-    req.session.data['isSamplePlansSection'] = true;
     
     // if a user is an org user then store it in the session
     if (req.query.user_type === 'organisation') {
@@ -159,7 +155,6 @@ module.exports = function (router) {
     // Clear any existing error flags when user navigates to the page
     req.session.data['sample-plan-errorthispage'] = "false";
     req.session.data['sample-plan-errortypeone'] = "false";
-    req.session.data['isSamplePlansSection'] = true;
     
     res.render(`versions/${version}/${section}/project-name-start`);
   });
@@ -646,7 +641,6 @@ module.exports = function (router) {
   ///////////////////////////////////////////
 
   router.get(`/versions/${version}/${section}/fee-are-you-sure`, function (req, res) {
-    req.session.data['isSamplePlansSection'] = true;
     res.render(`versions/${version}/${section}/fee-are-you-sure`);
   });
 
@@ -665,7 +659,6 @@ module.exports = function (router) {
   ///////////////////////////////////////////
 
   router.get(`/versions/${version}/${section}/check-answers`, function (req, res) {
-    req.session.data['isSamplePlansSection'] = true;
     res.render(`versions/${version}/${section}/check-answers`);
   });
 
@@ -683,7 +676,6 @@ module.exports = function (router) {
   ///////////////////////////////////////////
 
   router.get(`/versions/${version}/${section}/confirmation`, function (req, res) {
-    req.session.data['isSamplePlansSection'] = true;
     res.render(`versions/${version}/${section}/confirmation`);
   });
 

--- a/app/views/versions/multiple-sites-v2/layouts/sample-plans.html
+++ b/app/views/versions/multiple-sites-v2/layouts/sample-plans.html
@@ -16,10 +16,10 @@ https://prototype-kit.service.gov.uk/docs/how-to-use-layouts
   classes: "govuk-header--full-width-border"
 }) }}
 {{ govukServiceNavigation({
-  serviceName: "Get permission for marine work",
+  serviceName: "Get a plan for sediment sample analysis",
   navigation: [
     {
-      href: "/versions/multiple-sites-v2/exemption/home",
+      href: "/versions/multiple-sites-v2/sample-plans-v1/projects",
       text: "Projects"
     },
     {
@@ -28,7 +28,7 @@ https://prototype-kit.service.gov.uk/docs/how-to-use-layouts
       active: false
     },
     {
-      href: "/versions/multiple-sites-v2/exemption/sign-in.html?goto=home",
+      href: "#",
       text: "Sign out"
     }
   ]

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/before-you-start-dredging-volume.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/before-you-start-dredging-volume.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/exemption.html" %}
+{% extends "../layouts/sample-plans.html" %}
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/beneficial-use.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/beneficial-use.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/exemption.html" %}
+{% extends "../layouts/sample-plans.html" %}
 
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/check-answers.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/check-answers.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/exemption.html" %}
+{% extends "../layouts/sample-plans.html" %}
 
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/confirmation.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/confirmation.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/exemption.html" %}
+{% extends "../layouts/sample-plans.html" %}
 
 {% block beforeContent %}
     {% include "../includes/phase-banner.html" %}

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/delete.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/delete.html
@@ -1,4 +1,6 @@
-{% extends "../layouts/exemption.html" %}
+{% extends "../layouts/sample-plans.html" %}
+
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% block beforeContent %}
     {% include "../includes/phase-banner.html" %}

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/disposal-site-locations/before-you-start.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/disposal-site-locations/before-you-start.html
@@ -1,4 +1,4 @@
-{% extends "../../layouts/exemption.html" %}
+{% extends "../../layouts/sample-plans.html" %}
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/disposal-site-locations/beneficial-use.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/disposal-site-locations/beneficial-use.html
@@ -1,4 +1,4 @@
-{% extends "../../layouts/exemption.html" %}
+{% extends "../../layouts/sample-plans.html" %}
 
 {% block beforeContent %}
     {% include "../../includes/phase-banner.html" %}

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/disposal-site-locations/disposal-details-site-1.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/disposal-site-locations/disposal-details-site-1.html
@@ -1,4 +1,4 @@
-{% extends "../../layouts/exemption.html" %}
+{% extends "../../layouts/sample-plans.html" %}
 
 {% block beforeContent %}
     {% include "../../includes/phase-banner.html" %}

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/disposal-site-locations/disposal-details-site-2.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/disposal-site-locations/disposal-details-site-2.html
@@ -1,4 +1,4 @@
-{% extends "../../layouts/exemption.html" %}
+{% extends "../../layouts/sample-plans.html" %}
 
 {% block beforeContent %}
     {% include "../../includes/phase-banner.html" %}

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/disposal-site-locations/find-existing-disposal-site.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/disposal-site-locations/find-existing-disposal-site.html
@@ -1,4 +1,4 @@
-{% extends "../../layouts/exemption.html" %}
+{% extends "../../layouts/sample-plans.html" %}
 
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/disposal-site-locations/maximum-disposal-volume.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/disposal-site-locations/maximum-disposal-volume.html
@@ -1,4 +1,4 @@
-{% extends "../../layouts/exemption.html" %}
+{% extends "../../layouts/sample-plans.html" %}
 
 {% block beforeContent %}
     {% include "../../includes/phase-banner.html" %}

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/disposal-site-locations/review-disposal-site-details.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/disposal-site-locations/review-disposal-site-details.html
@@ -1,4 +1,4 @@
-{% extends "../../layouts/exemption.html" %}
+{% extends "../../layouts/sample-plans.html" %}
 
 {% block beforeContent %}
     {% include "../../includes/phase-banner.html" %}

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/disposal-site-locations/search-results.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/disposal-site-locations/search-results.html
@@ -1,4 +1,4 @@
-{% extends "../../layouts/exemption.html" %}
+{% extends "../../layouts/sample-plans.html" %}
 
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/disposal-site-locations/where-dispose-of-material.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/disposal-site-locations/where-dispose-of-material.html
@@ -1,4 +1,4 @@
-{% extends "../../layouts/exemption.html" %}
+{% extends "../../layouts/sample-plans.html" %}
 
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/before-you-start.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/before-you-start.html
@@ -1,4 +1,4 @@
-{% extends "../../layouts/exemption.html" %}
+{% extends "../../layouts/sample-plans.html" %}
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/dredge-depth-site-1.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/dredge-depth-site-1.html
@@ -1,4 +1,4 @@
-{% extends "../../layouts/exemption.html" %}
+{% extends "../../layouts/sample-plans.html" %}
 
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/dredging-details-site-1.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/dredging-details-site-1.html
@@ -1,4 +1,4 @@
-{% extends "../../layouts/exemption.html" %}
+{% extends "../../layouts/sample-plans.html" %}
 
 {% block beforeContent %}
     {% include "../../includes/phase-banner.html" %}

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/dredging-details-site-2.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/dredging-details-site-2.html
@@ -1,4 +1,4 @@
-{% extends "../../layouts/exemption.html" %}
+{% extends "../../layouts/sample-plans.html" %}
 
 {% block beforeContent %}
     {% include "../../includes/phase-banner.html" %}

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/how-do-you-want-to-provide-site-location.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/how-do-you-want-to-provide-site-location.html
@@ -1,4 +1,4 @@
-{% extends "../../layouts/exemption.html" %}
+{% extends "../../layouts/sample-plans.html" %}
 
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/maximum-dredge-volume.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/maximum-dredge-volume.html
@@ -1,4 +1,4 @@
-{% extends "../../layouts/exemption.html" %}
+{% extends "../../layouts/sample-plans.html" %}
 
 {% block beforeContent %}
     {% include "../../includes/phase-banner.html" %}

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/review-dredging-site-details.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/review-dredging-site-details.html
@@ -1,4 +1,4 @@
-{% extends "../../layouts/exemption.html" %}
+{% extends "../../layouts/sample-plans.html" %}
 
 {% block beforeContent %}
     {% include "../../includes/phase-banner.html" %}

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/site-history-site-1.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/site-history-site-1.html
@@ -1,4 +1,4 @@
-{% extends "../../layouts/exemption.html" %}
+{% extends "../../layouts/sample-plans.html" %}
 
 {% block beforeContent %}
     {% include "../../includes/phase-banner.html" %}

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/site-history-site-2.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/site-history-site-2.html
@@ -1,4 +1,4 @@
-{% extends "../../layouts/exemption.html" %}
+{% extends "../../layouts/sample-plans.html" %}
 
 {% block beforeContent %}
     {% include "../../includes/phase-banner.html" %}

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/upload-file.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/upload-file.html
@@ -1,4 +1,4 @@
-{% extends "../../layouts/exemption.html" %}
+{% extends "../../layouts/sample-plans.html" %}
 
 {% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/which-type-of-file.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/which-type-of-file.html
@@ -1,4 +1,4 @@
-{% extends "../../layouts/exemption.html" %}
+{% extends "../../layouts/sample-plans.html" %}
 
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/existing-licence-expiry.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/existing-licence-expiry.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/exemption.html" %}
+{% extends "../layouts/sample-plans.html" %}
 
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/fee-are-you-sure.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/fee-are-you-sure.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/exemption.html" %}
+{% extends "../layouts/sample-plans.html" %}
 
 {% block beforeContent %}
 	{% include "../includes/phase-banner.html" %} 

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/fee-estimate.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/fee-estimate.html
@@ -1,4 +1,6 @@
-{% extends "../layouts/exemption.html" %}
+{% extends "../layouts/sample-plans.html" %}
+
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 
 {% block beforeContent %}
 	{% include "../includes/phase-banner.html" %} 

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/get-a-plan-for-sediment-sample-analysis.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/get-a-plan-for-sediment-sample-analysis.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/main.html" %}
+{% extends "../layouts/sample-plans.html" %}
 
 {% block beforeContent %}
 	{% include "../includes/phase-banner.html" %} 

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/maximum-dredging-volume.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/maximum-dredging-volume.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/exemption.html" %}
+{% extends "../layouts/sample-plans.html" %}
 
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/new-licence-length.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/new-licence-length.html
@@ -1,8 +1,9 @@
-{% extends "../layouts/exemption.html" %}
+{% extends "../layouts/sample-plans.html" %}
 
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 
 {% block beforeContent %}
     {% include "../includes/phase-banner.html" %}

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/new-or-existing-licence.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/new-or-existing-licence.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/exemption.html" %}
+{% extends "../layouts/sample-plans.html" %}
 
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/organisation-selector.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/organisation-selector.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/exemption.html" %}
+{% extends "../layouts/sample-plans.html" %}
 
 {% block header %}
   {% from "govuk/components/header/macro.njk" import govukHeader %}

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/project-background.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/project-background.html
@@ -1,9 +1,10 @@
-{% extends "../layouts/exemption.html" %}
+{% extends "../layouts/sample-plans.html" %}
 
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
 
 {% block beforeContent %}
     {% include "../includes/phase-banner.html" %}

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/project-name.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/project-name.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/exemption.html" %}
+{% extends "../layouts/sample-plans.html" %}
 
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/projects.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/projects.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/exemption.html" %}
+{% extends "../layouts/sample-plans.html" %}
 
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/sample-plan-start-page.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/sample-plan-start-page.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/exemption.html" %}
+{% extends "../layouts/sample-plans.html" %}
 
 {% block beforeContent %}
     {% include "../includes/phase-banner.html" %}

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/sign-in.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/sign-in.html
@@ -1,9 +1,10 @@
-{% extends "../layouts/exemption.html" %}
+{% extends "../layouts/sample-plans.html" %}
 
-{% block header %}
 {% from "govuk/components/header/macro.njk" import govukHeader %}
 {% from "govuk/components/service-navigation/macro.njk" import govukServiceNavigation %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 
+{% block header %}
 {{ govukHeader({
   classes: "govuk-header--full-width-border"
 }) }}

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/which-activity.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/which-activity.html
@@ -1,4 +1,4 @@
-{% extends "../layouts/exemption.html" %}
+{% extends "../layouts/sample-plans.html" %}
 
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}


### PR DESCRIPTION
Created a new sample-plans.html layout and updated all sample plans v1 views to use it instead of exemption.html. Refactored route files to remove the isSamplePlansSection session flag, simplifying logic and navigation rendering. This change improves maintainability and ensures consistent navigation and layout for the sample plans user journey.