### PR TITLE
LCML - Fix sharing consent logic and enhance UI for application review

### DIFF
--- a/app/routes/versions/multiple-sites-v2/low-complexity-v2-site-locations.js
+++ b/app/routes/versions/multiple-sites-v2/low-complexity-v2-site-locations.js
@@ -712,6 +712,7 @@ module.exports = function (router) {
     req.session.data['low-complexity-site-duration-errorthispage'] = "false";
     req.session.data['low-complexity-site-duration-years-error'] = "false";
     req.session.data['low-complexity-site-duration-months-error'] = "false";
+    req.session.data['low-complexity-site-duration-zero-error'] = "false";
     res.render(`versions/${version}/${section}/${subsection}/duration`);
   });
 
@@ -721,6 +722,7 @@ module.exports = function (router) {
     req.session.data['low-complexity-site-duration-errorthispage'] = "false";
     req.session.data['low-complexity-site-duration-years-error'] = "false";
     req.session.data['low-complexity-site-duration-months-error'] = "false";
+    req.session.data['low-complexity-site-duration-zero-error'] = "false";
 
     let hasErrors = false;
 
@@ -740,6 +742,16 @@ module.exports = function (router) {
 
     if (hasErrors) {
       req.session.data['low-complexity-site-duration-errorthispage'] = "true";
+      res.redirect('duration');
+      return;
+    }
+
+    // Check if both fields are 0
+    if (req.session.data['low-complexity-site-duration-years'].trim() === '0' && req.session.data['low-complexity-site-duration-months'].trim() === '0') {
+      req.session.data['low-complexity-site-duration-errorthispage'] = "true";
+      req.session.data['low-complexity-site-duration-years-error'] = "true";
+      req.session.data['low-complexity-site-duration-months-error'] = "true";
+      req.session.data['low-complexity-site-duration-zero-error'] = "true";
       res.redirect('duration');
       return;
     }

--- a/app/routes/versions/multiple-sites-v2/low-complexity-v2.js
+++ b/app/routes/versions/multiple-sites-v2/low-complexity-v2.js
@@ -499,8 +499,8 @@ module.exports = function (router) {
     const sharingConsent = req.session.data['low-complexity-sharing-information'];
     const sharingDetails = req.session.data['low-complexity-sharing-information-details'];
 
-    // If "No" is selected, clear the textarea data
-    if (sharingConsent === 'No') {
+    // If "Yes" is selected, clear the textarea data (consent given, no details needed)
+    if (sharingConsent === 'Yes') {
       delete req.session.data['low-complexity-sharing-information-details'];
     }
 
@@ -509,14 +509,14 @@ module.exports = function (router) {
       // Set error flags
       req.session.data['errorthispage'] = "true";
       req.session.data['errortypeone'] = "true";
-      
+
       // Redirect back to the same page with errors
       res.redirect('sharing-your-project-information-publicly');
-    } else if (sharingConsent === 'Yes' && (!sharingDetails || sharingDetails.trim() === '')) {
-      // If Yes is selected, check if textarea has content
+    } else if (sharingConsent === 'No' && (!sharingDetails || sharingDetails.trim() === '')) {
+      // If No is selected, check if textarea has content
       req.session.data['errorthispage'] = "true";
       req.session.data['errortypetwo'] = "true";
-      
+
       // Redirect back to the same page with errors
       res.redirect('sharing-your-project-information-publicly');
     } else {

--- a/app/views/versions/multiple-sites-v2/low-complexity-v2/check-your-answers.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v2/check-your-answers.html
@@ -1362,7 +1362,7 @@ Check your answers before sending your information
 			</div>
 			<div class="govuk-summary-card__content">
 				<dl class="govuk-summary-list">
-					<div class="govuk-summary-list__row">
+					<div class="govuk-summary-list__row govuk-summary-list__row--no-border">
 						<dt class="govuk-summary-list__key">
 							Consent to publish your project information
 						</dt>

--- a/app/views/versions/multiple-sites-v2/low-complexity-v2/check-your-answers.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v2/check-your-answers.html
@@ -3,17 +3,37 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
+{% block head %}
+  {{ super() }}
+  {% if data['low-complexity-application-status'] == 'sent' %}
+  <style>
+    .app-read-only .govuk-summary-list__actions,
+    .app-read-only .govuk-summary-card__actions {
+      display: none;
+    }
+  </style>
+  {% endif %}
+{% endblock %}
+
 {% block beforeContent %}
     {% include "../includes/phase-banner.html" %}
+    {% if data['low-complexity-application-status'] == 'sent' %}
+    {% include "../includes/back-link.html" %}
+    {% else %}
     {% if data['organisation-name'] %}
         {% include "../includes/organisation-switcher.html" %}
     {% endif %}
     <a class="govuk-back-link govuk-link--no-visited-state" href="marine-licence-start-page">Go back to marine licence start page</a>
+    {% endif %}
 {% endblock %}
 
 <!-- Setting the big main heading at the top of the page -->
 {% set pageHeadingTextHTML %}
+{% if data['low-complexity-application-status'] == 'sent' %}
+{{ data['low-complexity-project-name-text-input'] }}
+{% else %}
 Check your answers before sending your information
+{% endif %}
 {% endset %}
 
 <!-- Format start date (month and year only) -->
@@ -38,9 +58,13 @@ Check your answers before sending your information
 
 {% block content %}
 
-<div class="govuk-grid-row">
+<div class="govuk-grid-row{% if data['low-complexity-application-status'] == 'sent' %} app-read-only{% endif %}">
 	<div class="govuk-grid-column-full">
+		{% if data['low-complexity-application-status'] == 'sent' %}
+		<span class="govuk-caption-l">MLA/2025/10025 – Marine licence</span>
+		{% else %}
 		<span class="govuk-caption-l">{{ data['low-complexity-project-name-text-input'] }}</span>
+		{% endif %}
 		<h1 class="govuk-heading-l">
 			{{ pageHeadingTextHTML }}
 		</h1>
@@ -48,6 +72,8 @@ Check your answers before sending your information
 		{# ============================== #}
 		{# PROJECT DETAILS                #}
 		{# ============================== #}
+		{% set isSent = data['low-complexity-application-status'] == 'sent' %}
+
 		{{ govukSummaryList({
 			card: {
 				title: {
@@ -71,7 +97,7 @@ Check your answers before sending your information
 								classes: "govuk-link--no-visited-state"
 							}
 						]
-					}
+					} if not isSent
 				},
 				{
 					key: {
@@ -89,7 +115,7 @@ Check your answers before sending your information
 								classes: "govuk-link--no-visited-state"
 							}
 						]
-					}
+					} if not isSent
 				},
 				{
 					key: {
@@ -107,7 +133,7 @@ Check your answers before sending your information
 								classes: "govuk-link--no-visited-state"
 							}
 						]
-					}
+					} if not isSent
 				}
 			]
 		}) }}
