### PR TITLE
LCML Update Change site location and upload file messages

### DIFF
--- a/app/views/versions/multiple-sites-v2/low-complexity-v2/site-details/change-site-location.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v2/site-details/change-site-location.html
@@ -27,7 +27,17 @@ Change site location
       {{ pageHeadingTextHTML }}
     </h1>
 
-    <p class="govuk-body">This is placeholder content. You can change this site location by uploading a single site shapefile or KML file. Any activity details you've already entered will be saved.</p>
+    <div class="govuk-inset-text">
+      {% if data['low-complexity-site-name'] %}
+        Site 1: {{ data['low-complexity-site-name'] }}
+      {% else %}
+        Site 1
+      {% endif %}
+    </div>
+
+    <p class="govuk-body">You can change your site location by uploading a single site file. Any activity details you've already entered will be saved.</p>
+
+    <p class="govuk-body">If you've started the Marine plan policies, changing your site location may change which policies are presented.</p>
 
     <form action="change-site-location-router" method="post" novalidate>
       <div class="govuk-button-group govuk-!-margin-top-7">

--- a/app/views/versions/multiple-sites-v2/low-complexity-v2/site-details/upload-file.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v2/site-details/upload-file.html
@@ -42,7 +42,13 @@
 
                     {% if data['low-complexity-file-type'] == "shapefile" %}
                     <p>Upload a ZIP file containing all the files for your shapefile. Your shapefile must include .shp, .shx, .dbf and .prj files.</p>
+                    {% if data['low-complexity-site-location-changing'] %}
+                    <p>The file you upload must be for a single site.</p>
+                    {% else %}
                     <p>You can include more than one site.</p>
+                    {% endif %}
+                    {% elif data['low-complexity-file-type'] == "kml" and data['low-complexity-site-location-changing'] %}
+                    <p>The file you upload must be for a single site.</p>
                     {% endif %}
 
 


### PR DESCRIPTION
Replace placeholder copy in change-site-location view with an inset showing the site name (or 'Site 1') and clearer guidance about uploading a single site file and that changing the site may affect Marine plan policies. Adjust upload-file view conditionals so shapefile (and KML when changing location) require a single-site file when 'low-complexity-site-location-changing' is set; otherwise allow multiple sites for shapefiles.