### PR TITLE
Require polygon geometries for site uploads

### DIFF
--- a/app/views/versions/multiple-sites-v2/exemption/site-details.html
+++ b/app/views/versions/multiple-sites-v2/exemption/site-details.html
@@ -53,6 +53,8 @@ Site details
 
 		<p>The coordinates must mark the full boundary of every site, including space for any movement or small changes in the activity location.</p>
 
+		<p>Your file must only contain sites drawn as polygons (shapes), not points or lines.</p>
+		
 		<p>If the activity happens outside the marked boundary, it will not be covered by the exemption.</p>
 
 		<div class="govuk-button-group">

--- a/app/views/versions/multiple-sites-v2/exemption/upload-file.html
+++ b/app/views/versions/multiple-sites-v2/exemption/upload-file.html
@@ -42,7 +42,9 @@
                 
                     {% if data['exemption-which-type-of-file-radios'] == "Shapefile" %}
                     <p>Upload a ZIP file containing all the files for your shapefile. Your shapefile must include .shp, .shx, .dbf and .prj files.</p>
-                    <p>You can include more than one site.</p>
+                    {% endif %}
+                    {% if data['exemption-which-type-of-file-radios'] == "Shapefile" or data['exemption-which-type-of-file-radios'] == "KML" %}
+                    <p>You can include more than one site. Your file must only contain sites drawn as polygons (shapes), not points or lines.</p>
                     {% endif %}
                   
 			{% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}

--- a/app/views/versions/multiple-sites-v2/low-complexity-v2/site-details/index.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v2/site-details/index.html
@@ -62,6 +62,8 @@ Site details
 
       <p class="govuk-body">The coordinates must mark the full boundary of every site, including space for any movement or small changes in the activity location.</p>
 
+      <p>Your file must only contain sites drawn as polygons (shapes), not points or lines.</p>
+
         <form action="index-router" method="post" novalidate>
             
             <div class="govuk-button-group">

--- a/app/views/versions/multiple-sites-v2/low-complexity-v2/site-details/upload-file.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v2/site-details/upload-file.html
@@ -43,12 +43,16 @@
                     {% if data['low-complexity-file-type'] == "shapefile" %}
                     <p>Upload a ZIP file containing all the files for your shapefile. Your shapefile must include .shp, .shx, .dbf and .prj files.</p>
                     {% if data['low-complexity-site-location-changing'] %}
-                    <p>The file you upload must be for a single site.</p>
+                    <p>The file you upload must be for a single site. Your file must only contain a site drawn as a polygon (shape), not a point or a line.</p>
                     {% else %}
-                    <p>You can include more than one site.</p>
+                    <p>You can include more than one site. Your file must only contain sites drawn as polygons (shapes), not points or lines.</p>
                     {% endif %}
-                    {% elif data['low-complexity-file-type'] == "kml" and data['low-complexity-site-location-changing'] %}
-                    <p>The file you upload must be for a single site.</p>
+                    {% elif data['low-complexity-file-type'] == "kml" %}
+                    {% if data['low-complexity-site-location-changing'] %}
+                    <p>The file you upload must be for a single site. Your file must only contain a site drawn as a polygon (shape), not a point or a line.</p>
+                    {% else %}
+                    <p>You can include more than one site. Your file must only contain sites drawn as polygons (shapes), not points or lines.</p>
+                    {% endif %}
                     {% endif %}
 
 


### PR DESCRIPTION
Add guidance that uploaded files must contain polygon geometries (shapes) rather than points or lines. Inserted the polygon-only note on the site details page and updated upload-file.html to show the same message for shapefile and KML branches (handling single-site vs multi-site cases). Also refactored the upload-file conditionals to consolidate KML handling and ensure the correct message is displayed.