@@ -1336,24 +1362,24 @@ Check your answers before sending your information
 			</div>
 			<div class="govuk-summary-card__content">
 				<dl class="govuk-summary-list">
-					<div class="govuk-summary-list__row{% if data['low-complexity-sharing-information'] == 'Yes' %} govuk-summary-list__row--no-border{% endif %}">
+					<div class="govuk-summary-list__row">
 						<dt class="govuk-summary-list__key">
-							Is there any reason your information cannot be shared publicly?
+							Consent to publish your project information
 						</dt>
 						<dd class="govuk-summary-list__value">
 							{{ data['low-complexity-sharing-information'] }}
 						</dd>
 						<dd class="govuk-summary-list__actions">
 							<a class="govuk-link govuk-link--no-visited-state" href="sharing-your-project-information-publicly?camefromcheckanswers=true">
-								Change<span class="govuk-visually-hidden"> if there is any reason your information cannot be shared publicly</span>
+								Change<span class="govuk-visually-hidden"> consent to publish your project information</span>
 							</a>
 						</dd>
 					</div>
 
-					{% if data['low-complexity-sharing-information'] == 'Yes' %}
+					{% if data['low-complexity-sharing-information'] == 'No' %}
 					<div class="govuk-summary-list__row">
 						<dt class="govuk-summary-list__key">
