### PR TITLE
TM-sample-plans-v2-accessibilty-add-links

### DIFF
--- a/app/views/versions/multiple-sites-v2/sample-plans-v2/disposal-site-locations/review-disposal-site-details.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v2/disposal-site-locations/review-disposal-site-details.html
@@ -217,6 +217,9 @@ Review disposal site details
                             {% endif %}
                         </dd>
                         <dd class="govuk-summary-list__actions">
+                            <a href="disposal-details-site-1" class="govuk-link govuk-visually-hidden">
+                                {% if site1DisposalMethodComplete %}Change{% else %}Add{% endif %} proposed method of disposal
+                            </a>
                         </dd>
                     </div>
 
@@ -415,6 +418,9 @@ Review disposal site details
                             {% endif %}
                         </dd>
                         <dd class="govuk-summary-list__actions">
+                            <a href="disposal-details-site-2" class="govuk-link govuk-visually-hidden">
+                                {% if site2DisposalMethodComplete %}Change{% else %}Add{% endif %} proposed method of disposal
+                            </a>
                         </dd>
                     </div>
                 </dl>

--- a/app/views/versions/multiple-sites-v2/sample-plans-v2/dredging-site-locations/review-dredging-site-details.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v2/dredging-site-locations/review-dredging-site-details.html
@@ -251,6 +251,9 @@ Review dredge site details
                             {% endif %}
                         </dd>
                         <dd class="govuk-summary-list__actions">
+                            <a href="dredging-details-site-1" class="govuk-link govuk-visually-hidden">
+                                {% if data['dredging-details-site-1-completed'] %}Change{% else %}Add{% endif %} proposed method of dredging
+                            </a>
                         </dd>
                     </div>
 


### PR DESCRIPTION
Introduced visually hidden 'Change/Add proposed method' links to the review pages for disposal and dredging site details. These links improve accessibility and allow users to update or add methods for each site.