### PR TITLE
TM-adding-visually-hidden-add-links-for-accessibility

### DIFF
--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/disposal-site-locations/review-disposal-site-details.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/disposal-site-locations/review-disposal-site-details.html
@@ -217,6 +217,9 @@ Review disposal site details
                             {% endif %}
                         </dd>
                         <dd class="govuk-summary-list__actions">
+                            <a href="disposal-details-site-1" class="govuk-link govuk-visually-hidden">
+                                {% if site1DisposalMethodComplete %}Change{% else %}Add{% endif %} proposed method of disposal
+                            </a>
                         </dd>
                     </div>
 
@@ -415,6 +418,9 @@ Review disposal site details
                             {% endif %}
                         </dd>
                         <dd class="govuk-summary-list__actions">
+                            <a href="disposal-details-site-2" class="govuk-link govuk-visually-hidden">
+                                {% if site2DisposalMethodComplete %}Change{% else %}Add{% endif %} proposed method of disposal
+                            </a>
                         </dd>
                     </div>
                 </dl>

--- a/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/review-dredging-site-details.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v1/dredging-site-locations/review-dredging-site-details.html
@@ -251,6 +251,9 @@ Review dredge site details
                             {% endif %}
                         </dd>
                         <dd class="govuk-summary-list__actions">
+                            <a href="dredging-details-site-1" class="govuk-link govuk-visually-hidden">
+                                {% if data['dredging-details-site-1-completed'] %}Change{% else %}Add{% endif %} proposed method of dredging
+                            </a>
                         </dd>
                     </div>
 


### PR DESCRIPTION
Introduced visually hidden 'Change' or 'Add' links for proposed methods of disposal and dredging in the review details pages. This improves accessibility and allows screen readers to access editing options for each site.