### PR TITLE
TM Exemptions - conditionally show cancel link on activity pages

### DIFF
--- a/app/routes/versions/multiple-sites-v2/exemption.js
+++ b/app/routes/versions/multiple-sites-v2/exemption.js
@@ -2454,13 +2454,17 @@ router.post('/' + version + section + 'same-activity-dates-router', function (re
 });
 
 router.get('/' + version + section + 'same-activity-dates', function (req, res) {
+    const returnTo = req.query.returnTo;
+    
     // Check if we're returning from review-site-details
-    if (req.query.returnTo === 'review-site-details') {
+    if (returnTo === 'review-site-details') {
         req.session.data['fromReviewSiteDetails'] = 'true';
         updateReviewState(req.session, 'editing');
     }
     
-    res.render(version + section + 'same-activity-dates');
+    res.render(version + section + 'same-activity-dates', {
+        returnTo: returnTo
+    });
 });
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -2544,13 +2548,17 @@ router.post('/' + version + section + 'same-activity-description-router', functi
 });
 
 router.get('/' + version + section + 'same-activity-description', function (req, res) {
+    const returnTo = req.query.returnTo;
+    
     // Check if we're returning from review-site-details
-    if (req.query.returnTo === 'review-site-details') {
+    if (returnTo === 'review-site-details') {
         req.session.data['fromReviewSiteDetails'] = 'true';
         updateReviewState(req.session, 'editing');
     }
     
-    res.render(version + section + 'same-activity-description');
+    res.render(version + section + 'same-activity-description', {
+        returnTo: returnTo
+    });
 });
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/app/views/versions/multiple-sites-v2/exemption/same-activity-dates.html
+++ b/app/views/versions/multiple-sites-v2/exemption/same-activity-dates.html
@@ -85,7 +85,9 @@ Are the activity dates the same for every site?
         {{ govukButton({
           text: "Continue"
         }) }}
+        {% if returnTo !== 'review-site-details' %}
         <a class="govuk-link govuk-link--no-visited-state" href="cancel-site-details">Cancel</a>
+        {% endif %}
     </div>
 
         </form>

--- a/app/views/versions/multiple-sites-v2/exemption/same-activity-description.html
+++ b/app/views/versions/multiple-sites-v2/exemption/same-activity-description.html
@@ -85,7 +85,9 @@ Is the activity description the same for every site?
         {{ govukButton({
           text: "Continue"
         }) }}
+        {% if returnTo !== 'review-site-details' %}
         <a class="govuk-link govuk-link--no-visited-state" href="cancel-site-details">Cancel</a>
+        {% endif %}
     </div>
 
         </form>


### PR DESCRIPTION
The cancel link on 'same-activity-dates' and 'same-activity-description' pages is now hidden when returning from 'review-site-details'. The route handlers pass the 'returnTo' query parameter to the views to support this conditional rendering.