### PR TITLE
Add IAT timeout page and route

### DIFF
--- a/app/iat-lcml/routes.js
+++ b/app/iat-lcml/routes.js
@@ -290,6 +290,10 @@ module.exports = function (router) {
     res.render("iat-lcml/start");
   });
 
+  router.get(`${base}/timeout`, (req, res) => {
+    res.render("iat-lcml/timeout");
+  });
+
   // =====================================================================
   // Phase 1: /activity-type — checkboxes
   // =====================================================================

--- a/app/views/iat-lcml/timeout.html
+++ b/app/views/iat-lcml/timeout.html
@@ -1,0 +1,22 @@
+{% extends "layouts/main.html" %}
+
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block pageTitle %}Your session has timed out{% endblock %}
+{% block beforeContent %}
+
+{% endblock %}
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">Your session has timed out</h1>
+
+      <p class="govuk-body">Any answers will be saved for 24 hours. To resume, you need to go back to the start.</p>
+
+      {{ govukButton({
+        text: "Return to start",
+        href: "/versions/multiple-sites-v2/iat-lcml"
+      }) }}
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -290,6 +290,8 @@ html: ''
     <ul class="govuk-list govuk-list--spaced">
       <li><a href="versions/multiple-sites-v2/iat-lcml" 
       class="govuk-link--no-visited-state">Start checker/IAT</a></li>
+      <li><a href="versions/multiple-sites-v2/iat-lcml/timeout"
+      class="govuk-link--no-visited-state">IAT timeout</a></li>
     </ul>
 
 


### PR DESCRIPTION
Introduce a timeout page for the iat-lcml flow: add app/views/iat-lcml/timeout.html to inform users their session has timed out (answers saved for 24 hours) and provide a button to return to the start. Register a GET /timeout route in app/iat-lcml/routes.js to render the view, and add a link to the new timeout page in app/views/index.html navigation.