### PR TITLE
PB Update error pages and index for improved clarity

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -53,7 +53,8 @@ html: ''
     <!-- End of session warning text -->
 
     <!-- Start of Multiple Sites v2 -->
-    <h2 class="govuk-heading-m">Private beta MVP – Exemptions<strong class="govuk-tag govuk-tag--yellow" style="float:right">In
+    <h2 class="govuk-heading-m">Private beta MVP – Exemptions<strong class="govuk-tag govuk-tag--yellow"
+        style="float:right">In
         progress</strong></h2>
 
     <p>(Previously known as 'Multiple sites v2')</p>
@@ -162,7 +163,7 @@ html: ''
           <li><a href="versions/multiple-sites-v2/errors/500" class="govuk-link--no-visited-state">500 / Service
               error</a></li>
           <li><a href="versions/multiple-sites-v2/errors/503" class="govuk-link--no-visited-state">503 / Service
-              unavailable</a></li>
+              unavailable (unplanned downtime)</a></li>
         </ul>
       </div>
     </details>
@@ -171,7 +172,7 @@ html: ''
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
     <h2 class="govuk-heading-m">Sample Plans<strong class="govuk-tag govuk-tag--yellow" style="float:right">In
-      progress</strong></h2>
+        progress</strong></h2>
 
     <h3 class="govuk-heading-s">Iteration 1 – start from:</h3>
 

--- a/app/views/versions/multiple-sites-v2/errors/403.html
+++ b/app/views/versions/multiple-sites-v2/errors/403.html
@@ -1,15 +1,15 @@
 {% extends "layouts/main.html" %}
-{% set pageTitle = "You need to sign in to access this page" %}
+{% set pageTitle = "You do not have permission to view this page" %}
 
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
 
-    <h1 class="govuk-heading-l">You need to sign in to access this page</h1>
+    <h1 class="govuk-heading-l">You do not have permission to view this page</h1>
 
 
-    <p class="govuk-body">If you already have a Defra ID account, <a class="govuk-link" href="/sign-in">sign in using
+    <!-- <p class="govuk-body">If you already have a Defra ID account, <a class="govuk-link" href="/sign-in">sign in using
         Government Gateway</a>.</p>
     <p class="govuk-body">If you do not have an account you can create one through Government Gateway.</p>
     <p class="govuk-body">Contact our helpline if you have any questions.</p>
@@ -19,14 +19,14 @@
     <p class="govuk-body govuk-!-margin-bottom-0">0191 376 2791</p>
 
 
-    <h2 class="govuk-heading-m govuk-!-margin-top-6 govuk-!-margin-bottom-1">Email</h2>
-    <p class="govuk-body govuk-!-margin-bottom-0"><a class="govuk-link"
+    <h2 class="govuk-heading-m govuk-!-margin-top-6 govuk-!-margin-bottom-1">Email</h2> -->
+    <p class="govuk-body govuk-!-margin-bottom-0">If you think you should have access, contact: <a class="govuk-link"
         href="mailto:marine.consents@marinemanagement.org.uk">marine.consents@marinemanagement.org.uk</a></p>
 
 
-    <h2 class="govuk-heading-m govuk-!-margin-top-6 govuk-!-margin-bottom-1">Opening times</h2>
+    <!-- <h2 class="govuk-heading-m govuk-!-margin-top-6 govuk-!-margin-bottom-1">Opening times</h2>
     <p class="govuk-body govuk-!-margin-bottom-1">Monday to Thursday: 9am to 4:30pm</p>
-    <p class="govuk-body govuk-!-margin-bottom-0">Friday: 9am to 4pm</p>
+    <p class="govuk-body govuk-!-margin-bottom-0">Friday: 9am to 4pm</p> -->
 
 
   </div>

--- a/app/views/versions/multiple-sites-v2/errors/503.html
+++ b/app/views/versions/multiple-sites-v2/errors/503.html
@@ -9,7 +9,8 @@
     <h1 class="govuk-heading-l">Sorry, the service is unavailable</h1>
 
 
-    <p class="govuk-body">You will be able to use the service from 9am on Monday 10 September 2025.</p>
+    <!-- <p class="govuk-body">You will be able to use the service from 9am on Monday 10 September 2025.</p> -->
+    <p class="govuk-body">Try again later.</p>
     <p class="govuk-body">Contact our helpline if you have any questions.</p>
 
 


### PR DESCRIPTION
Revised the 403 error page to clarify permission issues and simplified contact instructions. Updated the 503 error page to remove a specific date and provide a generic retry message. Adjusted index.html to clarify the 503 error link and improved formatting for section headings.