-							Reason your information cannot be shared publicly
+							Why you do not consent
 						</dt>
 						<dd class="govuk-summary-list__value">
 							{{ data['low-complexity-sharing-information-details'] }}
@@ -1369,11 +1395,13 @@ Check your answers before sending your information
 			</div>
 		</div>
 
+		{% if data['low-complexity-application-status'] != 'sent' %}
 		<form action="declaration" method="post" novalidate>
 			{{ govukButton({
 				text: "Continue"
 			}) }}
 		</form>
+		{% endif %}
 
 	</div>
 </div>

--- a/app/views/versions/multiple-sites-v2/low-complexity-v2/projects.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v2/projects.html
@@ -147,7 +147,7 @@ Projects
 					{% endif %}
 					<td class="govuk-table__cell">
 						{% if data['low-complexity-application-status'] == 'sent' %}
-						<a href="#" class="govuk-link--no-visited-state">View details</a>
+						<a href="check-your-answers" class="govuk-link--no-visited-state">View details</a>
 						{% else %}
 						<a href="marine-licence-start-page" class="govuk-link--no-visited-state govuk-!-margin-right-4">Continue</a> <a href="#" class="govuk-link--no-visited-state">Delete</a>
 						{% endif %}

--- a/app/views/versions/multiple-sites-v2/low-complexity-v2/sharing-your-project-information-publicly.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v2/sharing-your-project-information-publicly.html
@@ -18,6 +18,20 @@
 Sharing your project information publicly
 {% endset %}
 
+<!-- Setting the smaller secondary heading lower down the page -->
+{% set questionHeadingTextHTML %}
+Do you consent to the MMO publishing your project information publicly?
+{% endset %}
+
+<!-- Set the text for the error type -->
+{% set errorTextHTML %}
+{% if data['errortypeone'] == "true" %}
+Select whether you consent to the MMO publishing your project information publicly
+{% elif data['errortypetwo'] == "true" %}
+Enter details of why you do not consent to your project information being published
+{% endif %}
+{% endset %}
+
 <!-- Text that show in the browser tab. Does NOT need changing -->
 {% block pageTitle %}
 {% if data['errorthispage'] == "true" %}
@@ -27,95 +41,93 @@ Error:
 {{ pageHeadingTextHTML }} - {{ data['headerNameExemption'] }}
 {% endblock %}
 
-{% set sharingDetailsTextarea %}
+{% set detailsHtml %}
 {{ govukTextarea({
     id: "low-complexity-sharing-information-details",
     name: "low-complexity-sharing-information-details",
     value: data['low-complexity-sharing-information-details'],
-    rows: 5,
     label: {
-        text: "Provide details of why you do not consent to your project information being published"
+        text: "Provide details of why you do not consent to your project information being published",
+        classes: "govuk-label",
+        isPageHeading: false
     },
-    errorMessage: {
-        text: "Enter details of why you do not consent"
-    } if data['errortypetwo'] == "true"
+    errorMessage: null if data['errortypetwo'] != "true"
+    else { text: "Enter details of why you do not consent to your project information being published" }
 }) }}
-{% endset %}
+{% endset -%}
 
 {% block content %}
 
 <div class="govuk-grid-row">
 	<div class="govuk-grid-column-two-thirds">
+
+		<!-- ERROR LOGIC 'error summary' -->
 		{% if data['errorthispage'] == "true" %}
 		{{ govukErrorSummary({
 			titleText: "There is a problem",
 			errorList: [
 				{
-					text: "Select if there is any reason your information cannot be shared publicly" if data['errortypeone'] == "true" else "Enter details of why you do not consent",
+					text: errorTextHTML,
 					href: "#low-complexity-sharing-information" if data['errortypeone'] == "true" else "#low-complexity-sharing-information-details"
 				}
 			]
 		}) }}
 		{% endif %}
