### PR TITLE
Add retry spinner and timeout-recovery flow

### DIFF
--- a/app/routes/versions/multiple-sites-v2/low-complexity-v3.js
+++ b/app/routes/versions/multiple-sites-v2/low-complexity-v3.js
@@ -98,7 +98,7 @@ module.exports = function (router) {
   });
 
   router.get(`/versions/${version}/${section}/mpp-policies-recovered`, function (req, res) {
-    req.session.data['mpp-load-outcome'] = 'success';
+    req.session.data['mpp-load-outcome'] = 'timeout-recovered';
     delete req.session.data['mpp-policies-loaded'];
     res.redirect(`/versions/${version}/${section}/marine-licence-start-page`);
   });
@@ -106,6 +106,12 @@ module.exports = function (router) {
   router.get(`/versions/${version}/${section}/loading-marine-plan-policies`, function (req, res) {
     res.set('Cache-Control', 'no-store, no-cache, must-revalidate, private');
     res.render(`versions/${version}/${section}/loading-marine-plan-policies`);
+  });
+
+  router.get(`/versions/${version}/${section}/loading-marine-plan-policies-retry`, function (req, res) {
+    res.set('Cache-Control', 'no-store, no-cache, must-revalidate, private');
+    req.session.data['mpp-load-outcome'] = 'success';
+    res.render(`versions/${version}/${section}/loading-marine-plan-policies-retry`);
   });
 
   // Project name page (accessible from task list)

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/loading-marine-plan-policies-retry.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/loading-marine-plan-policies-retry.html
@@ -1,0 +1,65 @@
+{% extends "../layouts/low-complexity-v3.html" %}
+
+{% block header %}
+{% from "govuk/components/header/macro.njk" import govukHeader %}
+{% from "govuk/components/service-navigation/macro.njk" import govukServiceNavigation %}
+{{ govukHeader({
+  homepageUrl: "/",
+  classes: "govuk-header--full-width-border"
+}) }}
+{{ govukServiceNavigation({
+  serviceName: "Get permission for marine work"
+}) }}
+{% endblock %}
+
+{% block pageTitle %}
+Loading your Marine plan policies – GOV.UK
+{% endblock %}
+
+{% block head %}
+{{ super() }}
+{% set mppFolder = 'marine-plan-policies-v2/' if data['mpp-version'] == '2' else 'marine-plan-policies/' %}
+<meta http-equiv="refresh" content="3;url=/versions/multiple-sites-v2/low-complexity-v3/{{ mppFolder }}">
+<style>
+  .spinner {
+    margin: 0 auto 2rem auto;
+    width: 80px;
+    height: 80px;
+    border: 15px solid #b1b4b6;
+    border-top: 15px solid #1d70b8;
+    border-radius: 50%;
+    animation: spin 2s linear infinite;
+  }
+
+  @keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+  }
+</style>
+{% endblock %}
+
+{% block beforeContent %}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full govuk-!-text-align-centre govuk-!-padding-top-2">
+
+      <div class="spinner" role="status" aria-live="polite">
+        <span class="govuk-visually-hidden">Loading your Marine plan policies…</span>
+      </div>
+
+      <h1 class="govuk-heading-l">
+        Loading your Marine plan policies
+      </h1>
+
+      <p class="govuk-body">
+        This usually takes less than 50 seconds
+      </p>
+
+    </div>
+  </div>
+{% endblock %}
+
+{% block footer %}
+{% endblock %}

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/marine-licence-start-page.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/marine-licence-start-page.html
@@ -175,8 +175,8 @@ Marine licence start page
 			<li class="govuk-task-list__item govuk-task-list__item--with-link">
 			  <div class="govuk-task-list__name-and-hint">
 				{% if mppUnlocked %}
-				<a class="govuk-link govuk-task-list__link govuk-link--no-visited-state" href="{{ mppFolder }}" aria-describedby="marine-plan-policies-status">
-					Marine plan policy considerations{% if mppActiveCompletedCount == 0 and mppLoadOutcome != 'timeout' %} ({{ mppDisplayTotal }} to complete){% elif mppActiveComplete %} ({{ mppDisplayTotal }} of {{ mppDisplayTotal }} completed){% elif mppActiveCompletedCount > 0 %} ({{ mppActiveCompletedCount }} of {{ mppDisplayTotal }} completed){% endif %}
+				<a class="govuk-link govuk-task-list__link govuk-link--no-visited-state" href="{% if mppLoadOutcome == 'timeout-recovered' %}loading-marine-plan-policies-retry{% else %}{{ mppFolder }}{% endif %}" aria-describedby="marine-plan-policies-status">
+					Marine plan policy considerations{% if mppActiveCompletedCount == 0 and mppLoadOutcome != 'timeout' and mppLoadOutcome != 'timeout-recovered' %} ({{ mppDisplayTotal }} to complete){% elif mppActiveComplete %} ({{ mppDisplayTotal }} of {{ mppDisplayTotal }} completed){% elif mppActiveCompletedCount > 0 %} ({{ mppActiveCompletedCount }} of {{ mppDisplayTotal }} completed){% endif %}
 				</a>
 				{% else %}
 				<span>Marine plan policy considerations</span>

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/marine-plan-policies-v2/policies-unavailable.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/marine-plan-policies-v2/policies-unavailable.html
@@ -18,9 +18,7 @@ Marine plan policies - {{ data['headerNameExemption'] }}
 		<span class="govuk-caption-l">{{ data['low-complexity-project-name-text-input'] }}</span>
 		<h1 class="govuk-heading-l">Marine plan policies</h1>
 
