### PR TITLE
TM Exemptions rename OSGB36 option to British National Grid (OSGB36)

### DIFF
--- a/app/views/versions/multiple-sites-v2/exemption/check-answers-internal-01.html
+++ b/app/views/versions/multiple-sites-v2/exemption/check-answers-internal-01.html
@@ -357,7 +357,7 @@
           
         {% if data['exemption-what-coordinate-system-radios'] == "WGS84 (World Geodetic System 1984)" or not data['exemption-what-coordinate-system-radios'] %} Latitude and longitude
         
-        {% elif data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" %} Eastings and Northings
+        {% elif data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" %} Eastings and Northings
 
         {% endif %}
          

--- a/app/views/versions/multiple-sites-v2/exemption/check-answers-internal.html
+++ b/app/views/versions/multiple-sites-v2/exemption/check-answers-internal.html
@@ -348,7 +348,7 @@
           
         {% if data['exemption-what-coordinate-system-radios'] == "WGS84 (World Geodetic System 1984)" or not data['exemption-what-coordinate-system-radios'] %} Latitude and longitude
         
-        {% elif data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" %} Eastings and Northings
+        {% elif data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" %} Eastings and Northings
 
         {% endif %}
          

--- a/app/views/versions/multiple-sites-v2/exemption/check-answers-multiple-sites.html
+++ b/app/views/versions/multiple-sites-v2/exemption/check-answers-multiple-sites.html
@@ -413,7 +413,7 @@
             </dd>
             {% if data['applicationSubmitted'] != "true" %}
             <dd class="govuk-summary-list__actions">
-              <a class="govuk-link" href="project-name.html?camefromcheckanswers=true">Change<span class="govuk-visually-hidden"> Project name</span></a>
+              <a class="govuk-link govuk-link--no-visited-state" href="project-name.html?camefromcheckanswers=true">Change<span class="govuk-visually-hidden"> Project name</span></a>
             </dd>
             {% endif %}
           </div>
@@ -570,7 +570,7 @@
         {% if data['applicationSubmitted'] != "true" %}
         <ul class="govuk-summary-card__actions">
           <li class="govuk-summary-card__action">
-            <a class="govuk-link" href="review-site-details?batchId={{ fileUploadBatchId }}&camefromcheckanswers=true">Change<span class="govuk-visually-hidden"> Providing the site location</span></a>
+            <a class="govuk-link govuk-link--no-visited-state" href="review-site-details?batchId={{ fileUploadBatchId }}&camefromcheckanswers=true">Change<span class="govuk-visually-hidden"> Providing the site location</span></a>
           </li>
         </ul>
         {% endif %}
@@ -624,7 +624,7 @@
         {% if data['applicationSubmitted'] != "true" %}
         <ul class="govuk-summary-card__actions">
           <li class="govuk-summary-card__action">
-            <a class="govuk-link" href="review-site-details?batchId={{ fileUploadBatchId }}&camefromcheckanswers=true">Change<span class="govuk-visually-hidden"> Activity details</span></a>
+            <a class="govuk-link govuk-link--no-visited-state" href="review-site-details?batchId={{ fileUploadBatchId }}&camefromcheckanswers=true">Change<span class="govuk-visually-hidden"> Activity details</span></a>
           </li>
         </ul>
         {% endif %}
@@ -703,7 +703,7 @@
         {% if data['applicationSubmitted'] != "true" %}
         <ul class="govuk-summary-card__actions">
           <li class="govuk-summary-card__action">
-            <a class="govuk-link" href="manual-entry/review-site-details?batchId={{ manualEntryBatchId }}&camefromcheckanswers=true">Change<span class="govuk-visually-hidden"> Providing the site location</span></a>
+            <a class="govuk-link govuk-link--no-visited-state" href="manual-entry/review-site-details?batchId={{ manualEntryBatchId }}&camefromcheckanswers=true">Change<span class="govuk-visually-hidden"> Providing the site location</span></a>
           </li>
         </ul>
         {% endif %}
@@ -741,7 +741,7 @@
         {% if data['applicationSubmitted'] != "true" %}
         <ul class="govuk-summary-card__actions">
           <li class="govuk-summary-card__action">
-            <a class="govuk-link" href="manual-entry/review-site-details?batchId={{ manualEntryBatchId }}&camefromcheckanswers=true">Change<span class="govuk-visually-hidden"> Providing the site location</span></a>
+            <a class="govuk-link govuk-link--no-visited-state" href="manual-entry/review-site-details?batchId={{ manualEntryBatchId }}&camefromcheckanswers=true">Change<span class="govuk-visually-hidden"> Providing the site location</span></a>
           </li>
         </ul>
         {% endif %}
@@ -777,7 +777,7 @@
         {% if data['applicationSubmitted'] != "true" %}
         <ul class="govuk-summary-card__actions">
           <li class="govuk-summary-card__action">
-            <a class="govuk-link" href="manual-entry/review-site-details?batchId={{ manualEntryBatchId }}&camefromcheckanswers=true">Change<span class="govuk-visually-hidden"> Activity details</span></a>
+            <a class="govuk-link govuk-link--no-visited-state" href="manual-entry/review-site-details?batchId={{ manualEntryBatchId }}&camefromcheckanswers=true">Change<span class="govuk-visually-hidden"> Activity details</span></a>
           </li>
         </ul>
         {% endif %}
@@ -998,7 +998,7 @@
                   <dd class="govuk-summary-list__value">
                     {{ site.coordinateSystem }}
                     <br>
-                    {% if site.coordinateSystem == "OSGB36 (National Grid)" %}
+                    {% if site.coordinateSystem == "British National Grid (OSGB36)" %}
                       Eastings and Northings
                     {% else %}
                       Latitude and longitude
@@ -1095,7 +1095,7 @@
                   <dd class="govuk-summary-list__value">
                     {{ site.coordinateSystem }}
                     <br>
-                    {% if site.coordinateSystem == "OSGB36 (National Grid)" %}
+                    {% if site.coordinateSystem == "British National Grid (OSGB36)" %}
                       Eastings and Northings
                     {% else %}
                       Latitude and longitude
@@ -1219,7 +1219,7 @@
         {% if data['applicationSubmitted'] != "true" %}
         <ul class="govuk-summary-card__actions">
           <li class="govuk-summary-card__action">
-            <a class="govuk-link" href="public-register?camefromcheckanswers=true">Change<span class="govuk-visually-hidden"> Information withheld from public register</span></a>
+            <a class="govuk-link govuk-link--no-visited-state" href="public-register?camefromcheckanswers=true">Change<span class="govuk-visually-hidden"> Information withheld from public register</span></a>
           </li>
         </ul>
         {% endif %}

--- a/app/views/versions/multiple-sites-v2/exemption/check-answers-multiple-sites_pre-change.html
+++ b/app/views/versions/multiple-sites-v2/exemption/check-answers-multiple-sites_pre-change.html
@@ -380,7 +380,7 @@
                   <dd class="govuk-summary-list__value">
                     {{ site.coordinateSystem }}
                     <br>
-                    {% if site.coordinateSystem == "OSGB36 (National Grid)" %}
+                    {% if site.coordinateSystem == "British National Grid (OSGB36)" %}
                       Eastings and Northings
                     {% else %}
                       Latitude and longitude
@@ -483,7 +483,7 @@
                   <dd class="govuk-summary-list__value">
                     {{ site.coordinateSystem }}
                     <br>
-                    {% if site.coordinateSystem == "OSGB36 (National Grid)" %}
+                    {% if site.coordinateSystem == "British National Grid (OSGB36)" %}
                       Eastings and Northings
                     {% else %}
                       Latitude and longitude

--- a/app/views/versions/multiple-sites-v2/exemption/check-answers.html
+++ b/app/views/versions/multiple-sites-v2/exemption/check-answers.html
@@ -360,7 +360,7 @@
           
         {% if data['exemption-what-coordinate-system-radios'] == "WGS84 (World Geodetic System 1984)" or not data['exemption-what-coordinate-system-radios'] %} Latitude and longitude
         
-        {% elif data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" %} Eastings and Northings
+        {% elif data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" %} Eastings and Northings
 
         {% endif %}
          

--- a/app/views/versions/multiple-sites-v2/exemption/enter-multiple-coordinates-v1.html
+++ b/app/views/versions/multiple-sites-v2/exemption/enter-multiple-coordinates-v1.html
@@ -58,7 +58,7 @@ Enter multiple sets of coordinates to mark the boundary of the site
                         
         {% include "../includes/lat-long-content.html" %}
 
-        {% elif data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" %}
+        {% elif data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" %}
 
         <p class="govuk-hint">Eastings and northings should only include numbers. For example: 123456</p>
 
@@ -75,14 +75,14 @@ Enter multiple sets of coordinates to mark the boundary of the site
                     </dt>
                     <dd class="govuk-summary-list__value summary-header">
                         {% if data['exemption-what-coordinate-system-radios'] == "WGS84 (World Geodetic System 1984)" %}Latitude
-                        {% elif data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" %}Eastings
+                        {% elif data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" %}Eastings
 
                         {% endif %}
                     </dd>
                     <dd class="govuk-summary-list__value summary-header">
                         {% if data['exemption-what-coordinate-system-radios'] == "WGS84 (World Geodetic System 1984)" %}Longitude
 
-                        {% elif data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" %}Northings
+                        {% elif data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" %}Northings
 
                         {% endif %}
                     </dd>
@@ -98,7 +98,7 @@ Enter multiple sets of coordinates to mark the boundary of the site
                         
                             Latitude of start and end point
 
-                            {% elif data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" %}
+                            {% elif data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" %}
 
                             Eastings of start and end point
 
@@ -117,7 +117,7 @@ Enter multiple sets of coordinates to mark the boundary of the site
                         
                             Longitude of start and end point
 
-                            {% elif data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" %}
+                            {% elif data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" %}
 
                             Northings of start and end point
 
@@ -143,7 +143,7 @@ Enter multiple sets of coordinates to mark the boundary of the site
                         
                             Latitude of point 2
 
-                            {% elif data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" %}
+                            {% elif data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" %}
 
                             Eastings of point 2
 
@@ -162,7 +162,7 @@ Enter multiple sets of coordinates to mark the boundary of the site
                         
                             Longitude of point 2
 
-                            {% elif data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" %}
+                            {% elif data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" %}
 
                             Northings of point 2
 
@@ -188,7 +188,7 @@ Enter multiple sets of coordinates to mark the boundary of the site
                         
                             Latitude of point 3
 
-                            {% elif data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" %}
+                            {% elif data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" %}
 
                             Eastings of point 3
 
@@ -207,7 +207,7 @@ Enter multiple sets of coordinates to mark the boundary of the site
                         
                             Longitude of point 3
 
-                            {% elif data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" %}
+                            {% elif data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" %}
 
                             Northings of point 3
 
@@ -234,7 +234,7 @@ Enter multiple sets of coordinates to mark the boundary of the site
                         
                             Latitude of point 4
 
-                            {% elif data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" %}
+                            {% elif data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" %}
 
                             Eastings of point 4
 
@@ -248,7 +248,7 @@ Enter multiple sets of coordinates to mark the boundary of the site
                         
                             Longitude of point 4
 
-                            {% elif data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" %}
+                            {% elif data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" %}
 
                             Northings of point 4
 
@@ -272,7 +272,7 @@ Enter multiple sets of coordinates to mark the boundary of the site
                         
                             Latitude of point 5
 
-                            {% elif data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" %}
+                            {% elif data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" %}
 
                             Eastings of point 5
 
@@ -286,7 +286,7 @@ Enter multiple sets of coordinates to mark the boundary of the site
                         
                             Longitude of point 5
 
-                            {% elif data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" %}
+                            {% elif data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" %}
 
                             Northings of point 5
 

--- a/app/views/versions/multiple-sites-v2/exemption/enter-multiple-coordinates.html
+++ b/app/views/versions/multiple-sites-v2/exemption/enter-multiple-coordinates.html
@@ -13,7 +13,7 @@
 {% set point1LatHTML %}
     {% if data['exemption-what-coordinate-system-radios'] == "WGS84 (World Geodetic System 1984)" or not data['exemption-what-coordinate-system-radios'] %}                  
     Latitude of start and end point
-    {% elif data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" %}
+    {% elif data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" %}
     Eastings of the start and end point
     {% endif %}
 {% endset %}
@@ -21,7 +21,7 @@
 {% set point1LongHTML %}
     {% if data['exemption-what-coordinate-system-radios'] == "WGS84 (World Geodetic System 1984)" or not data['exemption-what-coordinate-system-radios'] %}
     Longitude of start and end point
-    {% elif data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" %}
+    {% elif data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" %}
     Northings of the start and end point
     {% endif %}
 {% endset %}
@@ -29,7 +29,7 @@
 {% set point2LatHTML %}
     {% if data['exemption-what-coordinate-system-radios'] == "WGS84 (World Geodetic System 1984)" or not data['exemption-what-coordinate-system-radios'] %}                 
     Latitude of point 2
-    {% elif data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" %}
+    {% elif data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" %}
     Eastings of point 2
     {% endif %}
 {% endset %}
@@ -37,7 +37,7 @@
 {% set point2LongHTML %}
     {% if data['exemption-what-coordinate-system-radios'] == "WGS84 (World Geodetic System 1984)" or not data['exemption-what-coordinate-system-radios'] %}          
     Longitude of point 2
-    {% elif data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" %}
+    {% elif data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" %}
     Northings of point 2
     {% endif %}
 {% endset %}
@@ -45,7 +45,7 @@
 {% set point3LatHTML %}
     {% if data['exemption-what-coordinate-system-radios'] == "WGS84 (World Geodetic System 1984)" or not data['exemption-what-coordinate-system-radios'] %}              
     Latitude of point 3
-    {% elif data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" %}
+    {% elif data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" %}
     Eastings of point 3
     {% endif %}
 {% endset %}
@@ -53,7 +53,7 @@
 {% set point3LongHTML %}
 {% if data['exemption-what-coordinate-system-radios'] == "WGS84 (World Geodetic System 1984)" or not data['exemption-what-coordinate-system-radios'] %}          
     Longitude of point 3
-    {% elif data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" %}
+    {% elif data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" %}
     Northings of point 3
     {% endif %}
 {% endset %}
@@ -61,7 +61,7 @@
 {% set point4LatHTML %}
     {% if data['exemption-what-coordinate-system-radios'] == "WGS84 (World Geodetic System 1984)" or not data['exemption-what-coordinate-system-radios'] %}              
     Latitude of point 4
-    {% elif data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" %}
+    {% elif data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" %}
     Eastings of point 4
     {% endif %}
 {% endset %}
@@ -69,7 +69,7 @@
 {% set point4LongHTML %}
 {% if data['exemption-what-coordinate-system-radios'] == "WGS84 (World Geodetic System 1984)" or not data['exemption-what-coordinate-system-radios'] %}          
     Longitude of point 4
-    {% elif data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" %}
+    {% elif data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" %}
     Northings of point 4
     {% endif %}
 {% endset %}
@@ -77,7 +77,7 @@
 {% set point5LatHTML %}
     {% if data['exemption-what-coordinate-system-radios'] == "WGS84 (World Geodetic System 1984)" or not data['exemption-what-coordinate-system-radios'] %}              
     Latitude of point 5
-    {% elif data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" %}
+    {% elif data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" %}
     Eastings of point 5
     {% endif %}
 {% endset %}
@@ -85,7 +85,7 @@
 {% set point5LongHTML %}
 {% if data['exemption-what-coordinate-system-radios'] == "WGS84 (World Geodetic System 1984)" or not data['exemption-what-coordinate-system-radios'] %}          
     Longitude of point 5
-    {% elif data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" %}
+    {% elif data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" %}
     Northings of point 5
     {% endif %}
 {% endset %}
@@ -95,28 +95,28 @@
     {% if data['errorLatHTML'] == "true" %}
         {% if data['exemption-what-coordinate-system-radios'] == "WGS84 (World Geodetic System 1984)" or not data['exemption-what-coordinate-system-radios'] %} 
             Enter the latitude
-        {% elif data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" %}
+        {% elif data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" %}
             Enter the eastings
         {% endif %}
     {% elif data['errorLongHTML'] == "true" %}
         {% if data['exemption-what-coordinate-system-radios'] == "WGS84 (World Geodetic System 1984)" or not data['exemption-what-coordinate-system-radios'] %} 
             Enter the longitude
-        {% elif data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" %}
+        {% elif data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" %}
             Enter the northings
         {% endif %}
     {% endif %}
 {% endset %}
 
-{% set point1LatError = "Enter the " + ("eastings" if data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" else "latitude") + " of the start and end point" %}
-{% set point1LongError = "Enter the " + ("northings" if data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" else "longitude") + " of the start and end point" %}
-{% set point2LatError = "Enter the " + ("eastings" if data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" else "latitude") + " of point 2" %}
-{% set point2LongError = "Enter the " + ("northings" if data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" else "longitude") + " of point 2" %}
-{% set point3LatError = "Enter the " + ("eastings" if data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" else "latitude") + " of point 3" %}
-{% set point3LongError = "Enter the " + ("northings" if data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" else "longitude") + " of point 3" %}
-{% set point4LatError = "Enter the " + ("eastings" if data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" else "latitude") + " of point 4" %}
-{% set point4LongError = "Enter the " + ("northings" if data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" else "longitude") + " of point 4" %}
-{% set point5LatError = "Enter the " + ("eastings" if data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" else "latitude") + " of point 5" %}
-{% set point5LongError = "Enter the " + ("northings" if data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" else "longitude") + " of point 5" %}
+{% set point1LatError = "Enter the " + ("eastings" if data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" else "latitude") + " of the start and end point" %}
+{% set point1LongError = "Enter the " + ("northings" if data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" else "longitude") + " of the start and end point" %}
+{% set point2LatError = "Enter the " + ("eastings" if data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" else "latitude") + " of point 2" %}
+{% set point2LongError = "Enter the " + ("northings" if data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" else "longitude") + " of point 2" %}
+{% set point3LatError = "Enter the " + ("eastings" if data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" else "latitude") + " of point 3" %}
+{% set point3LongError = "Enter the " + ("northings" if data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" else "longitude") + " of point 3" %}
+{% set point4LatError = "Enter the " + ("eastings" if data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" else "latitude") + " of point 4" %}
+{% set point4LongError = "Enter the " + ("northings" if data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" else "longitude") + " of point 4" %}
+{% set point5LatError = "Enter the " + ("eastings" if data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" else "latitude") + " of point 5" %}
+{% set point5LongError = "Enter the " + ("northings" if data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" else "longitude") + " of point 5" %}
 
 <!-- Text that show in the browser tab. Does NOT need changing -->
 {% block pageTitle %}
@@ -159,7 +159,7 @@
                         
         {% include "../includes/lat-long-content.html" %}
 
-        {% elif data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" %}
+        {% elif data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" %}
 
         {% include "../includes/east-north-content.html" %}
 

--- a/app/views/versions/multiple-sites-v2/exemption/enter-the-coordinates-at-the-centre-point.html
+++ b/app/views/versions/multiple-sites-v2/exemption/enter-the-coordinates-at-the-centre-point.html
@@ -16,7 +16,7 @@ Enter the coordinates at the centre point of the site
                                 
     Latitude
 
-    {% elif data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" %}
+    {% elif data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" %}
 
     Eastings
 
@@ -28,7 +28,7 @@ Enter the coordinates at the centre point of the site
                                 
     Longitude
 
-    {% elif data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" %}
+    {% elif data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" %}
 
     Northings
 
@@ -91,7 +91,7 @@ Enter the coordinates at the centre point of the site
                  
               {% include "../includes/lat-long-content.html" %}
       
-              {% elif data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" %}
+              {% elif data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" %}
 
               {% include "../includes/east-north-content.html" %}
       

--- a/app/views/versions/multiple-sites-v2/exemption/manual-entry/enter-coordinates.html
+++ b/app/views/versions/multiple-sites-v2/exemption/manual-entry/enter-coordinates.html
@@ -33,7 +33,7 @@ Enter the coordinates at the centre point of the site
         
         <!-- Setting the smaller secondary headings based on coordinate system -->
         {% set questionHeadingTextOneHTML %}
-            {% if site.coordinates.system == "OSGB36 (National Grid)" %}
+            {% if site.coordinates.system == "British National Grid (OSGB36)" %}
             Easting
             {% else %}
             Latitude
@@ -41,7 +41,7 @@ Enter the coordinates at the centre point of the site
         {% endset %}
 
         {% set questionHeadingTextTwoHTML %}
-            {% if site.coordinates.system == "OSGB36 (National Grid)" %}
+            {% if site.coordinates.system == "British National Grid (OSGB36)" %}
             Northing
             {% else %}
             Longitude
@@ -83,7 +83,7 @@ Enter the coordinates at the centre point of the site
                 }
               }) %}
               
-              {% if site.coordinates.system == "OSGB36 (National Grid)" %}
+              {% if site.coordinates.system == "British National Grid (OSGB36)" %}
               {% include "../../includes/east-north-content.html" %}
               {% else %}
               {% include "../../includes/lat-long-content.html" %}

--- a/app/views/versions/multiple-sites-v2/exemption/manual-entry/enter-multiple-coordinates.html
+++ b/app/views/versions/multiple-sites-v2/exemption/manual-entry/enter-multiple-coordinates.html
@@ -22,7 +22,7 @@
 {% set point1LatHTML %}
     {% if coordinateSystem == "WGS84 (World Geodetic System 1984)" or not coordinateSystem %}                  
     Latitude of start and end point
-    {% elif coordinateSystem == "OSGB36 (National Grid)" %}
+    {% elif coordinateSystem == "British National Grid (OSGB36)" %}
     Eastings of the start and end point
     {% endif %}
 {% endset %}
@@ -30,7 +30,7 @@
 {% set point1LongHTML %}
     {% if coordinateSystem == "WGS84 (World Geodetic System 1984)" or not coordinateSystem %}
     Longitude of start and end point
-    {% elif coordinateSystem == "OSGB36 (National Grid)" %}
+    {% elif coordinateSystem == "British National Grid (OSGB36)" %}
     Northings of the start and end point
     {% endif %}
 {% endset %}
@@ -38,7 +38,7 @@
 {% set point2LatHTML %}
     {% if coordinateSystem == "WGS84 (World Geodetic System 1984)" or not coordinateSystem %}                 
     Latitude of point 2
-    {% elif coordinateSystem == "OSGB36 (National Grid)" %}
+    {% elif coordinateSystem == "British National Grid (OSGB36)" %}
     Eastings of point 2
     {% endif %}
 {% endset %}
@@ -46,7 +46,7 @@
 {% set point2LongHTML %}
     {% if coordinateSystem == "WGS84 (World Geodetic System 1984)" or not coordinateSystem %}          
     Longitude of point 2
-    {% elif coordinateSystem == "OSGB36 (National Grid)" %}
+    {% elif coordinateSystem == "British National Grid (OSGB36)" %}
     Northings of point 2
     {% endif %}
 {% endset %}
@@ -54,7 +54,7 @@
 {% set point3LatHTML %}
     {% if coordinateSystem == "WGS84 (World Geodetic System 1984)" or not coordinateSystem %}              
     Latitude of point 3
-    {% elif coordinateSystem == "OSGB36 (National Grid)" %}
+    {% elif coordinateSystem == "British National Grid (OSGB36)" %}
     Eastings of point 3
     {% endif %}
 {% endset %}
@@ -62,7 +62,7 @@
 {% set point3LongHTML %}
 {% if coordinateSystem == "WGS84 (World Geodetic System 1984)" or not coordinateSystem %}          
     Longitude of point 3
-    {% elif coordinateSystem == "OSGB36 (National Grid)" %}
+    {% elif coordinateSystem == "British National Grid (OSGB36)" %}
     Northings of point 3
     {% endif %}
 {% endset %}
@@ -70,7 +70,7 @@
 {% set point4LatHTML %}
     {% if coordinateSystem == "WGS84 (World Geodetic System 1984)" or not coordinateSystem %}              
     Latitude of point 4
-    {% elif coordinateSystem == "OSGB36 (National Grid)" %}
+    {% elif coordinateSystem == "British National Grid (OSGB36)" %}
     Eastings of point 4
     {% endif %}
 {% endset %}
@@ -78,7 +78,7 @@
 {% set point4LongHTML %}
 {% if coordinateSystem == "WGS84 (World Geodetic System 1984)" or not coordinateSystem %}          
     Longitude of point 4
-    {% elif coordinateSystem == "OSGB36 (National Grid)" %}
+    {% elif coordinateSystem == "British National Grid (OSGB36)" %}
     Northings of point 4
     {% endif %}
 {% endset %}
@@ -86,7 +86,7 @@
 {% set point5LatHTML %}
     {% if coordinateSystem == "WGS84 (World Geodetic System 1984)" or not coordinateSystem %}              
     Latitude of point 5
-    {% elif coordinateSystem == "OSGB36 (National Grid)" %}
+    {% elif coordinateSystem == "British National Grid (OSGB36)" %}
     Eastings of point 5
     {% endif %}
 {% endset %}
@@ -94,23 +94,23 @@
 {% set point5LongHTML %}
 {% if coordinateSystem == "WGS84 (World Geodetic System 1984)" or not coordinateSystem %}          
     Longitude of point 5
-    {% elif coordinateSystem == "OSGB36 (National Grid)" %}
+    {% elif coordinateSystem == "British National Grid (OSGB36)" %}
     Northings of point 5
     {% endif %}
 {% endset %}
 
 <!-- Error text variables - cleaned up for batch system -->
 
-{% set point1LatError = "Enter the " + ("eastings" if coordinateSystem == "OSGB36 (National Grid)" else "latitude") + " of the start and end point" %}
-{% set point1LongError = "Enter the " + ("northings" if coordinateSystem == "OSGB36 (National Grid)" else "longitude") + " of the start and end point" %}
-{% set point2LatError = "Enter the " + ("eastings" if coordinateSystem == "OSGB36 (National Grid)" else "latitude") + " of point 2" %}
-{% set point2LongError = "Enter the " + ("northings" if coordinateSystem == "OSGB36 (National Grid)" else "longitude") + " of point 2" %}
-{% set point3LatError = "Enter the " + ("eastings" if coordinateSystem == "OSGB36 (National Grid)" else "latitude") + " of point 3" %}
-{% set point3LongError = "Enter the " + ("northings" if coordinateSystem == "OSGB36 (National Grid)" else "longitude") + " of point 3" %}
-{% set point4LatError = "Enter the " + ("eastings" if coordinateSystem == "OSGB36 (National Grid)" else "latitude") + " of point 4" %}
-{% set point4LongError = "Enter the " + ("northings" if coordinateSystem == "OSGB36 (National Grid)" else "longitude") + " of point 4" %}
-{% set point5LatError = "Enter the " + ("eastings" if coordinateSystem == "OSGB36 (National Grid)" else "latitude") + " of point 5" %}
-{% set point5LongError = "Enter the " + ("northings" if coordinateSystem == "OSGB36 (National Grid)" else "longitude") + " of point 5" %}
+{% set point1LatError = "Enter the " + ("eastings" if coordinateSystem == "British National Grid (OSGB36)" else "latitude") + " of the start and end point" %}
+{% set point1LongError = "Enter the " + ("northings" if coordinateSystem == "British National Grid (OSGB36)" else "longitude") + " of the start and end point" %}
+{% set point2LatError = "Enter the " + ("eastings" if coordinateSystem == "British National Grid (OSGB36)" else "latitude") + " of point 2" %}
+{% set point2LongError = "Enter the " + ("northings" if coordinateSystem == "British National Grid (OSGB36)" else "longitude") + " of point 2" %}
+{% set point3LatError = "Enter the " + ("eastings" if coordinateSystem == "British National Grid (OSGB36)" else "latitude") + " of point 3" %}
+{% set point3LongError = "Enter the " + ("northings" if coordinateSystem == "British National Grid (OSGB36)" else "longitude") + " of point 3" %}
+{% set point4LatError = "Enter the " + ("eastings" if coordinateSystem == "British National Grid (OSGB36)" else "latitude") + " of point 4" %}
+{% set point4LongError = "Enter the " + ("northings" if coordinateSystem == "British National Grid (OSGB36)" else "longitude") + " of point 4" %}
+{% set point5LatError = "Enter the " + ("eastings" if coordinateSystem == "British National Grid (OSGB36)" else "latitude") + " of point 5" %}
+{% set point5LongError = "Enter the " + ("northings" if coordinateSystem == "British National Grid (OSGB36)" else "longitude") + " of point 5" %}
 
 <!-- Error state helpers -->
 {% set hasPoint1LatError = false %}
@@ -191,7 +191,7 @@
                         
         {% include "../../includes/lat-long-content.html" %}
 
-        {% elif coordinateSystem == "OSGB36 (National Grid)" %}
+        {% elif coordinateSystem == "British National Grid (OSGB36)" %}
 
         {% include "../../includes/east-north-content.html" %}
 

--- a/app/views/versions/multiple-sites-v2/exemption/manual-entry/review-site-details.html
+++ b/app/views/versions/multiple-sites-v2/exemption/manual-entry/review-site-details.html
@@ -415,7 +415,7 @@ Review site details
                                         {{ site.coordinateSystem }}<br>
                                         {% if site.coordinateSystem == "WGS84 (World Geodetic System 1984)" %}
                                             Latitude and longitude
-                                        {% elif site.coordinateSystem == "OSGB36 (National Grid)" %}
+                                        {% elif site.coordinateSystem == "British National Grid (OSGB36)" %}
                                             Eastings and Northings
                                         {% endif %}
                                     {% else %}

--- a/app/views/versions/multiple-sites-v2/exemption/manual-entry/which-coordinate-system.html
+++ b/app/views/versions/multiple-sites-v2/exemption/manual-entry/which-coordinate-system.html
@@ -78,8 +78,8 @@ Which coordinate system do you want to use?
                  <h2 class="govuk-heading-s">WGS84 (World Geodetic System 1984)</h2>
                   <p>WGS84 is a global system widely used in GPS and mapping tools like Google Maps. It uses latitude and longitude to pinpoint locations. For example, latitude 55.019889, longitude -1.399500.</p>
                     
-                  <h2 class="govuk-heading-s">OSGB36 (National Grid)</h2>
-                  <p>Also known as the British National Grid (BNG), OSGB36 maps Great Britain using numerical east and north positions, called eastings and northings. For example, easting 438493, northing 569648.</p>
+                  <h2 class="govuk-heading-s">British National Grid (OSGB36)</h2>
+                  <p>The British National Grid maps Great Britain using numerical east and north positions, called eastings and northings. It’s based on the OSGB36 reference system used by Ordnance Survey. For example, easting 438493, northing 569648.</p>
                 </div>
               </details>
             
@@ -116,9 +116,9 @@ Which coordinate system do you want to use?
                             }
                         },
                         {
-                            value: "OSGB36 (National Grid)",
-                            text: "OSGB36 (National Grid)",
-                            checked: (site.coordinateSystem == "OSGB36 (National Grid)") if returnTo == 'review-site-details' else (data[siteDataKey] == "OSGB36 (National Grid)"),
+                            value: "British National Grid (OSGB36)",
+                            text: "British National Grid (OSGB36)",
+                            checked: (site.coordinateSystem == "British National Grid (OSGB36)") if returnTo == 'review-site-details' else (data[siteDataKey] == "British National Grid (OSGB36)"),
                             hint: {
                               text: "Uses eastings and northings"
                             }

--- a/app/views/versions/multiple-sites-v2/exemption/review-location.html
+++ b/app/views/versions/multiple-sites-v2/exemption/review-location.html
@@ -144,7 +144,7 @@ Review site details
           
         {% if data['exemption-what-coordinate-system-radios'] == "WGS84 (World Geodetic System 1984)" or not data['exemption-what-coordinate-system-radios'] %} Latitude and longitude
         
-        {% elif data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" %} Eastings and Northings
+        {% elif data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" %} Eastings and Northings
 
         {% endif %}
          

--- a/app/views/versions/multiple-sites-v2/exemption/summarytest.html
+++ b/app/views/versions/multiple-sites-v2/exemption/summarytest.html
@@ -87,7 +87,7 @@
                   Coordinate system
                 </dt>
                 <dd class="govuk-summary-list__value">
-                  OSGB36 (National Grid)<br>
+                  British National Grid (OSGB36)<br>
                   Eastings and Northings
                 </dd>
                 <dd class="govuk-summary-list__actions">

--- a/app/views/versions/multiple-sites-v2/exemption/what-are-the-coordinates-of-the-square.html
+++ b/app/views/versions/multiple-sites-v2/exemption/what-are-the-coordinates-of-the-square.html
@@ -16,7 +16,7 @@ What are the coordinates of the centre of the square?
                             
     Latitude
 
-    {% elif data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" %}
+    {% elif data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" %}
 
     Eastings
 
@@ -28,7 +28,7 @@ What are the coordinates of the centre of the square?
                             
     Longitude
 
-    {% elif data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" %}
+    {% elif data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" %}
 
     Northings
 
@@ -84,7 +84,7 @@ What are the coordinates of the centre of the square?
                         
               {% include "../includes/lat-long-content.html" %}
       
-              {% elif data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)" %}
+              {% elif data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)" %}
       
               <p class="govuk-hint">Eastings and northings should only include numbers. For example: 123456</p>
       

--- a/app/views/versions/multiple-sites-v2/exemption/what-coordinate-system.html
+++ b/app/views/versions/multiple-sites-v2/exemption/what-coordinate-system.html
@@ -63,8 +63,8 @@ Which coordinate system do you want to use?
 			 <h2 class="govuk-heading-s">WGS84 (World Geodetic System 1984)</h2>
 			  <p>WGS84 is a global system that pinpoints locations using latitude and longitude. Latitude shows how far north or south a place is, and longitude shows how far east or west it is. WGS84 is widely used in GPS and mapping tools like Google Maps.</p>
 				
-			  <h2 class="govuk-heading-s">OSGB36 (National Grid)</h2>
-			  <p>Also known as the British National Grid (BNG), OSGB36 is a system used to map Great Britain. It divides the country into squares using numerical east and north positions, known as eastings and northings.</p>
+			  <h2 class="govuk-heading-s">British National Grid (OSGB36)</h2>
+			  <p>The British National Grid maps Great Britain using numerical east and north positions, called eastings and northings. It’s based on the OSGB36 reference system used by Ordnance Survey. For example, easting 438493, northing 569648.</p>
 			</div>
 		  </details>
 
@@ -101,9 +101,9 @@ Which coordinate system do you want to use?
 							}
                         },
                         {
-                            value: "OSGB36 (National Grid)",
-                            text: "OSGB36 (National Grid)",
-                            checked: data['exemption-what-coordinate-system-radios'] == "OSGB36 (National Grid)",
+                            value: "British National Grid (OSGB36)",
+                            text: "British National Grid (OSGB36)",
+                            checked: data['exemption-what-coordinate-system-radios'] == "British National Grid (OSGB36)",
 							hint: {
 							  text: "Uses eastings and northings"
 							}


### PR DESCRIPTION
Updated all references of 'OSGB36 (National Grid)' to 'British National Grid (OSGB36)' across multiple views for consistency and clarity. Also updated related descriptions and radio button values to match the new naming convention.