+		<!-- END OF 'error summary' -->
 
-		<!--  END OF 'error summary' -->
-
-		<span class="govuk-caption-l">{{ data['low-complexity-project-name-text-input'] }}</span>
-		<h1 class="govuk-heading-l">
-			{{ pageHeadingTextHTML }}
-		</h1>
-
-		<p class="govuk-body">The MMO must keep a register of information relating to applications and licences it's responsible for. This register must be made available to the public.</p>
-
-		<p class="govuk-body">We will not publish your email address, phone number or the cost of your marine works.</p>
-
-		<h2 class="govuk-heading-m">Information that cannot be publicly shared</h2>
-
-		<p class="govuk-body">Information on your application will not be published on the MMO's public register if the:</p>
-
-		<ul class="govuk-list govuk-list--bullet">
-			<li>Secretary of State decides publishing it contains sensitive information that would be a threat to national security</li>
-			<li>MMO decides the information is commercially sensitive</li>
-		</ul>
-
+		<!-- go to routes.js for routing  -->
 		<form action="sharing-your-project-information-publicly-router" method="post" novalidate>
+			<span class="govuk-caption-l">{{ data['low-complexity-project-name-text-input'] }}</span>
+			<h1 class="govuk-heading-l">
+				{{ pageHeadingTextHTML }}
+			</h1>
+
+			<p>The Marine Management Organisation (MMO) publishes some of the information you provide on <a href="https://www.gov.uk/guidance/explore-marine-plans" rel="noreferrer noopener" target="_blank">Explore Marine Plans (opens in new tab)</a>. In the future, we may also publish this information on the MMO's public register.</p>
+
+			<p>Sharing this information helps you and other applicants:</p>
+
+			<ul class="govuk-list govuk-list--bullet">
+				<li>get a clear picture of activity in the marine environment</li>
+				<li>prepare applications more effectively by avoiding conflicts with existing marine activity</li>
+				<li>evaluate the environmental impact of projects in the context of other marine activity, leading to better applications and evidence for decision-makers</li>
+			</ul>
+
+			<p>We will not publish contact details, such as your email address, phone number or postal address, or any financial information.</p>
 
 			{{ govukRadios({
 				name: "low-complexity-sharing-information",
 				id: "low-complexity-sharing-information",
 				fieldset: {
 					legend: {
-						text: "Is there any reason your information cannot be shared publicly?",
+						html: questionHeadingTextHTML,
 						isPageHeading: false,
 						classes: "govuk-fieldset__legend--m"
 					}
 				},
+				errorMessage: null if data['errortypeone'] != "true"
+				else { html: "Select whether you consent to the MMO publishing your project information publicly" },
 				items: [
 					{
 						value: "Yes",
 						text: "Yes",
-						conditional: {
-							html: sharingDetailsTextarea
-						},
 						checked: data['low-complexity-sharing-information'] == "Yes"
 					},
 					{
 						value: "No",
 						text: "No",
+						conditional: {
+							html: detailsHtml
+						},
 						checked: data['low-complexity-sharing-information'] == "No"
 					}
-				],
-				errorMessage: {
-					text: "Select if there is any reason your information cannot be shared publicly"
-				} if data['errortypeone'] == "true"
+				]
 			}) }}
 
 			<div class="govuk-button-group">
 				{{ govukButton({
 					text: "Save and continue"
 				}) }}
-
-				<a class="govuk-link" href="javascript:history.back()">Cancel</a>
+				<a class="govuk-link govuk-link--no-visited-state" href="javascript:window.history.back()">Cancel</a>
 			</div>
 
 		</form>
@@ -132,7 +144,7 @@ Error:
 
 		<option value="errorthispage=true&errortypeone=true&errortypetwo=false&" {% if data['errortypeone'] == 'true' and data['errortypetwo'] != 'true' %}selected{% endif %}>Error 1 - No radio selected</option>
 