-		<p class="govuk-body">Marine plan policies are taking longer than expected to load. Come back and try again later.</p>
-
-		<p class="govuk-body">If they are still not loading contact <a href="mailto:marine.consents@marinemanagement.org.uk" class="govuk-link">marine.consents@marinemanagement.org.uk</a>.</p>
+		<p class="govuk-body">Marine plan policies are taking longer than expected to load. <a href="" class="govuk-link">Refresh the page</a> to check if they are ready or come back and try again later.</p>
 	</div>
 </div>
 {% endblock %}

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/marine-plan-policies/policies-unavailable.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/marine-plan-policies/policies-unavailable.html
@@ -18,9 +18,8 @@ Marine plan policies - {{ data['headerNameExemption'] }}
 		<span class="govuk-caption-l">{{ data['low-complexity-project-name-text-input'] }}</span>
 		<h1 class="govuk-heading-l">Marine plan policies</h1>
 
-		<p class="govuk-body">Marine plan policies are taking longer than expected to load. Come back and try again later.</p>
+		<p class="govuk-body">Marine plan policies are taking longer than expected to load. <a href="" class="govuk-link">Refresh the page</a> to check if they are ready or come back and try again later.</p>
 
-		<p class="govuk-body">If they are still not loading contact <a href="mailto:marine.consents@marinemanagement.org.uk" class="govuk-link">marine.consents@marinemanagement.org.uk</a>.</p>
 	</div>
 </div>
 {% endblock %}

--- a/docs/mpp-calculation-alert-mini-journey.md
+++ b/docs/mpp-calculation-alert-mini-journey.md
@@ -19,7 +19,7 @@ Both links are under **Marine plan policies loading journeys** on the index page
 
 **Quicker time:** MPP link shows `(37 to complete)` → full policy index with 37 policies.
 
-**Slower time:** MPP link shows no count → unavailable error page. Click **Back to your project task list** → policies have now loaded; link shows `(37 to complete)` and index is normal.
+**Slower time:** MPP link shows no count → unavailable error page. Click **Back to your project task list** → link still shows no count. Click MPP task → 3-second spinner → index is normal (all 37 policies).
 
 ### Organic flow
 
@@ -41,19 +41,21 @@ The prototype kit stores the query param in session. When the user selects **Yes
 | Variable | Values | Purpose |
 |----------|--------|---------|
 | `mpp-load` | `success` / `timeout` | Set from index URL; consumed on review POST |
-| `mpp-load-outcome` | `success` / `timeout` | Persisted after spinner; drives task list link text and MPP index |
+| `mpp-load-outcome` | `success` / `timeout` / `timeout-recovered` | Persisted after spinner; drives task list link text, href, and MPP index |
 | `mpp-policies-loaded=true` | query on task list (legacy) | Redirects to task list with outcome set to `success` |
-| `/mpp-policies-recovered` | back link from unavailable page | Sets outcome to `success`, redirects to task list |
+| `/mpp-policies-recovered` | back link from unavailable page | Sets outcome to `timeout-recovered`, redirects to task list |
+| `/loading-marine-plan-policies-retry` | MPP task link when `timeout-recovered` | Sets outcome to `success`, shows 3s spinner, redirects to MPP index |
 
 ## Files
 
 | File | Role |
 |------|------|
 | `app/views/index.html` | Details component with Quicker time / Slower time links |
-| `app/views/.../loading-marine-plan-policies.html` | Spinner page |
+| `app/views/.../loading-marine-plan-policies.html` | Spinner page (10s → task list) |
+| `app/views/.../loading-marine-plan-policies-retry.html` | Retry spinner page (3s → MPP index) |
 | `app/views/.../marine-plan-policies/policies-unavailable.html` | Delayed load error (v1 + v2) |
-| `app/views/.../marine-licence-start-page.html` | Task list; conditional MPP link text |
-| `app/routes/.../low-complexity-v3.js` | Spinner route; recovery on task list GET |
+| `app/views/.../marine-licence-start-page.html` | Task list; conditional MPP link text and href |
+| `app/routes/.../low-complexity-v3.js` | Spinner routes; recovery + retry routes |
 | `app/routes/.../low-complexity-v3-site-locations.js` | Review POST → spinner or task list |
 | `app/routes/.../low-complexity-v3-manual-entry.js` | Same redirect logic for manual entry |
 | `app/routes/.../low-complexity-v3-marine-plan-policies*.js` | Render unavailable page when outcome is `timeout` |


### PR DESCRIPTION
Introduce a short retry spinner and recovery state for Marine Plan Policies (MPP) when loading times out. Changes include:

- Set mpp-load-outcome to `timeout-recovered` when coming back from the unavailable page so the task list can show a retry flow.
- Add a new route `/loading-marine-plan-policies-retry` that sets the outcome to `success`, disables caching, and renders a 3s retry spinner page which then redirects to the MPP index.
- Update the task list link logic to point to the retry spinner when `mpp-load-outcome` is `timeout-recovered`, and adjust the link text conditions to account for the new state.
- Replace the unavailable pages' static messaging with a Refresh link to encourage retrying.
- Update documentation to describe the new `timeout-recovered` state, the retry spinner, and the updated file responsibilities.

This change provides a smoother recovery path for users when MPPs fail to load initially, by offering a short retry spinner that then displays the policy index once available.