### PR TITLE
Support both v1 and v2 disposal site table layouts

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -266,6 +266,14 @@ window.GOVUKPrototypeKit.documentReady(() => {
     const resultsPerPage = 20
     let sortedDisposalSites = [...disposalSites] // Copy for sorting
     let currentSort = { column: 'code', direction: 'asc' } // Default sort by site code ascending
+
+    // Detect if this table has an Action column (v1) so we can render rows appropriately
+    const disposalSitesTable = document.getElementById('disposal-sites-table')
+    const hasActionColumn = (() => {
+      if (!disposalSitesTable) return false
+      const lastHeader = disposalSitesTable.querySelector('thead th:last-child')
+      return !!lastHeader && lastHeader.textContent.trim().toLowerCase() === 'action'
+    })()
     
     // Get search criteria from template (will be undefined if not set)
     const searchCriteria = window.searchCriteria || {
@@ -464,13 +472,26 @@ window.GOVUKPrototypeKit.documentReady(() => {
       pageResults.forEach(site => {
         const row = document.createElement('tr')
         row.className = 'govuk-table__row'
-        row.innerHTML = `
-          <td class="govuk-table__cell"><a class="govuk-link govuk-link--no-visited-state" href="/versions/multiple-sites-v2/sample-plans-v2/disposal-site-locations/review-disposal-site-details?code=${encodeURIComponent(site.code)}&name=${encodeURIComponent(site.name)}&country=${encodeURIComponent(site.country)}&seaArea=${encodeURIComponent(site.seaArea)}&status=${encodeURIComponent(site.status)}">${site.code}</a></td>
-          <td class="govuk-table__cell">${site.name}</td>
-          <td class="govuk-table__cell">${site.country}</td>
-          <td class="govuk-table__cell">${site.seaArea}</td>
-          <td class="govuk-table__cell">${getStatusTag(site.status)}</td>
-        `
+        if (hasActionColumn) {
+          // Version 1 behaviour: plain text code and a Select link in the Action column
+          row.innerHTML = `
+            <td class="govuk-table__cell">${site.code}</td>
+            <td class="govuk-table__cell">${site.name}</td>
+            <td class="govuk-table__cell">${site.country}</td>
+            <td class="govuk-table__cell">${site.seaArea}</td>
+            <td class="govuk-table__cell">${getStatusTag(site.status)}</td>
+            <td class="govuk-table__cell"><a class="govuk-link govuk-link--no-visited-state" href="review-disposal-site-details?code=${encodeURIComponent(site.code)}&name=${encodeURIComponent(site.name)}&country=${encodeURIComponent(site.country)}&seaArea=${encodeURIComponent(site.seaArea)}&status=${encodeURIComponent(site.status)}">Select</a></td>
+          `
+        } else {
+          // Version 2 behaviour: code is a link; no Action column
+          row.innerHTML = `
+            <td class="govuk-table__cell"><a class="govuk-link govuk-link--no-visited-state" href="review-disposal-site-details?code=${encodeURIComponent(site.code)}&name=${encodeURIComponent(site.name)}&country=${encodeURIComponent(site.country)}&seaArea=${encodeURIComponent(site.seaArea)}&status=${encodeURIComponent(site.status)}">${site.code}</a></td>
+            <td class="govuk-table__cell">${site.name}</td>
+            <td class="govuk-table__cell">${site.country}</td>
+            <td class="govuk-table__cell">${site.seaArea}</td>
+            <td class="govuk-table__cell">${getStatusTag(site.status)}</td>
+          `
+        }
         tableBody.appendChild(row)
       })
 

--- a/app/views/versions/multiple-sites-v2/sample-plans-v2/disposal-site-locations/filter-disposal-sites-live.html
+++ b/app/views/versions/multiple-sites-v2/sample-plans-v2/disposal-site-locations/filter-disposal-sites-live.html
@@ -49,7 +49,7 @@ Find the existing disposal site
 
     <span class="govuk-caption-l">{{ data['sample-plan-project-name-text-input'] }}</span>
     <h1 class="govuk-heading-l">{{ pageHeadingTextHTML }}</h1>
-    <p>Results update automatically as you type.</p>
+    <p>The results will update automatically as you enter information or select filters.</p>
     <div class="moj-filter-layout sample-filter">
       <div class="moj-filter-layout__filter">
         <div class="moj-filter" data-module="moj-filter">

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@govuk-prototype-kit/common-templates": "2.0.1",
         "@govuk-prototype-kit/task-list": "2.0.0",
-        "@ministryofjustice/frontend": "5.1.3",
+        "@ministryofjustice/frontend": "^5.1.3",
         "@x-govuk/govuk-prototype-filters": "2.0.0",
         "accessible-autocomplete": "^3.0.1",
         "govuk-frontend": "5.11.2",
@@ -31,6 +31,7 @@
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-5.1.3.tgz",
       "integrity": "sha512-h6/riC6zDo5scevzZz1RByRo3AnX4k2ywFMTX47Irq9y7keyhalyfO5D0+VAJMpX0ADuNLg3f2tJh+cumH/PBA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"
       },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@govuk-prototype-kit/common-templates": "2.0.1",
     "@govuk-prototype-kit/task-list": "2.0.0",
-    "@ministryofjustice/frontend": "5.1.3",
+    "@ministryofjustice/frontend": "^5.1.3",
     "@x-govuk/govuk-prototype-filters": "2.0.0",
     "accessible-autocomplete": "^3.0.1",
     "govuk-frontend": "5.11.2",


### PR DESCRIPTION
Updated the disposal sites table rendering logic in application.js to detect and handle both v1 (with Action column) and v2 (code as link, no Action column) layouts. Also improved the filter page help text for clarity. Updated @ministryofjustice/frontend dependency to use a caret version in package.json and package-lock.json.