-		<option value="errorthispage=true&errortypeone=false&errortypetwo=true&" {% if data['errortypeone'] != 'true' and data['errortypetwo'] == 'true' %}selected{% endif %}>Error 2 - Textarea left blank</option>
+		<option value="errorthispage=true&errortypeone=false&errortypetwo=true&" {% if data['errortypeone'] != 'true' and data['errortypetwo'] == 'true' %}selected{% endif %}>Error 2 - Input text left blank</option>
 
 	</select>
 

--- a/app/views/versions/multiple-sites-v2/low-complexity-v2/site-details/date-completed-by.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v2/site-details/date-completed-by.html
@@ -37,7 +37,7 @@ Error:
         text: "Explain why the activity needs to be completed by a certain date"
     },
     hint: {
-        text: "Include the dates and reasons why"
+        html: "Include the dates and reasons why<br>Enter a maximum of 1,000 characters"
     },
     errorMessage: {
         text: "Enter the dates and the reasons why"

--- a/app/views/versions/multiple-sites-v2/low-complexity-v2/site-details/date-completed-by.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v2/site-details/date-completed-by.html
@@ -37,7 +37,7 @@ Error:
         text: "Explain why the activity needs to be completed by a certain date"
     },
     hint: {
-        html: "Include the dates and reasons why<br>Enter a maximum of 1,000 characters"
+        html: "Include the dates and reasons why<br><br>Enter a maximum of 1,000 characters"
     },
     errorMessage: {
         text: "Enter the dates and the reasons why"

--- a/app/views/versions/multiple-sites-v2/low-complexity-v2/site-details/duration.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v2/site-details/duration.html
@@ -38,7 +38,7 @@ Error:
 			</h2>
 			<div class="govuk-error-summary__body">
 				<ul class="govuk-list govuk-error-summary__list">
-					<li><a href="#low-complexity-site-duration-years">Enter the maximum duration of the activity</a></li>
+					<li><a href="#low-complexity-site-duration-years">{% if data['low-complexity-site-duration-zero-error'] == 'true' %}Enter a duration{% else %}Enter the maximum duration of the activity{% endif %}</a></li>
 				</ul>
 			</div>
 		</div>
@@ -61,7 +61,7 @@ Error:
 
 					{% if data['low-complexity-site-duration-errorthispage'] == "true" %}
 					<p id="duration-error" class="govuk-error-message">
-						<span class="govuk-visually-hidden">Error:</span> Enter the maximum duration of the activity
+						<span class="govuk-visually-hidden">Error:</span> {% if data['low-complexity-site-duration-zero-error'] == 'true' %}Enter a duration{% else %}Enter the maximum duration of the activity{% endif %}
 					</p>
 					{% endif %}
 


### PR DESCRIPTION
This pull request introduces several improvements and corrections to the low-complexity multi-site application flow, focusing on clearer consent handling, improved error validation, and enhanced user interface feedback for read-only and completed states.

**Consent to Publish Project Information:**
* The consent question and related error messages have been rewritten for clarity, now asking users if they consent to the MMO publishing their project information publicly. The textarea for reasons is only required and shown if the user selects "No" (does not consent), and error handling has been improved to match this logic. 

**Error Handling and Validation:**
* Duration validation now properly checks that the user does not enter zero for both years and months, displaying a specific error message if this occurs. Session variables and error summaries have been updated to support this new validation. 

* Error summary and inline error messages on the consent page now match the new question wording and validation logic. 

**Read-only and Completed State UI Enhancements:**
* The "Check your answers" page now displays in a read-only mode (hides action links and disables the submit button) if the application status is "sent," and the heading/caption adjusts accordingly. 
* The "View details" link on the projects list now correctly routes to the "Check your answers" page for sent applications.

**Content and Accessibility Improvements:**
* Project information consent section and related summary list items have been reworded for clarity and accessibility, including improved hidden text for screen readers.
* The hint for the "date completed by" field now includes a character limit for clarity.

These changes collectively improve the user experience, validation accuracy, and clarity of the low-complexity multi-site application process.