### PR TITLE
Add self-service IAT data file

### DIFF
--- a/app/data/_iat.json
+++ b/app/data/_iat.json
@@ -1,0 +1,9687 @@
+{
+  "name": "self-service",
+  "navBarLinkText": "Marine licence interactive assistance tool",
+  "firstQuestionRoute": "/sea",
+  "documentPreambleText": "The purpose of the MMO marine licence requirement checker tool is to assist prospective applicants to determine whether a marine licence is be required in order to carry out an activity. The outcome produced is based on the answers provided. Prospective applicants are responsible for ensuring that the information supplied is correct. Providing false or misleading information may result in enforcement action being taken.",
+  "sections": [
+    {
+      "id": "doINeedAMarineLicence",
+      "text": "Jurisdiction check"
+    },
+    {
+      "id": "doINeedAMarineLicenceConstruction",
+      "text": "Construction activity"
+    },
+    {
+      "id": "doINeedAMarineLicenceDeposit",
+      "text": "Deposit activity"
+    },
+    {
+      "id": "doINeedAMarineLicenceRemoval",
+      "text": "Removal activity"
+    },
+    {
+      "id": "doINeedAMarineLicenceDredging",
+      "text": "Dredging activity"
+    },
+    {
+      "id": "doINeedAMarineLicenceIncineration",
+      "text": "Incineration activity"
+    },
+    {
+      "id": "doINeedAMarineLicenceScuttling",
+      "text": "Scuttling activity"
+    },
+    {
+      "id": "doINeedAMarineLicenceExplosives",
+      "text": "Explosives activity"
+    },
+    {
+      "id": "elsewhereActivity",
+      "text": "Jurisdiction check - Elsewhere in the world"
+    },
+    {
+      "id": "elsewhereDeposit",
+      "text": "Jurisdiction check -  Elsewhere in the world - Deposit activity"
+    },
+    {
+      "id": "elsewhereScuttling",
+      "text": "Jurisdiction check  - Elsewhere in the world - Scuttling activity"
+    },
+    {
+      "id": "elsewhereIncineration",
+      "text": "Jurisdiction check  - Elsewhere in the world - Incineration activity "
+    },
+    {
+      "id": "construction",
+      "text": "Exemption check - Construction activity"
+    },
+        {
+      "id": "constructionMaintenance",
+      "text": "Exemption check - Construction activity - Maintenance"
+    },
+    {
+      "id": "deposit",
+      "text": "Exemption check - Deposit activity"
+    },
+    {
+      "id": "removal",
+      "text": "Exemption check - Removal activity"
+    },
+    {
+      "id": "dredging",
+      "text": "Exemption check - Dredging activity"
+    },
+    {
+      "id": "incineration",
+      "text": "Incineration"
+    },
+    {
+      "id": "jurisdiction",
+      "text": "Jurisdiction"
+    },
+    {
+      "id": "activitiesOutsideUkWaters",
+      "text": "Activities proposed outside of English (inshore and offshore) and Welsh and Northern Irish Offshore areas"
+    },
+    {
+      "id": "activityType",
+      "text": "Self-service check - Activity type"
+    },
+    {
+      "id": "subactivityType",
+      "text": "Self-service check - Sub-activities"
+    },
+    {
+      "id": "scaffoldingAccesstowers",
+      "text": "Self-service check - Scaffolding and access towers"
+    },
+    {
+      "id": "navigationalRisk",
+      "text": "Self-service check - Navigational risk"
+    },
+    {
+      "id": "harbourAuthority",
+      "text": "Self-service check - Harbour authority jurisdiction"
+    },
+    {
+      "id": "mcaAndOrTh",
+      "text": "Self-service check - Scaffolding or access towers"
+    },
+    {
+      "id": "lightingConfiguration",
+      "text": "Self-service check- Lighting and configuration requirments"
+    },
+    {
+      "id": "durationOfWorks",
+      "text": "Self-service check - Duration of works"
+    },
+    {
+      "id": "publicRegister",
+      "text": "Self-service check - Public register"
+    },
+    {
+      "id": "largerProject",
+      "text": "Self-service check - Environmental impact assessment (EIA)"
+    },
+    {
+      "id": "eiaDirective",
+      "text": "Self-service check - Environmental impact assessment (EIA)"
+    },
+    {
+      "id": "groundInvestigation",
+      "text": "Self-service check - Environmental impact assessment (EIA)"
+    },
+    {
+      "id": "screeningOpinion",
+      "text": "Self-service check - Environmental impact assessment (EIA)"
+    },
+    {
+      "id": "activityLocation",
+      "text": "Self-service check - Activity location"
+    },
+    {
+      "id": "multipleLocations",
+      "text": "Self-service check - Activity location"
+    },
+    {
+      "id": "siteSensitivities",
+      "text": "Self-service check - Site sensitivities"
+    },
+    {
+      "id": "defence",
+      "text": "Self-service check - Defence"
+    },
+    {
+      "id": "modActivity",
+      "text": "Self-service check - Defence"
+    },
+    {
+      "id": "modPermission",
+      "text": "Self-service check - Defence"
+    },
+    {
+      "id": "otherUsesOfTheSea",
+      "text": "Self-service check - Other uses of the sea"
+    },
+    {
+      "id": "protectionOfHeritage",
+      "text": "Self-service check - Heritage"
+    },
+    {
+      "id": "heritageDesignations",
+      "text": "Self-service check - Heritage"
+    },
+    {
+      "id": "archaeologicalHeritageHistoricAssets",
+      "text": "Self-service check - Heritage"
+    },
+    {
+      "id": "historicEngland",
+      "text": "Self-service check - Heritage"
+    },
+    {
+      "id": "marineProtectedArea200",
+      "text": "Self-service check - Marine protected areas"
+    },
+    {
+      "id": "marineProtectedAreaActivity",
+      "text": "Self-service check - Marine protected areas"
+    },
+    {
+      "id": "vehicularAccess",
+      "text": "Self-service check - Marine protected areas"
+    },
+    {
+      "id": "naturalEngland",
+      "text": "Self-service check - Marine protected areas"
+    }
+  ],
+  "outcomeTypes": [
+    {
+      "id": "WO_STANDARD_TRACK_MLA",
+      "heading": "Apply for a standard marine licence",
+      "text": "Based on the information provided the activity requires a marine licence from the MMO but the activity is not suitable for self-service marine licensing.",
+      "module": "MMO_APP2_CONTROL",
+      "entryTheme": "new"
+    },
+    {
+      "id": "WO_STANDARD_TRACK_MLA_OTHER_REMOVALS",
+      "heading": "Apply for a standard marine licence",
+      "text": "You selected 'Other removals' which indicates that your proposed activity includes an activity not specified in the self-service sub-activity list provided. Only activities specified are suitable for self-service marine licensing. <p> Based on the information provided the activity requires a marine licence from the MMO but the activity is not suitable for self-service marine licensing.",
+      "module": "MMO_APP2_CONTROL",
+      "entryTheme": "new"
+    },
+    {
+      "id": "WO_STANDARD_TRACK_MLA_OTHER_CLEARANCE_DREDGING",
+      "heading": "Apply for a standard marine licence",
+     "text": "You selected 'Other clearance dredging' which indicates that your proposed activity includes an activity not specified in the self-service sub-activity list provided. Only activities specified are suitable for self-service marine licensing. <p> Based on the information provided the activity requires a marine licence from the MMO but the activity is not suitable for self-service marine licensing.",
+      "module": "MMO_APP2_CONTROL",
+      "entryTheme": "new"
+    },
+    {
+      "id": "WO_STANDARD_TRACK_MLA_OTHER_BEACH_MAINTENANCE",
+      "heading": "Apply for a standard marine licence",
+      "text": "You selected 'Other beach maintenance' which indicates that your proposed activity includes an activity not specified in the self-service sub-activity list provided. Only activities specified are suitable for self-service marine licensing. <p> Based on the information provided the activity requires a marine licence from the MMO but the activity is not suitable for self-service marine licensing.",
+      "module": "MMO_APP2_CONTROL",
+      "entryTheme": "new"
+    },
+    {
+      "id": "WO_STANDARD_TRACK_MLA_OTHER_DEPOSITS",
+      "heading": "Apply for a standard marine licence",
+      "text": "You selected 'Other deposits' which indicates that your proposed activity includes an activity not specified in the self-service sub-activity list provided. Only activities specified are suitable for self-service marine licensing. <p> Based on the information provided the activity requires a marine licence from the MMO but the activity is not suitable for self-service marine licensing.",
+      "module": "MMO_APP2_CONTROL",
+      "entryTheme": "new"
+    },
+    {
+      "id": "WO_STANDARD_TRACK_MLA_OTHER_ACTIVITY",
+      "heading": "Apply for a standard marine licence",
+      "text": " You selected 'Other' which indicates that your proposed activity includes an activity type not specified. Only activity types specified are suitable for self-service marine licensing. <p> Based on the information provided the activity requires a marine licence from the MMO but the activity is not suitable for self-service marine licensing.",
+      "module": "MMO_APP2_CONTROL",
+      "entryTheme": "new"
+    },
+    {
+      "id": "WO_STANDARD_TRACK_MLA_OTHER_MAINTENANCE",
+      "heading": "Apply for a standard marine licence",
+      "text": " You selected 'Other maintenance' which indicates that your proposed activity includes an activity not specified in the self-service sub-activity list provided. Only activities specified are suitable for self-service marine licensing. <p> Based on the information provided the activity requires a marine licence from the MMO but the activity is not suitable for self-service marine licensing.",
+      "module": "MMO_APP2_CONTROL",
+      "entryTheme": "new"
+    },
+    {
+      "id": "WO_FAST_TRACK_MLA",
+      "heading": "Apply for a self-service marine licence",
+      "text": "Based on the information provided the activity requires a marine licence and is suitable for self-service marine licensing.",
+      "module": "MMO_APP2_CONTROL",
+      "entryTheme": "new",
+      "params": [
+        {
+          "name": "FAST_TRACK",
+          "value": "true"
+        }
+      ]
+    },
+    {
+      "id": "WO_INTERACTIVE_MAP_STAGE1",
+      "heading": "Open MMO self-service GIS tool",
+      "text": "To find out if the activity is in a place that may need a licence from the Marine Management Organisation, use our interactive map.",
+      "link": "http://defra.maps.arcgis.com/apps/webappviewer/index.html?id=6d5a7b3a1f07440f947d1e31bfaa7d38"
+    },
+    {
+      "id": "WO_INTERACTIVE_MAP",
+      "heading": "Open MMO self-service GIS tool",
+      "text": "To find out if the activity is in a place that may need a licence from the Marine Management Organisation, use our interactive map. If the activity is inside or next to the blue lines then it may need a marine licence.",
+      "link": "https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c"
+    },
+    {
+      "id": "WO_ENQUIRY",
+      "heading": "Submit an enquiry",
+      "text": "<p>Based on the information provided it has not been possible to establish whether or not the proposed activity is one which might require environmental impact assessment. Self-service marine licensing is intended to enable small scale low risk activities to be regulated in a proportionate manner. Activities forming part of active larger projects which require environmental impact assessment will not be suitable for self-service.</p><p>Please contact MMO to enquire about the activity.</p>",
+      "module": "MMO_ADVICE_CONTROL",
+      "entryTheme": "new",
+      "params": [
+        {
+          "name": "ADV_TYPE",
+          "value": "ENQ"
+        }
+      ]
+    },
+    {
+      "id": "WO_EIA",
+      "heading": "Request an environmental impact assessment screening opinion",
+      "text": "<p>Based on the information provided it has not been possible to establish whether or not the proposed activity is one which might require environmental impact assessment. Self-service marine licensing is intended to enable small scale low risk activities to be regulated in a proportionate manner. Activities forming part of active larger projects which require environmental impact assessment will not be suitable for self-service.</p>",
+      "module": "MMO_ADVICE_CONTROL",
+      "entryTheme": "new",
+      "params": [
+        {
+          "name": "ADV_TYPE",
+          "value": "EIA"
+        }
+      ]
+    },
+    {
+      "id": "WO_NOT_LICENSABLE",
+      "text": "Based on the information provided the activity does not require a marine licence from the MMO."
+    },
+    {
+      "id": "WO_FAST_TRACK_MLA_BAS_BLOCK",
+      "text": "Based on the information provided the activity requires a marine licence from the MMO and qualifies for self-service marine licensing but a licence cannot be issued until the ‘relevant documentation’ is obtained."
+    },
+    {
+      "id": "WO_DOWNLOAD_TH_MARKERS_AGREED_METHOD_TEMPLATE",
+      "heading": "Download TH (Markers) self-service marine licensing agreed method template",
+      "text": "<p>Based on the information provided the activity requires a marine licence from the MMO but the activity is not suitable for self-service marine licensing without a method agreed with Trinity House.</p> <p>Details of the proposed work and a methodology should be sent to Trinity House at navigation.directorate@thls.org. Further contact details can be found at https://www.trinityhouse.co.uk/contact.</p>",
+      "link": "https://marinelicensing.marinemanagement.org.uk/docs/HA_TH_Self_Service_Agreed_Method_Template.docx"
+    },
+    {
+      "id": "WO_DOWNLOAD_HA_MARKERS_AGREED_METHOD_TEMPLATE",
+      "heading": "Download HA (Markers) self-service marine licensing agreed method template",
+      "text": "<p>Based on the information provided the activity requires a marine licence from the MMO but the activity is not suitable for self-service marine licensing without requirements agreed with the harbour authority.</p><p>Contact details for the relevant harbour authority can be found at www.ports.org.uk.</p>",
+      "link": "https://marinelicensing.marinemanagement.org.uk/docs/HA_TH_Self_Service_Agreed_Method_Template.docx"
+    },
+    {
+      "id": "WO_DOWNLOAD_MCA_TH_AGREED_METHOD_TEMPLATE",
+      "heading": "Download MCA/TH self-service marine licensing agreed method template",
+      "text": "<p>Based on the information provided the activity requires a marine licence from the MMO but the activity is not suitable for self-service marine licensing without a method agreed with the Maritime and Coastguard Agency and/or Trinity House.</p><p>Details of the proposed work and a methodology should be sent to the Maritime &amp; Coastguard Agency at navigationsafety@mcga.gov.uk, and also to Trinity House at navigation.directorate@thls.org. Further contact details can be found at https://www.trinityhouse.co.uk/contact.</p>",
+      "link": "https://marinelicensing.marinemanagement.org.uk/docs/HA_MCA_TH_Self_Service_Agreed_Method_Template.docx"
+    },
+    {
+      "id": "WO_DOWNLOAD_HA_AGREED_METHOD_TEMPLATE",
+      "heading": "Download HA self-service marine licensing agreed method template",
+      "text": "<p>Based on the information provided the activity requires a marine licence from the MMO but the activity is not suitable for self-service marine licensing without a method agreed with the harbour authority.</p> <p>Contact details for the relevant harbour authority can be found at www.ports.org.uk.</p>",
+      "link": "https://marinelicensing.marinemanagement.org.uk/docs/HA_MCA_TH_Self_Service_Agreed_Method_Template.docx"
+    },
+    {
+      "id": "WO_DOWNLOAD_HE_AGREED_METHOD_TEMPLATE",
+      "heading": "Download HE self-service marine licensing agreed method template",
+      "text": "<p>Based on the information provided the activity requires a marine licence from the MMO but the activity is not suitable for self-service marine licensing without a valid consent from Historic England or an agreed method.</p> <p>Details of the proposed work and a methodology should be sent to Historic England at MPUconsultation@HistoricEngland.org.uk</p>",
+      "link": "https://marinelicensing.marinemanagement.org.uk/docs/HE_Self_Service_Agreed_Method_Template.docx"
+    },
+    {
+      "id": "WO_DOWNLOAD_NE_AGREED_METHOD_TEMPLATE",
+      "heading": "Download NE self-service marine licensing agreed method template",
+      "text": "<p>Based on the information provided the activity requires a marine licence from the MMO but the activity is not suitable for self-service marine licensing without a method agreed with Natural England.</p> <p>Details of the proposed work and a methodology should be sent to Natural England at consultations@naturalengland.org.uk</p>",
+      "link": "https://marinelicensing.marinemanagement.org.uk/docs/NE_Self_Service_Agreed_Method_Template.docx"
+    },
+    {
+      "id": "WO_MOD_PERMISSION",
+      "text": "<p>Based on the information provided the activity requires a marine licence from the MMO but the activity is not suitable for self-service marine licensing without permission from the MOD.</p> <p>For queries regarding permissions to carry out activities within military/defence areas, please contact the MOD at:<ul><li>Jon Wilson (DIO estates safeguarding)</li><li>DIOSEE-EPSSG3@mod.uk</li></ul></p>"
+    },
+    {
+      "id": "WO_EXE_NOT_LICENSABLE",
+      "text": "Based on the information provided a marine licence is not required for the activity."
+    },
+    {
+      "id": "WO_EXE_NOT_LICENSABLE_SEA",
+      "text": "You have indicated that the activity will not take place in the ‘Sea’, over the ‘Sea’, or on or under the 'Seabed'. <p>Based on the information provided a marine licence is not required from the MMO. <p>The definition of ‘Sea’ under the Marine and Coastal Access Act 2009 is broad and includes any area which is submerged at Mean High Water Springs (MHWS) and the waters of every estuary, river or channel where the tide flows at MHWS tide up to the Normal Tidal Limit. Even waters in areas which are closed permanently or intermittently by a lock or other artificial means against the regular action of the tide are included, where seawater flows into or out from the area, either continuously or from time to time.<p>if you have cause to doubt whether the information you provided is correct you are advised to review the guidance provided and re-run the check where appropriate."
+    },
+    {
+      "id": "WO_EXE_NOT_LICENSABLE_ELSEWHERE_ACTIVITY",
+      "text": "You have indicated that the activity will take place outside of the UK marine area and does not involve the deposit of a substance or object, the sinking of a vessel or floating containers or the incineration of a substance or object. <p>Based on the information provided a marine licence is not required from the MMO.<p>if you have cause to doubt whether the information you provided is correct you are advised to review the guidance provided and re-run the check where appropriate."
+    },
+    {
+      "id": "WO_EXE_NOT_LICENSABLE_DEPOSIT_METHOD",
+      "text": "You have indicated that the activity will not involve the deposit of a substance or object from a vehicle or vessel, aircraft, marine structure, floating container, or from a structure on land, constructed or adapted wholly or mainly for the purposes of depositing solids in the Sea. <p>Based on the information provided a marine licence is not required from the MMO.<p>if you have cause to doubt whether the information you provided is correct you are advised to review the guidance provided and re-run the check where appropriate."
+    },
+    {
+      "id": "WO_EXE_NOT_LICENSABLE_REMOVAL_METHOD",
+      "text": "You have indicated that the activity will not involve the removal of a substance or object using a vehicle or vessel, aircraft, marine structure, floating container or using a structure on land, constructed or adapted wholly or mainly for the purposes of depositing solids in the Sea. <p>Based on the information provided a marine licence is not required from the MMO.<p>if you have cause to doubt whether the information you provided is correct you are advised to review the guidance provided and re-run the check where appropriate."
+    },
+    {
+      "id":  "WO_EXE_NOT_LICENSABLE_REMOVAL_SEABED",
+      "text": "You have indicated that the activity will not involve the removal of a substance or object from the 'Seabed'. <p>Based on the information provided a marine licence is not required from the MMO.<p>The meaning of 'Seabed' is broad, it includes the ground under the 'Sea' and anything resting on it such as a wreck. It includes the intertidal area of the sea or any river at such time as it is exposed temporarily at low tide.<p>The definition of ‘Sea’ under the Marine and Coastal Access Act 2009 is also broad and includes any area which is submerged at Mean High Water Springs (MHWS) and the waters of every estuary, river or channel where the tide flows at MHWS tide up to the Normal Tidal Limit. Even waters in areas which are closed permanently or intermittently by a lock or other artificial means against the regular action of the tide are included, where seawater flows into or out from the area, either continuously or from time to time.<p>if you have cause to doubt whether the information you provided is correct you are advised to review the guidance provided and re-run the check where appropriate. " 
+    },
+   {
+      "id":  "WO_EXE_NOT_LICENSABLE_INCINERATION_ON",
+      "text": "You have indicated that the activity will not take place on a vehicle or vessel, a marine structure, floating container. <p>Based on the information provided a marine licence is not required from the MMO.<p>if you have cause to doubt whether the information you provided is correct you are advised to review the guidance provided and re-run the check where appropriate."
+    },
+    {
+      "id": "WO_EXE_NOT_LICENSABLE_DEPOSIT_METHOD_ELSEWHERE",
+     "text": "You have indicated that the activity will not involve the deposit of a substance or object from a British vessel, British aircraft, British marine structure or floating container controlled by any of the aforementioned. You also indicated that the substance or object to be deposited was not or will not be loaded anywhere in the United kingdom (except Scotland) or in the UK marine licensing area.  <p>Based on the information provided a marine licence is not required from the MMO.<p>if you have cause to doubt whether the information you provided is correct you are advised to review the guidance provided and re-run the check where appropriate."
+    },
+    {
+      "id": "WO_EXE_NOT_LICENSABLE_INCINERATION_METHOD_ELSEWHERE",
+     "text": "You have indicated that the activity will not take place on a British vessel, British marine structure or floating container controlled by a British vessel, British aircraft or British marine structure. You also indicated that the substance or object to be incinerated was not or will not be loaded anywhere in the United kingdom (except Scotland) or in the UK marine licensing area.  <p>Based on the information provided a marine licence is not required from the MMO.<p>if you have cause to doubt whether the information you provided is correct you are advised to review the guidance provided and re-run the check where appropriate."
+    },
+   {
+      "id": "WO_EXE_NOT_LICENSABLE_SCUTTLING_METHOD_ELSEWHERE",
+      "text": "You have indicated that the activity will not be controlled from a British vessel, British aircraft, British marine structure and will the will the vessel or container in question  will not be towed or propelled from either, the United Kingdom (Except Scotland) or the Uk marine licensing area (other than where towing or propelling began outside that area).  <p>Based on the information provided a marine licence is not required from the MMO.<p>if you have cause to doubt whether the information you provided is correct you are advised to review the guidance provided and re-run the check where appropriate."
+    },
+    {
+      "id": "WO_EXE_NOT_LICENSABLE_CABLES",
+      "text": "You indicated that the activity involved the laying of an 'exempt' cable. <p>Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in Section 81 of the Marine and Coastal Access Act 2009 and a marine licence is therefore not required. <p>This exemption does not require any action from you before the activity is carried out. <p>Please note that a marine licence is required for the deposit of any associated cable protection."
+    },
+    {
+      "id": "WO_EXE_NOT_LICENSABLE_CABLES_MAINTENANCE",
+      "text": "You indicated that the activity involved the maintenance of an 'exempt' cable. <p>Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in Section 81 of the Marine and Coastal Access Act 2009 and a marine licence is therefore not required. <p>This exemption does not require any action from you before the activity is carried out. <p>Please note that a marine licence is required for the deposit of any associated cable protection."
+    },
+    {
+      "id": "WO_EXE_NOT_LICENSABLE_PART_CABLES",
+      "heading": "Apply for a marine licence",
+      "text": "You indicated that the activity involved the laying of an 'exempt' cable, part of which would be located within 12NM and part outside of 12NM of the UK. <p>Based on the information provided the activity requires a marine licence for the element to be located within 12NM. The element beyond 12NM meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/ukpga/2009/23/section/81\"> S81 of the Marine and Coastal Access Act 2009 </a> and a marine licence is therefore not required for that part. <p>Please note that a marine licence is required for the deposit of any associated cable protection.",
+      "module": "MMO_APP2_CONTROL",
+      "entryTheme": "new"
+    },
+    {
+      "id": "WO_EXE_NOT_LICENSABLE_PART_CABLES_MAINTENANCE_BOTH",
+      "text": "You indicated that the activity involved the maintenance of an 'exempt' cable, part of which is located within 12NM and part outside of 12NM of the UK. <p>Based on the information provided the activity meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/ukpga/2009/23/section/81\"> S81 of the Marine and Coastal Access Act 2009 </a> and a marine licence is therefore not required. <p>Please note that a marine licence is required for the deposit of any associated cable protection."
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_7",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/7\"> Article 7 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption does not require any action from you before the activity is carried out."
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_8",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/8\"> Article 8 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption does not require any action from you before the activity is carried out."
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_9",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/9\"> Article 9 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption does not require any action from you before the activity is carried out."
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_10",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/10\"> Article 10 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption does not require any action from you before the activity is carried out."
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_11",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/11\"> Article 11 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption does not require any action from you before the activity is carried out."
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_12",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/12\"> Article 12 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption does not require any action from you before the activity is carried out."
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_13",
+      "heading": "Fill out an exemption notification",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/13\"> Article 13 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption is subject to the requirement that notification of the intention to carry out the activity is given to the MMO prior to the commencement of the activity.",
+      "module": "MMO_ADVICE_CONTROL",
+      "entryTheme": "new",
+      "params": [
+        {
+          "name": "ADV_TYPE",
+          "value": "EXE"
+        },
+        {
+          "name": "ARTICLE",
+          "value": "13"
+        }
+      ]
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_14",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/14\"> Article 14 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption does not require any action from you before the activity is carried out."
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_15",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/15\"> Article 15 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption is subject to the requirement that notification of the intention to carry out the activity is given to the MMO and that approval is granted prior to the commencement of the activity.<br/><br/><strong>Administrative action(s) required</strong><br/>Approval to carry out the activity must be granted by the MMO.<br/><br/>Notifications and approvals under this category are handled outside the standard exemption process.<br/><br/>Please use this <a target=\"_blank\" href=\"https://www.gov.uk/guidance/how-we-respond-to-marine-pollution-incidents#oil-spill-treatment-products\">guidance</a> if you need to use an oil or chemical treatment product or report a marine pollution incident."
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_16",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/16\"> Article 16 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption does not require any action from you before the activity is carried out."
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_17",
+      "heading": "Fill out an exemption notification",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/17\"> Article 17 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption is subject to the requirement that notification of the intention to carry out the activity is given to the MMO prior to the commencement of the activity. <p> Kindly please click through this link to join us for the new private beta service we are developing <a target=\"_blank\" href=\"https://marine-licensing-prototype-5b7b33ca29e1.herokuapp.com/versions/2025-01-27/exemption/what-is-your-name\"> Private beta link </a>",
+      "module": "MMO_ADVICE_CONTROL",
+      "entryTheme": "new",
+      "params": [
+        {
+          "name": "ADV_TYPE",
+          "value": "EXE"
+        },
+        {
+          "name": "ARTICLE",
+          "value": "17"
+        }
+      ]
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_17A",
+      "heading": "Fill out an exemption notification",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/17A\"> Article 17A of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption is subject to the requirement that notification of the intention to carry out the activity is given to the MMO prior to the commencement of the activity.",
+      "module": "MMO_ADVICE_CONTROL",
+      "entryTheme": "new",
+      "params": [
+        {
+          "name": "ADV_TYPE",
+          "value": "EXE"
+        },
+        {
+          "name": "ARTICLE",
+          "value": "17A"
+        }
+      ]
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_17B",
+      "heading": "Fill out an exemption notification",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/17B\"> Article 17B of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption is subject to the requirement that notification of the intention to carry out the activity is given to the MMO prior to the commencement of the activity.",
+      "module": "MMO_ADVICE_CONTROL",
+      "entryTheme": "new",
+      "params": [
+        {
+          "name": "ADV_TYPE",
+          "value": "EXE"
+        },
+        {
+          "name": "ARTICLE",
+          "value": "17B"
+        }
+      ]
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_18",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/18\"> Article 18 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption does not require any action from you before the activity is carried out."
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_18A",
+      "heading": "Fill out an exemption notification",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/18A\"> Article 18A of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption is subject to the requirement that notification of the intention to carry out the activity is given to the MMO prior to the commencement of the activity.",
+      "module": "MMO_ADVICE_CONTROL",
+      "entryTheme": "new",
+      "params": [
+        {
+          "name": "ADV_TYPE",
+          "value": "EXE"
+        },
+        {
+          "name": "ARTICLE",
+          "value": "18A"
+        }
+      ]
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_19",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/19\"> Article 19 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption does not require any action from you before the activity is carried out."
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_20",
+      "heading": "Fill out an exemption notification",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/20\"> Article 20 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption is subject to the requirement that notification of the carrying on of the emergency works is given to the MMO within 168 hours of the commencement of the activity. The notification must set out the location of, the circumstances giving rise to and the nature of the emergency works",
+      "module": "MMO_ADVICE_CONTROL",
+      "entryTheme": "new",
+      "params": [
+        {
+          "name": "ADV_TYPE",
+          "value": "EXE"
+        },
+        {
+          "name": "ARTICLE",
+          "value": "20"
+        },
+        {
+          "name": "EMERGENCY",
+          "value": "true"
+        }
+      ]
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_21",
+      "heading": "Fill out an exemption notification",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/21\"> Article 21 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption is subject to the requirement that notification of the intention to carry out the activity is given to the MMO prior to the commencement of the activity.",
+      "module": "MMO_ADVICE_CONTROL",
+      "entryTheme": "new",
+      "params": [
+        {
+          "name": "ADV_TYPE",
+          "value": "EXE"
+        },
+        {
+          "name": "ARTICLE",
+          "value": "21"
+        }
+      ]
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_21_NO_NOTIFICATION",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/21\"> Article 21 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption does not require any action from you before the activity is carried out."
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_21A",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/21A\"> Article 21A of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption does not require any action from you before the activity is carried out. <p>NOTE:The MMO has produced some best practice guidance for divers who wish to remove abandoned, lost or discarded fishing gear (ALDFG). You are advised to consider the <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/recovery-of-abandoned-lost-and-discarded-fishing-gear\"> guidance </a> before carrying out your activity."
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_22",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/22\"> Article 22 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption does not require any action from you before the activity is carried out."
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_23",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/23\"> Article 23 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption does not require any action from you before the activity is carried out."
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_24",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/24\"> Article 24 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption does not require any action from you before the activity is carried out."
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_24A",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/24A\"> Article 24A of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption does not require any action from you before the activity is carried out."
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_25",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/25\"> Article 25 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption does not require any action from you before the activity is carried out."
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_25_NOTIFICATION",
+      "heading": "Fill out an exemption notification",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/25\"> Article 25 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption is subject to the requirement that notification of the intention to carry out the activity is given to the MMO prior to the commencement of the activity.",
+      "module": "MMO_ADVICE_CONTROL",
+      "entryTheme": "new",
+      "params": [
+        {
+          "name": "ADV_TYPE",
+          "value": "EXE"
+        },
+        {
+          "name": "ARTICLE",
+          "value": "25"
+        }
+      ]
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_25A",
+      "heading": "Fill out an exemption notification",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/25A\"> Article 25A of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption is subject to the requirement that notification of the intention to carry out the activity is given to the MMO prior to the commencement of the activity.",
+      "module": "MMO_ADVICE_CONTROL",
+      "entryTheme": "new",
+      "params": [
+        {
+          "name": "ADV_TYPE",
+          "value": "EXE"
+        },
+        {
+          "name": "ARTICLE",
+          "value": "25A"
+        }
+      ]
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_25A_MMO_APPROVAL",
+      "heading": "Fill out an exemption notification",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/25A\"> Article 25A of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption is subject to the requirement that the activity is carried out in accordance with an approval granted by the MMO. Please submit notification of your intention to carry out the activity and await approval before proceeding.",
+      "module": "MMO_ADVICE_CONTROL",
+      "entryTheme": "new",
+      "params": [
+        {
+          "name": "ADV_TYPE",
+          "value": "EXE"
+        },
+        {
+          "name": "ARTICLE",
+          "value": "25A"
+        }
+      ]
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_26",
+      "heading": "Fill out an exemption notification",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/26\"> Article 26 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption is subject to the requirement that the activity is carried out in accordance with an approval granted by the MMO. Please submit notification of your intention to carry out the activity and await approval before proceeding.",
+      "module": "MMO_ADVICE_CONTROL",
+      "entryTheme": "new",
+      "params": [
+        {
+          "name": "ADV_TYPE",
+          "value": "EXE"
+        },
+        {
+          "name": "ARTICLE",
+          "value": "26"
+        }
+      ]
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_26A",
+      "heading": "Fill out an exemption notification",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/26A\"> Article 26A of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption is subject to the requirement that notification of the intention to carry out the activity is given to the MMO prior to the commencement of the activity.",
+      "module": "MMO_ADVICE_CONTROL",
+      "entryTheme": "new",
+      "params": [
+        {
+          "name": "ADV_TYPE",
+          "value": "EXE"
+        },
+        {
+          "name": "ARTICLE",
+          "value": "26A"
+        }
+      ]
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_26A_NO_NOTIFICATION",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/26A\"> Article 26A of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption does not require any action from you before it is carried out."
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_27",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/27\"> Article 27 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption does not require any action from you before it is carried out."
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_27A",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/27A\"> Article 27A of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption does not require any action from you before it is carried out."
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_28",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/28\"> Article 28 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption does not require any action from you before it is carried out."
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_29",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/29\"> Article 29 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption does not require any action from you before it is carried out."
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_30",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/30\"> Article 30 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption does not require any action from you before it is carried out."
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_31",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/31\"> Article 31 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption does not require any action from you before it is carried out."
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_32",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/32\"> Article 32 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption does not require any action from you before it is carried out."
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_33",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/33\"> Article 33 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption does not require any action from you before it is carried out."
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_34",
+      "heading": "Fill out an exemption notification",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/34\"> Article 34 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption is subject to the requirement that notification of the carrying on of the emergency works is given to the MMO within 24 hours of the commencement of the activity. The notification must set out the location of, the circumstances giving rise to and the nature of the emergency works",
+      "module": "MMO_ADVICE_CONTROL",
+      "entryTheme": "new",
+      "params": [
+        {
+          "name": "ADV_TYPE",
+          "value": "EXE"
+        },
+        {
+          "name": "ARTICLE",
+          "value": "34"
+        },
+        {
+          "name": "EMERGENCY",
+          "value": "true"
+        }
+      ]
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_35",
+      "heading": "Fill out an exemption notification",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/35\"> Article 35 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption is subject to the requirement that notification of the intention to carry out the activity is given to the MMO prior to the commencement of the activity.",
+      "module": "MMO_ADVICE_CONTROL",
+      "entryTheme": "new",
+      "params": [
+        {
+          "name": "ADV_TYPE",
+          "value": "EXE"
+        },
+        {
+          "name": "ARTICLE",
+          "value": "35"
+        }
+      ]
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_36",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/36\"> Article 36 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption does not require any action from you before it is carried out."
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_ARTICLE_37",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/37\"> Article 37 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption does not require any action from you before it is carried out."
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_SECTION_75",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/ukpga/2009/23/section/75\"> S75 of the Marine and Coastal Access Act 2009 </a> and a marine licence is therefore not required. <p>This exemption does not require any action from you before it is carried out. <p>Note: This exemption does not permit the disposal of dredged material at 'Sea'. Disposal of dredged material at 'Sea' by means other than plough or agitation dredging technique is likely to require a marine licence.<p><p>If the project also involves a deposit activity, that activity a separate check should be carried out. "
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_SECTION_75_DISPOSAL",
+      "heading": "Submit an enquiry",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/ukpga/2009/23/section/75\"> S75 of the Marine and Coastal Access Act 2009 </a> and a marine licence is therefore not required. <p>However, this exemption is subject to the requirement that the activity is carried out in accordance with an <u>approval</u> granted by the MMO. <p>Before granting approval you must satisfy the MMO that the material to be disposed is non-hazardous. Please submit an enquiry setting out the particulars of the project and include evidence to inform the MMO’s assessment. <p>This approval service constitutes a formal permission and is chargeable. An estimate of costs will be provided on receipt of the enquiry form. <p>This exemption does not apply until the MMO grant an approval.",
+      "module": "MMO_ADVICE_CONTROL",
+      "entryTheme": "new",
+      "params": [
+        {
+          "name": "ADV_TYPE",
+          "value": "ENQ"
+        }
+      ]
+    },
+    {
+      "id": "WO_EXE_AVAILABLE_SECTION_77",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/ukpga/2009/23/section/77\"> S77 of the Marine and Coastal Access Act 2009 </a> and a marine licence is therefore not required. <p>This exemption does not require any action from you before it is carried out."
+    },
+        {
+      "id": "WO_EXE_AVAILABLE_SECTION_81",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/ukpga/2009/23/section/81\"> S81 of the Marine and Coastal Access Act 2009 </a> and a marine licence is therefore not required. <p>This exemption does not require any action from you before it is carried out."
+    },
+    {
+      "id": "WO_EXE_LICENCE_DEVOLVED",
+      "text": "Based on the information provided the activity does not require a marine licence from the MMO but you may require a marine licence from the relevant devolved administration:<p>The marine licensing authority for Welsh waters is <a target=\"_blank\" href=\"https://naturalresources.wales/permits-and-permissions/marine-licensing/?lang=en\"> Natural Resources Wales </a>. <br/>The marine licensing authority for Scotish waters is  <a target=\"_blank\" href=\"https://www2.gov.scot/Topics/marine/Licensing/marine\"> Marine Scotland </a>. <br/>The marine licesing authority for Northern Irish inshore waters is the  <a target=\"_blank\" href=\"https://www.daera-ni.gov.uk/articles/marine-licensing\"> Department for Agriculture, Environment and Rural Affairs. </a><p>Activities in and around the 'Sea' may require other consents, irrespective of whether they need a marine licence. <p>Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/do-i-need-a-marine-licence#other-consents\"> other consents </a>."
+    },
+    {
+      "id": "WO_EXE_LICENCE_REQUIRED_NO_SELF_SERVICE",
+      "heading": "Apply for a marine licence",
+      "text": "Based on the information provided the activity requires a marine licence. No exemption is available and the activity is not suitable for self-service licensing.",
+      "module": "MMO_APP2_CONTROL",
+      "entryTheme": "new"
+    },
+    {
+      "id": "WO_EXE_LICENCE_REQUIRED",
+      "heading": "Apply for a marine licence",
+      "text": "Based on the information provided the activity requires a marine licence. No exemption is available and the activity is not suitable for self-service licensing.",
+      "module": "MMO_APP2_CONTROL",
+      "entryTheme": "new"
+    },
+    {
+      "id": "WO_CON_NO_EXE_SELF_SERVICE",
+      "heading": "Check to see if the activity is suitable for self-service marine licensing",
+      "text": "Based on the information provided an exemption is not available and a marine licence is required.<p><p>You are advised to select an appropriate option and continue.",
+      "nextQuestionRoute": "/construction/activity"
+    },
+    {
+      "id": "WO_DEPOSIT_NO_EXE_SELF_SERVICE",
+      "heading": "Check to see if the activity is suitable for self-service marine licensing",
+      "text": "Based on the information provided an exemption is not available and a marine licence is required.<p><p>You are advised to select an appropriate option and continue.",
+      "nextQuestionRoute": "/deposit/activity"
+    },
+    {
+      "id": "WO_REMOVAL_NO_EXE_SELF_SERVICE",
+      "heading": "Check to see if the activity is suitable for self-service marine licensing",
+      "text": "Based on the information provided an exemption is not available and a marine licence is required.<p><p>You are advised to select an appropriate option and continue.",
+      "nextQuestionRoute": "/removal/activity"
+    },
+    {
+      "id": "WO_DREDGING_NO_EXE_SELF_SERVICE",
+      "heading": "Check to see if the activity is suitable for self-service marine licensing",
+      "text": "Based on the information provided an exemption is not available and a marine licence is required.<p><p>You are advised to select an appropriate option and continue.",
+      "nextQuestionRoute": "/dredging/activity"
+    },
+    {
+      "id": "WO_NO_EXE_STANDARD_MLA",
+      "heading": "Apply for a standard marine licence",
+      "text": "Based on the information provided an exemption is not available and a marine licence is required.<p><p>You are advised to select an appropriate option and continue.",
+      "module": "MMO_APP2_CONTROL",
+      "entryTheme": "new"
+    },
+    {
+      "id": "WO_STANDARD_MLA",
+      "heading": "Apply for a standard marine licence",
+      "text": "Based on the information provided the selected activity is a licensable activity and as such may require a marine licence.<p><p>You are advised to select an appropriate option and continue your check.",
+      "module": "MMO_APP2_CONTROL",
+      "entryTheme": "new"
+    },
+    {
+      "id": "WO_CON_EXEMPTION_JOURNEY",
+      "heading": "Check to see if an exemption applies or notify the MMO about an exempt activity",
+      "text": "Based on the information provided the selected activity is a licensable activity and as such may require a marine licence.<p><p>You are advised to select an appropriate option and continue your check.",
+      "nextQuestionRoute": "/exemption/construction"
+    },
+    {
+      "id": "WO_CON_EXEMPTION_JOURNEY_ARTICLE99",
+      "heading": "Check to see if an exemption applies or notify the MMO about an exempt activity",
+      "text": "Based on the information provided the selected activity is a licensable activity and as such may require a marine licence.<p><p>You are advised to select an appropriate option and continue your check.",
+      "nextQuestionRoute": "/exemption/construction/article99"
+    },
+    {
+      "id": "WO_CON_SELF_SERVICE_JOURNEY",
+      "heading": "Check to see if the activity is suitable for self-service marine licensing",
+      "text": "Based on the information provided the selected activity is a licensable activity and as such may require a marine licence.<p><p>You are advised to select an appropriate option and continue your check.",
+      "nextQuestionRoute": "/construction/activity"
+    },
+    {
+      "id": "WO_DEPOSIT_EXEMPTION_JOURNEY",
+      "heading": "Check to see if an exemption applies or notify the MMO about an exempt activity",
+          "text": "Based on the information provided the selected activity is a licensable activity and as such may require a marine licence.<p><p>You are advised to select an appropriate option and continue your check.",
+      "nextQuestionRoute": "/exemption/deposit/activity-type"
+    },
+    {
+      "id": "WO_DEPOSIT_SELF_SERVICE_JOURNEY",
+      "heading": "Check to see if the activity is suitable for self-service marine licensing",
+          "text": "Based on the information provided the selected activity is a licensable activity and as such may require a marine licence.<p><p>You are advised to select an appropriate option and continue your check.",
+      "nextQuestionRoute": "/deposit/activity"
+    },
+    {
+      "id": "WO_REMOVAL_EXEMPTION_JOURNEY",
+      "heading": "Check to see if an exemption applies or notify the MMO about an exempt activity",
+          "text": "Based on the information provided the selected activity is a licensable activity and as such may require a marine licence.<p><p>You are advised to select an appropriate option and continue your check.",
+      "nextQuestionRoute": "/exemption/removal/activity-type"
+    },
+    {
+      "id": "WO_REMOVAL_SELF_SERVICE_JOURNEY",
+      "heading": "Check to see if the activity is suitable for self-service marine licensing",
+          "text": "Based on the information provided the selected activity is a licensable activity and as such may require a marine licence.<p><p>You are advised to select an appropriate option and continue your check.",
+      "nextQuestionRoute": "/removal/activity"
+    },
+    {
+      "id": "WO_DREDGING_EXEMPTION_JOURNEY",
+      "heading": "Check to see if an exemption applies or notify the MMO about an exempt activity",
+          "text": "Based on the information provided the selected activity is a licensable activity and as such may require a marine licence.<p><p>You are advised to select an appropriate option and continue your check.",
+      "nextQuestionRoute": "/exemption/dredging"
+    },
+    {
+      "id": "WO_DREDGING_SELF_SERVICE_JOURNEY",
+      "heading": "Check to see if the activity is suitable for self-service marine licensing",
+          "text": "Based on the information provided the selected activity is a licensable activity and as such may require a marine licence.<p><p>You are advised to select an appropriate option and continue your check.",
+      "nextQuestionRoute": "/dredging/activity"
+    }
+  ],
+  "outcomes": [
+    {
+      "route": "/mod-permission",
+      "heading": "MOD permission not sought or granted",
+      "outcomeTypes": [
+        "WO_MOD_PERMISSION",
+        "WO_STANDARD_TRACK_MLA"
+      ]
+    },
+    {
+      "route": "/not-licensable",
+      "outcomeTypes": [
+        "WO_NOT_LICENSABLE"
+      ]
+    },
+    {
+      "route": "/scaffolding-impede-navigation",
+      "heading": "Scaffolding or access towers - impede safe or normal navigation",
+      "outcomeTypes": [
+        "WO_DOWNLOAD_HA_AGREED_METHOD_TEMPLATE",
+        "WO_STANDARD_TRACK_MLA"
+      ]
+    },
+    {
+      "route": "/scaffolding-mca-th-agreed",
+      "heading": "Scaffolding or access towers - impede safe or normal navigation",
+      "outcomeTypes": [
+        "WO_DOWNLOAD_MCA_TH_AGREED_METHOD_TEMPLATE",
+        "WO_STANDARD_TRACK_MLA"
+      ]
+    },
+    {
+      "route": "/markers/ha-not-agreed",
+      "heading": "Deposit of markers - requirements not agreed with the harbour authority",
+      "outcomeTypes": [
+        "WO_DOWNLOAD_HA_MARKERS_AGREED_METHOD_TEMPLATE",
+        "WO_STANDARD_TRACK_MLA"
+      ]
+    },
+    {
+      "route": "/markers/th-not-agreed",
+      "heading": "Deposit of markers - requirements not agreed with Trinity House",
+      "outcomeTypes": [
+        "WO_DOWNLOAD_TH_MARKERS_AGREED_METHOD_TEMPLATE",
+        "WO_STANDARD_TRACK_MLA"
+      ]
+    },
+    {
+      "route": "/fast-track-mla",
+      "heading": "Self-service marine licensing",
+      "outcomeTypes": [
+        "WO_FAST_TRACK_MLA"
+      ]
+    },
+    {
+      "route": "/fast-track-mla/bas-block",
+      "heading": "Licence required",
+      "outcomeTypes": [
+        "WO_FAST_TRACK_MLA_BAS_BLOCK"
+      ]
+    },
+    {
+      "route": "/not-screened-out",
+      "heading": "Project not \"screened out\" by the MMO",
+      "outcomeTypes": [
+        "WO_ENQUIRY",
+        "WO_EIA",
+        "WO_STANDARD_TRACK_MLA"
+      ]
+    },
+    {
+      "route": "/historic-england/not-agreed",
+      "heading": "Historic England - no consent or method agreed",
+      "outcomeTypes": [
+        "WO_DOWNLOAD_HE_AGREED_METHOD_TEMPLATE",
+        "WO_STANDARD_TRACK_MLA"
+      ]
+    },
+    {
+      "route": "/fast-track-mla/activity",
+      "heading": "Licence required - Self-service activity",
+      "outcomeTypes": [
+        "WO_FAST_TRACK_MLA"
+      ]
+    },
+    {
+      "route": "/natural-england/not-agreed",
+      "heading": "Natural England - no method agreed",
+      "outcomeTypes": [
+        "WO_DOWNLOAD_NE_AGREED_METHOD_TEMPLATE",
+        "WO_STANDARD_TRACK_MLA"
+      ]
+    },
+    {
+      "route": "/standard-marine-licence-application/construction",
+      "heading": "Construction",
+      "outcomeTypes": ["WO_STANDARD_TRACK_MLA"]
+    },
+    {
+      "route": "/standard-marine-licence-application/deposit",
+      "heading": "Deposit",
+      "outcomeTypes": [
+        "WO_STANDARD_TRACK_MLA"
+      ]
+    },
+    {
+      "route": "/standard-marine-licence-application/removal",
+      "heading": "Removal",
+      "outcomeTypes": ["WO_STANDARD_TRACK_MLA"]
+    },
+    {
+      "route": "/standard-marine-licence-application/dredging",
+      "heading": "Dredging",
+      "outcomeTypes": ["WO_STANDARD_TRACK_MLA"]
+    },
+    {
+      "route": "/standard-marine-licence-application/incineration",
+      "heading": "Incineration",
+      "outcomeTypes": [
+        "WO_STANDARD_TRACK_MLA"
+      ]
+    },
+    {
+      "route": "/standard-marine-licence-application/scuttling",
+      "heading": "Scuttling",
+      "outcomeTypes": [
+        "WO_STANDARD_TRACK_MLA"
+      ]
+    },
+    {
+      "route": "/standard-marine-licence-application/explosives",
+      "heading": "Explosives",
+      "outcomeTypes": [
+        "WO_STANDARD_TRACK_MLA"
+      ]
+    },
+    {
+      "route": "/standard-marine-licence-application/other-activity",
+      "heading": "Activity - other",
+      "outcomeTypes": [
+        "WO_STANDARD_TRACK_MLA_OTHER_ACTIVITY"
+      ]
+    },
+    {
+      "route": "/standard-marine-licence-application/other-maintenance",
+      "heading": "Maintenance of existing structures or assets - Other maintenance",
+      "outcomeTypes": [
+        "WO_STANDARD_TRACK_MLA_OTHER_MAINTENANCE"
+      ]
+    },
+    {
+      "route": "/standard-marine-licence-application/bas-duration",
+      "heading": "Activity - duration over 3 months (Burial at Sea)",
+      "outcomeTypes": [
+        "WO_STANDARD_TRACK_MLA"
+      ]
+    },
+    {
+      "route": "/standard-marine-licence-application/bas-other-location",
+      "heading": "Deposit - Burial at Sea - Other location",
+      "outcomeTypes": [
+        "WO_STANDARD_TRACK_MLA"
+      ]
+    },
+    {
+      "route": "/standard-marine-licence-application/other-removals",
+      "heading": "Minor removals - Other removals",
+      "outcomeTypes": [
+        "WO_STANDARD_TRACK_MLA_OTHER_REMOVALS"
+      ]
+    },
+    {
+      "route": "/standard-marine-licence-application/other-clearance-dredging",
+      "heading": "Non-navigational clearance dredging - Other clearance dredging",
+      "outcomeTypes": [
+        "WO_STANDARD_TRACK_MLA_OTHER_CLEARANCE_DREDGING"
+      ]
+    },
+    {
+      "route": "/standard-marine-licence-application/other-beach-maintenance",
+      "heading": "Beach maintenance activities - Other beach maintenance",
+      "outcomeTypes": [
+        "WO_STANDARD_TRACK_MLA_OTHER_BEACH_MAINTENANCE"
+      ]
+    },
+    {
+      "route": "/standard-marine-licence-application/other-deposits",
+      "heading": "Deposit of markers - Other deposits",
+      "outcomeTypes": [
+        "WO_STANDARD_TRACK_MLA_OTHER_DEPOSITS"
+      ]
+    },
+    {
+      "route": "/standard-marine-licence-application/duration",
+      "heading": "Activity - duration over 12 months",
+      "outcomeTypes": [
+        "WO_STANDARD_TRACK_MLA"
+      ]
+    },
+    {
+      "route": "/standard-marine-licence-application/public-register",
+      "heading": "Information needs be withheld from the MMO public register",
+      "outcomeTypes": [
+        "WO_STANDARD_TRACK_MLA"
+      ]
+    },
+    {
+      "route": "/standard-marine-licence-application/ten-square-miles",
+      "heading": "Activity locations not within 10 square miles",
+      "outcomeTypes": [
+        "WO_STANDARD_TRACK_MLA"
+      ]
+    },
+    {
+      "route": "/standard-marine-licence-application/intrusive-in-nature",
+      "heading": "Activity intrusive in nature",
+      "outcomeTypes": [
+        "WO_STANDARD_TRACK_MLA"
+      ]
+    },
+    {
+      "route": "/standard-marine-licence-application/routing-measure",
+      "heading": "New activity within an International Maritime Organisation routing measure",
+      "outcomeTypes": [
+        "WO_STANDARD_TRACK_MLA"
+      ]
+    },
+    {
+      "route": "/standard-marine-licence-application/protected-place",
+      "heading": "Activity within a protected place or controlled site under the Protection of Military Remains Act (1986)",
+      "outcomeTypes": [
+        "WO_STANDARD_TRACK_MLA"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required",
+      "heading": "Marine licence not required",
+      "outcomeTypes": [
+        "WO_EXE_NOT_LICENSABLE"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required/deposit-method",
+      "heading": "Marine licence not required",
+      "outcomeTypes": [
+        "WO_EXE_NOT_LICENSABLE_DEPOSIT_METHOD"
+      ]
+    },
+     {
+      "route": "/exemption/licence-not-required/sea",
+      "heading": "Marine licence not required",
+      "outcomeTypes": [
+        "WO_EXE_NOT_LICENSABLE_SEA"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required/deposit-method",
+      "heading": "Marine licence not required",
+      "outcomeTypes": [
+        "WO_EXE_NOT_LICENSABLE_DEPOSIT_METHOD"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required/removal-seabed",
+      "heading": "Marine licence not required",
+      "outcomeTypes": [
+        "WO_EXE_NOT_LICENSABLE_REMOVAL_SEABED"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required/removal-method",
+      "heading": "Marine licence not required",
+      "outcomeTypes": [
+        "WO_EXE_NOT_LICENSABLE_REMOVAL_METHOD"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required/Incineration-on",
+      "heading": "Marine licence not required",
+      "outcomeTypes": [
+        "WO_EXE_NOT_LICENSABLE_INCINERATION_ON"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required/Activity-elsewhere",
+      "heading": "Marine licence not required",
+      "outcomeTypes": [
+        "WO_EXE_NOT_LICENSABLE_ELSEWHERE_ACTIVITY"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required/deposit-method-elsewhere",
+      "heading": "Marine licence not required",
+      "outcomeTypes": [
+        "WO_EXE_NOT_LICENSABLE_DEPOSIT_METHOD_ELSEWHERE"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required/scuttling-method-elsewhere",
+      "heading": "Marine licence not required",
+      "outcomeTypes": [
+        "WO_EXE_NOT_LICENSABLE_SCUTTLING_METHOD_ELSEWHERE"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required/incineration-method-elsewhere",
+      "heading": "Marine licence not required",
+      "outcomeTypes": [
+        "WO_EXE_NOT_LICENSABLE_INCINERATION_METHOD_ELSEWHERE"
+      ]
+    },
+   {
+      "route": "/exemption/licence-not-required/scuttling-method-elsewhere",
+      "heading": "Marine licence not required",
+      "outcomeTypes": [
+        "WO_EXE_NOT_LICENSABLE_SCUTTLING_METHOD_ELSEWHERE"
+      ]
+    },
+
+    {
+      "route": "/exemption/licence-not-required-cables",
+      "heading": "Exempt activity",
+      "outcomeTypes": [
+        "WO_EXE_NOT_LICENSABLE_CABLES"
+      ]
+    },
+     {
+      "route": "/exemption/licence-not-required-cables/maintenance",
+      "heading": "Exempt activity",
+      "outcomeTypes": [
+        "WO_EXE_NOT_LICENSABLE_CABLES_MAINTENANCE"
+      ]
+    },
+    {
+      "route": "/exemption/licence-required-no-exemption-part-cables",
+      "heading": "Marine licence is required",
+      "outcomeTypes": [
+        "WO_EXE_NOT_LICENSABLE_PART_CABLES"
+      ]
+    },
+     {
+      "route": "/exemption/licence-not-required-cables/maintenance/both",
+      "heading": "Exempt activity",
+      "outcomeTypes": [
+        "WO_EXE_NOT_LICENSABLE_PART_CABLES_MAINTENANCE_BOTH"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-7",
+      "heading": "Exempt activity",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_7"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-8",
+      "heading": "Exempt activity",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_8"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-9",
+      "heading": "Exempt activity",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_9"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-10",
+      "heading": "Exempt activity",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_10"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-11",
+      "heading": "Exempt activity",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_11"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-12",
+      "heading": "Exempt activity",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_12"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-13",
+      "heading": "Exempt activity - Notification required",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_13"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-14",
+      "heading": "Exempt activity",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_14"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-15",
+      "heading": "Marine licence not required",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_15"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-16",
+      "heading": "Exempt activity - Approval required",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_16"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-17",
+      "heading": "Exempt activity - Notification required",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_17"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-17A",
+      "heading": "Exempt activity - Notification required",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_17A"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-17B",
+      "heading": "Exempt activity - Notification required",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_17B"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-18",
+      "heading": "Licence is not required",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_18"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-18A",
+      "heading": "Exempt activity - Notification required",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_18A"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-19",
+      "heading": "Exempt activity",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_19"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-20",
+      "heading": "Exempt activity - Notification required",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_20"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-21",
+      "heading": "Exempt activity - Notification required",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_21"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-21-no-notification",
+      "heading": "Exempt activity",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_21_NO_NOTIFICATION"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-21A",
+      "heading": "Exempt activity",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_21A"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-22",
+      "heading": "Exempt activity",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_22"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-23",
+      "heading": "Exempt activity",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_23"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-24",
+      "heading": "Exempt activity",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_24"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-24A",
+      "heading": "Exempt activity",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_24A"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-25",
+      "heading": "Exempt activity",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_25"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-25-notification",
+      "heading": "Exempt activity - Notification required",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_25_NOTIFICATION"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-25A",
+      "heading": "Exempt activity - Notification required",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_25A"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-25A-mmo-approval",
+      "heading": "Exempt activity - Approval required",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_25A_MMO_APPROVAL"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-26",
+      "heading": "Exempt activity - Approval required",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_26"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-26a",
+      "heading": "Exempt activity - Notification required",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_26A"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-26a-no-notification",
+      "heading": "Exempt activity",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_26A_NO_NOTIFICATION"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-27",
+      "heading": "Exempt activity",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_27"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-27A",
+      "heading": "Exempt activity",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_27A"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-28",
+      "heading": "Exempt activity",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_28"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-29",
+      "heading": "Exempt activity",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_29"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-30",
+      "heading": "Exempt activity",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_30"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-31",
+      "heading": "Exempt activity",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_31"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-32",
+      "heading": "Exempt activity",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_32"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-33",
+      "heading": "Exempt activity",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_33"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-34",
+      "heading": "Exempt activity - Notification required",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_34"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-35",
+      "heading": "Exempt activity",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_35"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-36",
+      "heading": "Exempt activity",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_36"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-article-37",
+      "heading": "Exempt activity",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_ARTICLE_37"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-Section-75",
+      "heading": "Exempt activity",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_SECTION_75"
+      ]
+    },
+        {
+      "route": "/exemption/licence-not-required-exemption-available-Section-75-disposal",
+      "heading": "Exempt activity - Approval required",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_SECTION_75_DISPOSAL"
+      ]
+    },
+    {
+      "route": "/exemption/licence-not-required-exemption-available-Section-77",
+      "heading": "Exempt activity",
+      "outcomeTypes": [
+        "WO_EXE_AVAILABLE_SECTION_77"
+      ]
+    },
+    {
+      "route": "/licence-not-required-devolved",
+      "heading": "Marine licence not required",
+      "outcomeTypes": [
+        "WO_EXE_LICENCE_DEVOLVED"
+      ]
+    },
+    {
+      "route": "/exemption/licence-required-no-exemption-no-self-service",
+      "heading": "Marine licence is required",
+      "outcomeTypes": [
+        "WO_EXE_LICENCE_REQUIRED_NO_SELF_SERVICE"
+      ]
+    },
+    {
+      "route": "/exemption/licence-required-no-exemption",
+      "heading": "Marine licence is required",
+      "outcomeTypes": [
+        "WO_EXE_LICENCE_REQUIRED"
+      ]
+    },
+    {
+      "route": "/exemption/construction-exe-not-available-continue",
+      "heading": "Exemption not available",
+      "section": "doINeedAMarineLicenceConstruction",
+      "text": "<b><b>Please select the service you require.</b></b><p><p> Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/do-i-need-a-marine-licence#self-service\">self-service</a>, or <a target=\"_blank\" href=\"https://www.gov.uk/guidance/do-i-need-a-marine-licence#standard-marine-licence\">standard marine licensing</a>.<p><p>Note: If you select option 1 but it is subsequently determined in the course of the check that the activity does not meet relevant qualifying criteria you will have the opportunity to continue your journey and apply for a standard marine licence once the check is concluded.",
+      "outcomeTypes": [
+        "WO_CON_NO_EXE_SELF_SERVICE",
+        "WO_NO_EXE_STANDARD_MLA"
+      ]
+    },
+    {
+      "route": "/exemption/deposit-exe-not-available-continue",
+      "heading": "Exemption not available",
+      "section": "doINeedAMarineLicenceDeposit",
+      "text": "<b>Please select the service you require.</b><p><p> Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/do-i-need-a-marine-licence#self-service\">self-service</a>, or <a target=\"_blank\" href=\"https://www.gov.uk/guidance/do-i-need-a-marine-licence#standard-marine-licence\">standard marine licensing</a>.<p><p>Note: If you select option 1 but it is subsequently determined in the course of the check that the activity does not meet relevant qualifying criteria you will have the opportunity to continue your journey and apply for a standard marine licence once the check is concluded.",
+      "outcomeTypes": [
+        "WO_DEPOSIT_NO_EXE_SELF_SERVICE",
+        "WO_NO_EXE_STANDARD_MLA"
+      ]
+    },
+    {
+      "route": "/exemption/removal-exe-not-available-continue",
+      "heading": "Exemption not available",
+      "section": "doINeedAMarineLicenceRemoval",
+      "text": "<b>Please select the service you require.</b><p><p> Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/do-i-need-a-marine-licence#self-service\">self-service</a>, or <a target=\"_blank\" href=\"https://www.gov.uk/guidance/do-i-need-a-marine-licence#standard-marine-licence\">standard marine licensing</a>.<p><p>Note: If you select option 1 but it is subsequently determined in the course of the check that the activity does not meet relevant qualifying criteria you will have the opportunity to continue your journey and apply for a standard marine licence once the check is concluded.",
+      "outcomeTypes": [
+        "WO_REMOVAL_NO_EXE_SELF_SERVICE",
+        "WO_NO_EXE_STANDARD_MLA"
+      ]
+    },
+    {
+      "route": "/exemption/dredging-exe-not-available-continue",
+      "heading": "Exemption not available",
+      "section": "doINeedAMarineLicenceDredging",
+      "text": "<b>Please select the service you require.</b><p><p> Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/do-i-need-a-marine-licence#self-service\">self-service</a>, or <a target=\"_blank\" href=\"https://www.gov.uk/guidance/do-i-need-a-marine-licence#standard-marine-licence\">standard marine licensing</a>.<p><p>Note: If you select option 1 but it is subsequently determined in the course of the check that the activity does not meet relevant qualifying criteria you will have the opportunity to continue your journey and apply for a standard marine licence once the check is concluded.",
+      "outcomeTypes": [
+        "WO_DREDGING_NO_EXE_SELF_SERVICE",
+        "WO_NO_EXE_STANDARD_MLA"
+      ]
+    },
+    {
+      "route": "/construction/journey-select",
+      "heading": "Marine licence may be required",
+      "text": "<b>Please select the service you require.</b><p><p> Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/do-i-need-a-marine-licence#exemptions\">exemptions</a>, <a target=\"_blank\" href=\"https://www.gov.uk/guidance/do-i-need-a-marine-licence#self-service\">self-service</a>, or <a target=\"_blank\" href=\"https://www.gov.uk/guidance/do-i-need-a-marine-licence#standard-marine-licence\">standard marine licensing</a>.<p><p>Note: If you select either option 1 or option 2 but it is subsequently determined in the course of the check that the activity does not meet relevant qualifying criteria you will have the opportunity to continue your journey and select a different option once the check is concluded.",
+      "section": "doINeedAMarineLicenceConstruction",
+      "outcomeTypes": [
+        "WO_CON_EXEMPTION_JOURNEY",
+        "WO_CON_SELF_SERVICE_JOURNEY",
+        "WO_STANDARD_MLA"
+      ]
+    },
+    {
+      "route": "/deposit/journey-select",
+      "heading": "Marine licence may be required",
+      "text": "<b>Please select the service you require.</b><p><p> Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/do-i-need-a-marine-licence#exemptions\">exemptions</a>, <a target=\"_blank\" href=\"https://www.gov.uk/guidance/do-i-need-a-marine-licence#self-service\">self-service</a>, or <a target=\"_blank\" href=\"https://www.gov.uk/guidance/do-i-need-a-marine-licence#standard-marine-licence\">standard marine licensing</a>.<p><p>Note: If you select either option 1 or option 2 but it is subsequently determined in the course of the check that the activity does not meet relevant qualifying criteria you will have the opportunity to continue your journey and select an different option once the check is concluded.",
+      "section": "doINeedAMarineLicenceDeposit",
+      "outcomeTypes": [
+        "WO_DEPOSIT_EXEMPTION_JOURNEY",
+        "WO_DEPOSIT_SELF_SERVICE_JOURNEY",
+        "WO_STANDARD_MLA"
+      ]
+    },
+    {
+      "route": "/removal/journey-select",
+      "heading": "Marine licence may be required",
+      "text": "<b>Please select the service you require.</b><p><p> Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/do-i-need-a-marine-licence#exemptions\">exemptions</a>, <a target=\"_blank\" href=\"https://www.gov.uk/guidance/do-i-need-a-marine-licence#self-service\">self-service</a>, or <a target=\"_blank\" href=\"https://www.gov.uk/guidance/do-i-need-a-marine-licence#standard-marine-licence\">standard marine licensing</a>.<p><p>Note: If you select either option 1 or option 2 but it is subsequently determined in the course of the check that the activity does not meet relevant qualifying criteria you will have the opportunity to continue your journey and select an different option once the check is concluded.",
+      "section": "doINeedAMarineLicenceRemoval",
+      "outcomeTypes": [
+        "WO_REMOVAL_EXEMPTION_JOURNEY",
+        "WO_REMOVAL_SELF_SERVICE_JOURNEY",
+        "WO_STANDARD_MLA"
+      ]
+    },
+    {
+      "route": "/dredging/journey-select",
+      "heading": "Marine licence may be required",
+      "text": "<b>Please select the service you require.</b><p><p> Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/do-i-need-a-marine-licence#exemptions\">exemptions</a>, <a target=\"_blank\" href=\"https://www.gov.uk/guidance/do-i-need-a-marine-licence#self-service\">self-service</a>, or <a target=\"_blank\" href=\"https://www.gov.uk/guidance/do-i-need-a-marine-licence#standard-marine-licence\">standard marine licensing</a>.<p><p>Note: If you select either option 1 or option 2 but it is subsequently determined in the course of the check that the activity does not meet relevant qualifying criteria you will have the opportunity to continue your journey and select an different option once the check is concluded.",
+      "section": "doINeedAMarineLicenceDredging",
+      "outcomeTypes": [
+        "WO_DREDGING_EXEMPTION_JOURNEY",
+        "WO_DREDGING_SELF_SERVICE_JOURNEY",
+        "WO_STANDARD_MLA"
+      ]
+    }
+  ],
+  "questions": [
+    {
+      "route": "/sea",
+      "text": "Where will the activity take place?",
+      "section": "doINeedAMarineLicence",
+      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/marine-licensing-definitions#mean-high-water-springs\"> mean high water springs (MHWS)</a>, the <a target=\"_blank\" href=\"https://www.gov.uk/guidance/marine-licensing-definitions#normal-tidal-limit\"> normal tidal limit (NTL) </a>, or the MMO’s <a target=\"_blank\" href=\"https://www.gov.uk/guidance/marine-licensing-definitions#jurisdiction\">jurisdiction</a>.",
+      "answers": [
+        {
+          "id": "inSea",
+          "text": "In the 'Sea'",
+          "nextQuestionRoute": "/jurisdiction",
+          "hint": "'Sea' includes any area which is <u>submerged</u> at MHWS and the waters of every <u>estuary, river or channel</u> where the tide flows at MHWS tide up to the NTL. Even waters in areas which are closed permanently or intermittently by a lock or other artificial means against the regular action of the tide are included, where seawater flows into or out from the area, either continuously or from time to time."
+        },
+        {
+          "id": "overSea",
+          "text": "Over the 'Sea'",
+          "nextQuestionRoute": "/jurisdiction",
+          "hint": "'Over' the 'Sea' includes a location directly above or overhanging the 'Sea' such as a bridge, open piled structure or cantilever."
+        },
+        {
+          "id": "onOrUnderSea",
+          "text": "On or under the 'Seabed'",
+          "nextQuestionRoute": "/jurisdiction",
+          "hint": "'Seabed' means the ground under the 'Sea' and anything resting on it such as a wreck. It includes the intertidal area of the sea or any river at such time as it is exposed temporarily at low tide."
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/licence-not-required/sea",
+          "hint": "In an area <u>other</u> than those defined above. For example the part of beach <u>above MHWS</u>, the upper extent of a river <u>beyond the NTL</u> and or a land locked body of water such as a lake."
+        }
+      ]
+    },
+    {
+      "route": "/jurisdiction",
+      "text": "In which waters will the activity take place?",
+      "hint": "See an illustration of these 'waters' or find out more about the MMO’s <a target=\"_blank\" href=\"https://www.gov.uk/guidance/marine-licensing-definitions#jurisdiction\">jurisdiction</a>.",
+      "section": "doINeedAMarineLicence",
+      "answers": [
+        {
+          "id": "englishWaters",
+          "text": "In English waters",
+          "nextQuestionRoute": "/activity-type",
+          "hint": "'English waters' is the area of 'Sea' within the limits of territorial waters (12 nautical miles) adjacent to the English coastline (the 'inshore' area). This also includes any area of sea beyond the territorial limit (the 'offshore' area), that is within the exclusive economic zone (EEZ) and the UK sector of the continental shelf (up to 200 nautical miles). This excludes the waters of any devolved administration."
+        },
+        {
+          "id": "northernIrishOffshoreWaters",
+          "text": "In Northern Ireland offshore waters",
+          "nextQuestionRoute": "/activity-type",
+          "hint": "'Northern Ireland offshore waters' is the area of 'Sea', adjacent to Northern Ireland beyond the territorial limit, providing it includes the EEZ and the UK sector of the continental shelf (excluding the waters of any other administration)."
+        },
+        {
+          "id": "otherUkWaters",
+          "text": "In other UK waters",
+          "outcomeRoute": "/licence-not-required-devolved",
+          "hint": "'Other UK waters'means the waters of the devolved administrations of Wales, Scotland or Northern Ireland (excluding Northern Ireland offshore waters)."
+        },
+        {
+          "id": "elsewhere",
+          "text": "Somewhere else in the world",
+          "nextQuestionRoute": "/elsewhere-in-the-world/activity-type"
+        }
+      ]
+    },
+    {
+      "route": "/elsewhere-in-the-world/activity-type",
+      "text": "What type of activity will be carried out?",
+      "section": "elsewhereActivity",
+      "answers": [
+        {
+          "id": "deposit",
+          "text": "Deposit a substance or object",
+          "nextQuestionRoute": "/elsewhere-in-the-world/deposit"
+        },
+        {
+          "id": "scuttling",
+          "text": "Sinking of a vessel or floating container",
+          "nextQuestionRoute": "/elsewhere-in-the-world/scuttling"
+        },
+        {
+          "id": "incineration",
+          "text": "Incinerate a substance or object",
+          "nextQuestionRoute": "/elsewhere-in-the-world/incineration"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/licence-not-required/Activity-elsewhere"
+        }
+      ]
+    },
+    {
+      "route": "/elsewhere-in-the-world/deposit",
+      "text": "How will the deposit be made?",
+      "section": "elsewhereDeposit",
+      "answers": [
+        {
+          "id": "britishVessel",
+          "text": "From a British vessel",
+          "outcomeRoute": "/exemption/licence-required-no-exemption-no-self-service",
+          "hint": "'British vessel' means a vessel which is registered in the United Kingdom, which falls within section 1(1)(d) of the Merchant Shipping Act 1995 (small ships), or which is exempt from registration under section 294 of that Act"
+        },
+        {
+          "id": "britishMarineStructure",
+          "text": "From a British marine structure",
+          "outcomeRoute": "/exemption/licence-required-no-exemption-no-self-service",
+          "hint": "'Marine structure' means a platform or other artificial structure at 'Sea', other than a pipeline. 'British marine structure' means a marine structure owned by or leased to an individual residing in, or a body corporate incorporated under the law of, any part of the United Kingdom."
+        },
+        {
+          "id": "britishAircraft",
+          "text": "From a British aircraft",
+          "outcomeRoute": "/exemption/licence-required-no-exemption-no-self-service",
+          "hint": "British aircraft” means an aircraft registered in the United Kingdom"
+        },
+        {
+          "id": "floatingContainer",
+          "text": "From a Floating container and the deposit is controlled by a British vessel, British aircraft or British marine structure",
+          "outcomeRoute": "/exemption/licence-required-no-exemption-no-self-service"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "nextQuestionRoute": "/elsewhere-in-the-world/deposit/where-loaded"
+        }
+      ]
+    },
+    {
+      "route": "/elsewhere-in-the-world/deposit/where-loaded",
+      "text": "Where will the substance or object to be deposited be loaded?",
+      "section": "elsewhereDeposit",
+      "answers": [
+        {
+          "id": "inUk",
+          "text": "United Kingdom (except Scotland)",
+          "outcomeRoute": "/exemption/licence-required-no-exemption-no-self-service"
+        },
+        {
+          "id": "inUkMLA",
+          "text": "UK marine licensing area",
+          "outcomeRoute": "/exemption/licence-required-no-exemption-no-self-service",
+          "hint": "Find out more about the <a target=\"_blank\" href=\"https://www.legislation.gov.uk/ukpga/2009/23/section/42\">UK marine licensing area</a>"
+        },
+        {
+          "id": "none",
+          "text": "Somewhere else",
+          "outcomeRoute": "/exemption/licence-not-required/deposit-method-elsewhere"
+        }
+      ]
+    },
+    {
+      "route": "/elsewhere-in-the-world/incineration",
+      "text": "Where will the incineration take place?",
+      "section": "elsewhereIncineration",
+      "answers": [
+        {
+          "id": "britishVessel",
+          "text": "On a British vessel",
+          "outcomeRoute": "/exemption/licence-required-no-exemption-no-self-service",
+          "hint": "'British vessel' means a vessel which is registered in the United Kingdom, which falls within section 1(1)(d) of the Merchant Shipping Act 1995 (small ships), or which is exempt from registration under section 294 of that Act"
+        },
+        {
+          "id": "britishMarineStructure",
+          "text": "On a British marine structure",
+          "outcomeRoute": "/exemption/licence-required-no-exemption-no-self-service",
+          "hint": "'Marine structure' means a platform or other artificial structure at 'Sea', other than a pipeline. 'British marine structure' means a marine structure owned by or leased to an individual residing in, or a body corporate incorporated under the law of, any part of the United Kingdom."
+        },
+        {
+          "id": "controlledFloatingContainer",
+          "text": "On a floating container controlled from a British vessel, British aircraft, or British marine structure.",
+          "outcomeRoute": "/exemption/licence-required-no-exemption-no-self-service",
+          "hint": "'British aircraft' means an aircraft registered in the United Kingdom."
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "nextQuestionRoute": "/elsewhere-in-the-world/incineration/where-loaded"
+        }
+      ]
+    },
+       {
+      "route": "/elsewhere-in-the-world/incineration/where-loaded",
+      "text": "Where will the substance or object to be incinerated be loaded? ",
+      "section": "elsewhereIncineration",
+      "answers": [
+        {
+          "id": "inUk",
+          "text": "United Kingdom (except Scotland)",
+          "outcomeRoute": "/exemption/licence-required-no-exemption-no-self-service"
+        },
+        {
+          "id": "inUkMLA",
+          "text": "UK marine licensing area",
+          "outcomeRoute": "/exemption/licence-required-no-exemption-no-self-service",
+          "hint": "Find out more about the <a target=\"_blank\" href=\"https://www.legislation.gov.uk/ukpga/2009/23/section/42\">UK marine licensing area</a>"
+        },
+        {
+          "id": "none",
+          "text": "Somewhere else",
+          "outcomeRoute": "/exemption/licence-not-required/incineration-method-elsewhere"
+        }
+      ]
+    },
+    {
+      "route": "/elsewhere-in-the-world/scuttling",
+      "text": "How will the sinking be controlled?",
+      "section": "elsewhereScuttling",
+      "answers": [
+        {
+          "id": "britishVessel",
+          "text": "From a British vessel",
+          "outcomeRoute": "/exemption/licence-required-no-exemption-no-self-service",
+          "hint": "'British vessel' means a vessel which is registered in the United Kingdom, which falls within section 1(1)(d) of the Merchant Shipping Act 1995 (small ships), or which is exempt from registration under section 294 of that Act"
+        },
+        {
+          "id": "britishAircraft",
+          "text": "From a British aircraft",
+          "outcomeRoute": "/exemption/licence-required-no-exemption-no-self-service",
+          "hint": "British aircraft” means an aircraft registered in the United Kingdom"
+        },
+        {
+          "id": "britishMarineStructure",
+          "text": "From a British marine structure",
+          "outcomeRoute": "/exemption/licence-required-no-exemption-no-self-service",
+          "hint": "'Marine structure' means a platform or other artificial structure at 'Sea', other than a pipeline. 'British marine structure' means a marine structure owned by or leased to an individual residing in, or a body corporate incorporated under the law of, any part of the United Kingdom."
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "nextQuestionRoute": "/elsewhere-in-the-world/scuttling/towed-or-propelled-from-uk"
+        }
+      ]
+    },
+    {
+      "route": "/elsewhere-in-the-world/scuttling/towed-or-propelled-from-uk",
+      "text": "Where will the vessel or container be towed or propelled from, for the purpose of its sinking?",
+      "section": "elsewhereScuttling",
+      "answers": [
+        {
+          "id": "inUk",
+          "text": "United Kingdom (except Scotland)",
+          "outcomeRoute": "/exemption/licence-required-no-exemption-no-self-service"
+        },
+        {
+          "id": "inUkMLA",
+          "text": "UK marine licensing area (unless towing or propelling began outside of that area)",
+          "outcomeRoute": "/exemption/licence-required-no-exemption-no-self-service",
+          "hint": "Find out more about the <a target=\"_blank\" href=\"https://www.legislation.gov.uk/ukpga/2009/23/section/42\">UK marine licensing area</a>"
+        },
+        {
+          "id": "none",
+          "text": "Somewhere else",
+          "outcomeRoute": "/exemption/licence-not-required/scuttling-method-elsewhere"
+        }
+      ]
+    },
+    {
+      "route": "/activity-type",
+      "mcmsAppFormMapping": "ACTIVITY_TYPE",
+      "text": "What type of activity will be carried out?",
+      "hint": "HINT: Try to think about what you intend to do at a basic level. For example if you plan to take sediment samples for testing or analysis, the type of activity that will take place is a removal activity. If the activity involves the building of something new, or the maintenance, alteration or improvement of something that already exists, then the activity that will take place is a construction activity.<p> </br> Doing more than one thing? If your project involves multiple activities make sure you check each separately starting with the main or most significant activity.",
+      "section": "doINeedAMarineLicence",
+      "answers": [
+        {
+          "id": "CON",
+          "text": "Construction",
+          "outcomeRoute": "/construction/journey-select",
+          "hint": "Including maintenance, alteration and improvement of works and the laying of cables or pipelines.<br/>Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/construction-alteration-or-improvement-of-works\">construction, maintenance, alteration and improvement</a>"
+        },
+        {
+          "id": "DEPOSIT",
+          "text": "Deposit of a substance or object",
+          "nextQuestionRoute": "/deposit/method",
+          "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/deposits#deposit-of-any-substance-or-object\">deposits</a>"
+        },
+        {
+          "id": "REMOVAL",
+          "text": "Removal of a substance or object",
+          "nextQuestionRoute": "/removal/method",
+          "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/removal-of-any-substance-or-object\">removals</a>"
+        },
+        {
+          "id": "DREDGE",
+          "text": "Dredging",
+          "outcomeRoute": "/dredging/journey-select",
+          "hint": "Please note: The <u>disposal</u> of dredged material is a different activity to <u>dredging</u>. Disposal activities can be checked by choosing 'Deposit of a substance or object' but in most cases deposit or disposal of dredged material to sea will require a marine licence.<br/>Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/dredging\">dredging</a>"
+        },
+        {
+          "id": "INCINERATION",
+          "text": "Incineration of a substance or object",
+          "nextQuestionRoute": "/incineration/method",
+          "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/incineration-of-any-substance-or-object\">incineration</a>"
+        },
+        {
+          "id": "EXPLOSIVES",
+          "text": "Use of an explosive substance",
+          "outcomeRoute": "/exemption/licence-required-no-exemption",
+          "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/deposits#deposit-or-use-of-explosives\">explosives</a>"
+        },
+        {
+          "id": "SCUTTLING",
+          "text": "Sinking of a vessel or floating container",
+          "outcomeRoute": "/exemption/licence-required-no-exemption",
+          "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/scuttling-of-any-floating-vessel-or-container\">scuttling</a>"
+        }
+      ]
+    },
+    {
+      "route": "/deposit/method",
+      "text": "How will the substance or object be deposited?",
+      "section": "doINeedAMarineLicenceDeposit",
+      "answers": [
+        {
+          "id": "vehicleOrVessel",
+          "text": "From a vehicle or vessel",
+          "outcomeRoute": "/deposit/journey-select",
+          "hint": "'vessel' includes hovercraft and any other craft capable of travelling on, in or under water, whether or not self-propelled."
+        },
+        {
+          "id": "aircraft",
+          "text": "From an aircraft",
+          "outcomeRoute": "/deposit/journey-select"
+        },
+        {
+          "id": "marineStructure",
+          "text": "From a marine structure",
+          "outcomeRoute": "/deposit/journey-select",
+          "hint": "'marine structure' means a platform or other artificial structure at 'Sea', other than a pipeline."
+        },
+        {
+          "id": "floatingContainer",
+          "text": "From a floating container in the 'Sea'",
+          "outcomeRoute": "/deposit/journey-select"
+        },
+        {
+          "id": "landStructure",
+          "text": "From a structure on land constructed or adapted wholly or mainly for the purposes of depositing solids in the 'Sea'",
+          "outcomeRoute": "/deposit/journey-select"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/licence-not-required/deposit-method"
+        }
+      ]
+    },
+    {
+      "route": "/removal/method",
+      "text": "How will the removal be carried out?",
+      "section": "doINeedAMarineLicenceRemoval",
+      "answers": [
+        {
+          "id": "vehicleOrVessel",
+          "text": "Using a vehicle or vessel",
+          "nextQuestionRoute": "/removal",
+          "hint": "Includes using a winch or other device on the vehicle or vessel. </br>'Vessel' includes hovercraft and any other craft capable of travelling on, in or under water, whether or not self-propelled."
+        },
+        {
+          "id": "aircraft",
+          "text": "Using an aircraft",
+          "nextQuestionRoute": "/removal"
+        },
+        {
+          "id": "marineStructure",
+          "text": "Using a marine structure",
+          "nextQuestionRoute": "/removal",
+          "hint": "'marine structure' means a platform or other artificial structure at 'Sea', other than a pipeline."
+        },
+        {
+          "id": "floatingContainer",
+          "text": "Using a floating container in the 'Sea'",
+          "hint": "'Floating container' includes an 'airbag' or 'lifting bag'",
+          "nextQuestionRoute": "/removal"
+        },
+        {
+          "id": "landStructure",
+          "text": "Using a structure on land constructed or adapted wholly or mainly for the purposes of depositing solids in the 'Sea'",
+          "nextQuestionRoute": "/removal"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/licence-not-required/removal-method"
+        }
+      ]
+    },
+    {
+      "route": "/removal",
+      "text": "Will the substance or object to be removed, be removed from the 'Seabed'?",
+      "section": "doINeedAMarineLicenceRemoval",
+      "hint": "'Seabed' means the ground under the 'Sea' and anything resting on it such as a wreck. It includes the intertidal area of the sea or any river at such time as it is exposed temporarily at low tide.<p><p>'Sea' includes any area which is submerged at MHWS and the waters of every estuary, river or channel where the tide flows at MHWS tide up to the NTL. Even waters in areas which are closed permanently or intermittently by a lock or other artificial means against the regular action of the tide are included, where seawater flows into or out from the area, either continuously or from time to time.<p><p>Find out more about the MMO’s <a target=\"_blank\" href=\"https://www.gov.uk/guidance/marine-licensing-definitions#what-do-we-mean-by-the-sea\">jurisdiction</a>.",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/removal/journey-select"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/licence-not-required/removal-seabed"
+        }
+      ]
+    },
+    {
+      "route": "/incineration/method",
+      "text": "Where will the substance or object be incinerated?",
+      "section": "doINeedAMarineLicenceIncineration",
+      "answers": [
+        {
+          "id": "vehicle",
+          "text": "On a vehicle",
+          "outcomeRoute": "/exemption/licence-required-no-exemption"
+        },
+        {
+          "id": "vessel",
+          "text": "On a vessel",
+          "outcomeRoute": "/exemption/licence-required-no-exemption",
+          "hint": "'vessel' includes hovercraft and any other craft capable of travelling on, in or under water, whether or not self-propelled."
+        },
+        {
+          "id": "marineStructure",
+          "text": "On a marine structure",
+          "outcomeRoute": "/exemption/licence-required-no-exemption",
+          "hint": "'marine structure' means a platform or other artificial structure at 'Sea', other than a pipeline."
+        },
+        {
+          "id": "controlledFloatingContainer",
+          "text": "On a floating container",
+          "outcomeRoute": "/exemption/licence-required-no-exemption"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/licence-not-required/Incineration-on"
+        }
+      ]
+    },
+    {
+      "route": "/construction/activity",
+      "mcmsAppFormMapping": "ACTIVITY_SUBTYPE_CONSTRUCTION",
+      "text": "Please select an activity type that matches with the activity to be carried out.",
+      "hint": "<p>Only one activity type may be included in a self-service licence. The process may be repeated where additional self-service activities are required and criteria permits.</p><p>If you prefer to combine multiple self-service activity types listed in a single licence you will be subject to the standard marine licence process.</p><p>To apply for more than one of the activities listed below in a single application or to apply for a marine licence for an activity type not listed please select 'Other'.</p>",
+      "section": "activityType",
+      "answers": [
+        {
+          "id": "CON_MNTN_FT",
+          "text": "Maintenance of existing structures or assets",
+          "nextQuestionRoute": "/construction/maintenance-existing-works",
+          "hint": "'Maintenance' means the upkeep or repair of an existing structure or asset wholly within its existing 3 dimensional boundaries"
+        },
+        {
+          "id": "OTHER",
+          "text": "Other",
+          "outcomeRoute": "/standard-marine-licence-application/other-activity",
+          "hint": "An activity type not listed above"
+        }
+      ]
+    },
+    {
+      "route": "/deposit/activity",
+      "mcmsAppFormMapping": "ACTIVITY_SUBTYPE_DEPOSIT",
+      "text": "Please select an activity type that matches with the activity to be carried out.",
+      "hint": "<p>Only one activity type may be included in a self-service licence. The process may be repeated where additional self-service activities are required, where criteria permits.</p><p>If you prefer to combine multiple self-service activity types listed in a single licence you will be subject to the standard marine licence process.</p><p>To apply for more than one of the activities listed below in a single application or to apply for a marine licence for an activity type not listed please select 'Other'.</p>",
+      "section": "activityType",
+      "answers": [
+        {
+          "id": "DEPOSIT_MARKERS_FT",
+          "text": "Deposit of markers",
+          "nextQuestionRoute": "/deposit/markers/harbour-authority"
+        },
+        {
+          "id": "BAS",
+          "text": "Burial at Sea",
+          "hint": "The Burial at Sea of the human remains of the deceased identified in the associated application, subject to the criteria and conditions contained in the licence document.",
+          "nextQuestionRoute": "/burial-at-sea/completion"
+        },
+        {
+          "id": "OTHER",
+          "text": "Other",
+          "outcomeRoute": "/standard-marine-licence-application/other-activity",
+          "hint": "An activity type not listed above"
+        }
+      ]
+    },
+    {
+      "route": "/removal/activity",
+      "mcmsAppFormMapping": "ACTIVITY_SUBTYPE_REMOVAL",
+      "text": "Please select an activity type that matches with the activity to be carried out.",
+      "hint": "<p>Only one activity type may be included in a self-service licence. The process may be repeated where additional self-service activities are required, where criteria permits.</p><p>If you prefer to combine multiple self-service activity types listed in a single licence you will be subject to the standard marine licence process.</p><p>To apply for more than one of the activities listed below in a single application or to apply for a marine licence for an activity type not listed please select 'Other'.</p>",
+      "section": "activityType",
+      "answers": [
+        {
+          "id": "REM_MINOR_FT",
+          "text": "Minor removals",
+          "nextQuestionRoute": "/removal/activities"
+        },
+        {
+          "id": "OTHER",
+          "text": "Other",
+          "outcomeRoute": "/standard-marine-licence-application/other-activity",
+          "hint": "An activity type not listed above"
+        }
+      ]
+    },
+    {
+      "route": "/dredging/activity",
+      "mcmsAppFormMapping": "ACTIVITY_SUBTYPE_DREDGING",
+      "text": "Please select an activity type that matches with the activity to be carried out.",
+      "hint": "<p>Only one activity type may be included in a self-service licence. The process may be repeated where additional self-service activities are required, where criteria permits.</p><p>If you prefer to combine multiple self-service activity types listed in a single licence you will be subject to the standard marine licence process.</p><p>To apply for more than one of the activities listed below in a single application or to apply for a marine licence for an activity type not listed please select 'Other'.</p>",
+      "section": "activityType",
+      "answers": [
+        {
+          "id": "DREDGE_CLEARANCE_FT",
+          "text": "Non-navigational clearance dredging",
+          "nextQuestionRoute": "/dredging/activities"
+        },
+        {
+          "id": "DREDGE_BEACH_FT",
+          "text": "Beach maintenance activities",
+          "nextQuestionRoute": "/dredging/beach-maintenance/activities"
+        },
+        {
+          "id": "OTHER",
+          "text": "Other",
+          "outcomeRoute": "/standard-marine-licence-application/other-activity",
+           "hint": "An activity type not listed above"
+        }
+      ]
+    },
+    {
+      "route": "/construction/maintenance-existing-works",
+      "text": "Please select sub-activites that match with activities proposed to be carried out.",
+      "section": "subactivityType",
+      "hint": "When selecting sub-activities please read each activity description carefully. You must be satisfied that your activity does not extend beyond the scope of that set out. <br/> NOTE: Multiple sub-activities can be selected.",
+      "mcmsAppFormMapping": "MAINTENANCE_EXISTING_WORKS_ACTIVITIES",
+      "multiSelect": {
+        "questionRoute": "/construction/maintenance-existing-works/scaffolding",
+        "outcomeRoute": "/standard-marine-licence-application/other-maintenance",
+        "outcomeAnswerId": "OTHER_MAINTENANCE"
+      },
+      "answers": [
+        {
+          "id": "SCAFFOLDING_ACCESS_TOWERS",
+          "text": "Scaffolding or access towers",
+          "hint": "The erection and subsequent removal of scaffolding and or access towers for the purpose of maintaining existing structures or assets described in the associated application, subject to the criteria and conditions contained in this licence document."
+        },
+        {
+          "id": "REPAINTING_STRUCTURES",
+          "text": "Re-painting of existing structures or assets",
+          "hint": "The re-painting of existing structures or assets, including preparation work, described in the associated application, subject to the criteria and conditions contained in the licence document. 'Preparation' is defined as the basic cleaning or priming of the existing surface to enable re-painting to occur."
+        },
+        {
+          "id": "SAND_GRIT_BLASTING",
+          "text": "Sand or grit blasting",
+          "hint": "The use of sand or grit blasting undertaken for the purpose of maintaining an existing structure or asset described in the associated application, subject to the criteria and conditions contained in the licence document."
+        },
+        {
+          "id": "REMOVAL_MARINE_GROWTH",
+          "text": "Removal of marine growth",
+          "hint": "The removal of marine growth and guano from existing structures or assets (excluding vessels) described in the associated application, subject to the criteria and conditions contained in the licence document. The removal may only be undertaken using unheated water. No chemicals, biocides are permitted. The marine growth must be removed from the structure or asset in-situ."
+        },
+        {
+          "id": "RERENDER_RESURFACE_REPOINT",
+          "text": "Re-rendering, resurfacing or repointing of existing structures or slipways",
+          "hint": "The re-rendering, resurfacing or repointing of existing structures or slipways within existing boundaries, described in the associated application and subject to the criteria and conditions contained in the licence document."
+        },
+        {
+          "id": "REMOVAL_SINGLE_PILE_CON",
+          "text": "Removal of a single pile",
+          "hint": "The removal of a single pile not exceeding 1m in diameter and not displaying any aids to navigation, described in the associated application, subject to the criteria and conditions contained in the licence document."
+        },
+        {
+          "id": "REPLACING_SINGLE_PILE",
+          "text": "Replacing a single pile",
+          "hint": "The replacement of a single pile not exceeding 1m in diameter described in the associated application, subject to the criteria and conditions contained in the licence document."
+        },
+        {
+          "id": "INSTALLATION_LADDERS",
+          "text": "Installation of ladders",
+          "hint": "The installation of ladders at a location on an existing structure or asset described in the associated application,  where they were not previously found, subject to the criteria and conditions contained in the licence document."
+        },
+        {
+          "id": "MINOR_MAINTENANCE",
+          "text": "Minor maintenance",
+          "hint": "Minor maintenance comprising the upkeep or small scale repair of an existing structure or asset within its existing 3 dimensional boundaries described in the associated application, subject to the criteria and conditions contained in the licence document. Minor maintenance includes the replacement or reasonable improvement of removable items or ancillary equipment which form part of the structure/asset."
+        },
+        {
+          "id": "OTHER_MAINTENANCE",
+          "text": "Other maintenance"
+        }
+      ]
+    },
+    {
+      "route": "/construction/maintenance-existing-works/scaffolding",
+      "text": "Will the proposed activity impede safe or normal navigation through the reduction of head clearance or navigational channel width?",
+      "section": "navigationalRisk",
+      "answers": [
+        {
+          "id": "YES",
+          "text": "Yes",
+          "nextQuestionRoute": "/construction/maintenance-existing-works/scaffolding/harbour-authority"
+        },
+        {
+          "id": "NO",
+          "text": "No",
+          "nextQuestionRoute": "/activity/completion"
+        }
+      ]
+    },
+    {
+      "route": "/construction/maintenance-existing-works/scaffolding/harbour-authority",
+      "text": "Will the proposed activity be carried out within the jurisdiction of a harbour authority?",
+      "section": "navigationalRisk",
+      "answers": [
+        {
+          "id": "YES",
+          "text": "Yes",
+          "nextQuestionRoute": "/construction/maintenance-existing-works/scaffolding/harbour-authority-agreed"
+        },
+        {
+          "id": "NO",
+          "text": "No",
+          "nextQuestionRoute": "/construction/maintenance-existing-works/scaffolding/mca-th-agreed"
+        }
+      ]
+    },
+    {
+      "route": "/construction/maintenance-existing-works/scaffolding/harbour-authority-agreed",
+      "text": "Has a method been agreed with the harbour authority?",
+      "section": "navigationalRisk",
+      "mcmsAppFormMapping": "SCAFFOLDING_HA_METHOD",
+      "answers": [
+        {
+          "id": "YES",
+          "text": "Yes",
+          "nextQuestionRoute": "/activity/completion"
+        },
+        {
+          "id": "NO",
+          "text": "No",
+          "outcomeRoute": "/scaffolding-impede-navigation"
+        }
+      ]
+    },
+    {
+      "route": "/construction/maintenance-existing-works/scaffolding/mca-th-agreed",
+      "text": "Has a method been agreed with the Maritime and Coastguard Agency and/or Trinity House?",
+      "section": "navigationalRisk",
+      "mcmsAppFormMapping": "SCAFFOLDING_MCA_TH_METHOD",
+      "answers": [
+        {
+          "id": "YES",
+          "text": "Yes",
+          "nextQuestionRoute": "/activity/completion"
+        },
+        {
+          "id": "NO",
+          "text": "No",
+          "outcomeRoute": "/scaffolding-mca-th-agreed"
+        }
+      ]
+    },
+    {
+      "route": "/deposit/markers/harbour-authority",
+      "text": "Will the proposed activity be carried out within the jurisdiction of a harbour authority?",
+      "section": "navigationalRisk",
+      "answers": [
+        {
+          "id": "YES",
+          "text": "Yes",
+          "nextQuestionRoute": "/deposit/markers/lighting-ha"
+        },
+        {
+          "id": "NO",
+          "text": "No",
+          "nextQuestionRoute": "/deposit/markers/lighting-th"
+        }
+      ]
+    },
+    {
+      "route": "/deposit/markers/lighting-ha",
+      "text": "Have lighting and configuration requirements been agreed with the harbour authority?",
+      "section": "navigationalRisk",
+      "mcmsAppFormMapping": "DEPOSIT_MARKERS_HA_LIGHTING",
+      "answers": [
+        {
+          "id": "YES",
+          "text": "Yes",
+          "nextQuestionRoute": "/deposit/markers/activities"
+        },
+        {
+          "id": "NO",
+          "text": "No",
+          "outcomeRoute": "/markers/ha-not-agreed"
+        }
+      ]
+    },
+    {
+      "route": "/deposit/markers/lighting-th",
+      "text": "Have lighting and configuration requirements been agreed with Trinity House?",
+      "section": "navigationalRisk",
+      "mcmsAppFormMapping": "DEPOSIT_MARKERS_TH_LIGHTING",
+      "answers": [
+        {
+          "id": "YES",
+          "text": "Yes",
+          "nextQuestionRoute": "/deposit/markers/activities"
+        },
+        {
+          "id": "NO",
+          "text": "No",
+          "outcomeRoute": "/markers/th-not-agreed"
+        }
+      ]
+    },
+    {
+      "route": "/burial-at-sea/completion",
+      "text": "Will the proposed activity be completed within 3 months from the date of submission?",
+      "hint": "Activities which cannot be completed within the 3 month period following the issue of the licence are not suitable for self-service marine licensing.",
+      "section": "durationOfWorks",
+      "answers": [
+        {
+          "id": "YES",
+          "text": "Yes",
+          "nextQuestionRoute": "/burial-at-sea/site"
+        },
+        {
+          "id": "NO",
+          "text": "No",
+          "outcomeRoute": "/standard-marine-licence-application/bas-duration"
+        }
+      ]
+    },
+    {
+      "route": "/burial-at-sea/site",
+      "text": "Please select a burial site:",
+      "mcmsAppFormMapping": "BAS_SITE",
+      "answers": [
+        {
+          "id": "WI090",
+          "text": "Needles, Isle of Wight",
+          "nextQuestionRoute": "/burial-at-sea/site/needles"
+        },
+        {
+          "id": "TY193",
+          "text": "Tynemouth, Northumberland",
+          "nextQuestionRoute": "/burial-at-sea/site/tynemouth"
+        },
+        {
+          "id": "WI011",
+          "text": "Between Hastings and Newhaven, South Coast",
+          "nextQuestionRoute": "/burial-at-sea/site/between-hastings-and-newhaven"
+        },
+        {
+          "id": "OTHER",
+          "text": "Other location",
+          "outcomeRoute": "/standard-marine-licence-application/bas-other-location"
+        }
+      ]
+    },
+    {
+      "route": "/burial-at-sea/site/needles",
+      "text": "Has all relevant documentation relating to the deceased been obtained?",
+      "hint": "'Relevant documentation' means: <p><br/></li><li>a death certificate<br/></li><li>a Certificate of Freedom from Fever and Infection (available from the deceased person’s GP or hospital doctor)<br/> </li><li>a Notice to a Coroner of Intention to Remove a Body out of England (available from the coroner in exchange for a Certificate of Disposal provided by the registrar)<br/> </li><li>a signed DNA sample consent form (required for The Needles site only).<p><p>Additional information about relevant documentation can be found at <a target=\"_blank\" href=\"https://www.gov.uk/guidance/how-to-get-a-licence-for-a-burial-at-sea-in-england\"> GOV.UK</a>.<p>",
+      "answers": [        {
+          "id": "YES",
+          "text": "Yes",
+          "outcomeRoute": "/fast-track-mla"
+        },
+        {
+          "id": "NO",
+          "text": "No",
+          "outcomeRoute": "/fast-track-mla/bas-block"
+        }
+      ]
+    },
+    {
+      "route": "/burial-at-sea/site/tynemouth",
+      "text": "Has all relevant documentation relating to the deceased been obtained?",
+      "hint": "'Relevant documentation' means: <p><br/></li><li>a death certificate<br/></li><li>a Certificate of Freedom from Fever and Infection (available from the deceased person’s GP or hospital doctor)<br/> </li><li>a Notice to a Coroner of Intention to Remove a Body out of England (available from the coroner in exchange for a Certificate of Disposal provided by the registrar)<p><p>Additional information about relevant documentation can be found at <a target=\"_blank\" href=\"https://www.gov.uk/guidance/how-to-get-a-licence-for-a-burial-at-sea-in-england\"> GOV.UK</a>.<p>",
+      "answers": [
+        {
+          "id": "YES",
+          "text": "Yes",
+          "outcomeRoute": "/fast-track-mla"
+        },
+        {
+          "id": "NO",
+          "text": "No",
+          "outcomeRoute": "/fast-track-mla/bas-block"
+        }
+      ]
+    },
+    {
+      "route": "/burial-at-sea/site/between-hastings-and-newhaven",
+      "text": "Has all relevant documentation relating to the deceased been obtained?",
+      "hint": "'Relevant documentation' means: <p><br/></li><li>a death certificate<br/></li><li>a Certificate of Freedom from Fever and Infection (available from the deceased person’s GP or hospital doctor)<br/> </li><li>a Notice to a Coroner of Intention to Remove a Body out of England (available from the coroner in exchange for a Certificate of Disposal provided by the registrar)<p><p>Additional information about relevant documentation can be found at <a target=\"_blank\" href=\"https://www.gov.uk/guidance/how-to-get-a-licence-for-a-burial-at-sea-in-england\"> GOV.UK</a>.<p>",
+      "answers": [
+        {
+          "id": "YES",
+          "text": "Yes",
+          "outcomeRoute": "/fast-track-mla"
+        },
+        {
+          "id": "NO",
+          "text": "No",
+          "outcomeRoute": "/fast-track-mla/bas-block"
+        }
+      ]
+    },
+    {
+      "route": "/removal/activities",
+      "text": "Please select sub-activites that match with activities proposed to be carried out.",
+      "section": "subactivityType",
+      "mcmsAppFormMapping": "MINOR_REMOVALS_ACTIVITIES",
+      "multiSelect": {
+        "questionRoute": "/activity/completion",
+        "outcomeRoute": "/standard-marine-licence-application/other-removals",
+        "outcomeAnswerId": "OTHER_REMOVALS"
+      },
+      "answers": [
+        {
+          "id": "LITTER",
+          "text": "Litter",
+          "hint": "The removal of litter, using vehicles or vessels, described in the associated application and subject to the criteria and conditions contained in the licence document. In this case the term 'litter' is defined as an accumulation of items and materials below mean high water springs (MHWS). This includes marine litter which has been collected by hand (specifically a mass of items rather than discrete object) but is subsequently stored below MHWS to be removed using a vehicle or vessel."
+        },
+        {
+          "id": "DISCREET_MINOR_OBJECTS",
+          "text": "Discreet minor objects",
+          "hint": "The removal of discrete minor objects of recent origin from the seabed, described in the associated application, subject to the criteria and conditions contained in the licence document. 'Minor objects' is defined as discrete debris. 'Recent origin' is defined as an object appearing to be no more than 10 years old."
+        },
+        {
+          "id": "DISCREET_MINOR_OBJECTS_HERITAGE",
+          "text": "Discreet minor objects from heritage designations",
+          "hint": "The removal of discrete minor objects from a heritage designation described in the associated application, subject to the criteria and conditions contained in the licence document. The activity must be carried out in accordance with a valid consent or agreed method statement from Historic England (or relevant local authority in respect of listed buildings). \"Heritage designation\" is defined as:- Protected wrecks designated under the Protection of Wrecks Act 1973; Scheduled monuments designated under the Ancient Monuments and Archaeological Areas Act 1979; and Listed buildings designated under The Planning (Listed Buildings and Conservation Area) Act 1990."
+        },
+        {
+          "id": "DISCREET_MINOR_OBJECTS_ARC_HIST",
+          "text": "Discreet minor objects of archaeological or historic interest",
+          "hint": "The removal of discrete minor objects of archaeological or historic interest from the seabed, described in the associated application, subject to the criteria and conditions contained in the licence document. \"Minor objects\" is defined as discrete debris. \"Archaeological or historic interest\" includes all traces of human existence having a cultural, historical or archaeological character such as: (i) sites, structures, buildings, artefacts and human remains, together with their archaeological and natural context; (ii) vessels, aircraft, other vehicles or any part thereof, their cargo or other contents, together with their archaeological and natural context; and (iii) objects of prehistoric character."
+        },
+        {
+          "id": "BOREHOLES",
+          "text": "Boreholes",
+          "hint": "The taking of boreholes up to 4 cubic metres in volume described in the associated application, subject to the criteria and conditions contained in the licence document. Within 1 nm of the shore: 1) Each borehole must be located at least 25 metres from any other borehole included in the same application. 2) The maximum number of boreholes must not exceed 5 including any under other licences which form as part of the project as a whole. Beyond 1nm of the shore: 1) Each borehole must be located at least 500 metres from any other borehole included in the same application. 2) The maximum number of boreholes must not exceed 20 including any under other licences which form as part of the project as a whole."
+        },
+        {
+          "id": "TRIAL_PITS",
+          "text": "Trial pits",
+          "hint": "The excavation and reinstatement of trial pits described in the associated application, subject to the criteria and conditions contained in the licence document. Within 1 nm of the shore: 1) The pit is no larger than 1 metre x 4 metres in plan area and 2 metres depth; 2) The pit is at least 25 metres from any other trial pit included in the same application; and 3) The total number of trial pits does not exceed 5 including any under other licences which form as part of the project as a whole. Beyond 1nm of the shore: 1) The pit is no larger than 2 metres x 4 metres in plan area and up to 2 metres depth. 2) Each trial pit must be located at least 100 metres from any other trial pit included in the same application. 3) The total number of trial pits does not exceed 20 including any under other licences which form as part of the project as a whole."
+        },
+        {
+          "id": "GRAB_SAMPLES",
+          "text": "Grab samples",
+          "hint": "The taking of grab samples (sediment samples) up to 4 cubic metres in volume, described in the associated application, subject to the criteria and conditions contained in the licence document. Within 1 nm of the shore: 1) Each grab must be located at least 25 metres from any other grab included in the same application. 2) The maximum number of grabs must not exceed 5 including any under other licences which form as part of the project as a whole. Beyond 1nm of the shore: 1) Each grab is located at least 500 metres from any other grabs including those in the same application. 2) The maximum number of grabs does not exceed 20 including any under other licences which form as part of the project as a whole."
+        },
+        {
+          "id": "REMOVAL_SINGLE_PILE",
+          "text": "Removal of a single pile",
+          "hint": "The removal of a single pile not exceeding 1m in diameter and not displaying any aids to navigation, described in the associated application, subject to the criteria and conditions contained in the licence document."
+        },
+        {
+          "id": "OTHER_REMOVALS",
+          "text": "Other removals"
+        }
+      ]
+    },
+    {
+      "route": "/dredging/activities",
+      "text": "Please select sub-activites that match with activities proposed to be carried out.",
+      "section": "subactivityType",
+      "mcmsAppFormMapping": "CLEARANCE_DREDGING_ACTIVITIES",
+      "multiSelect": {
+        "questionRoute": "/activity/completion",
+        "outcomeRoute": "/standard-marine-licence-application/other-clearance-dredging",
+        "outcomeAnswerId": "OTHER_CLEARANCE_DREDGING"
+      },
+      "answers": [
+        {
+          "id": "CLEARANCE_DREDGING_HERITAGE",
+          "text": "Non-navigational clearance dredging (within a heritage designation or a wreck site elsewhere in the sea)",
+          "hint": "The removal of material within a heritage designation or a wreck site elsewhere in the sea, described in the associated application, subject to the criteria and conditions contained in the licence document.  The activity must be for the purpose of preserving a historic asset or exposing such an asset for the same purpose, or for the purpose of archaeological survey or investigation. The activity must be carried out in accordance with a valid consent or agreed method statement from Historic England. The maximum amount of material removed cannot exceed 500 cubic metres in a single dredge campaign and cannot exceed 1500 cubic metres in any 12 month period. The maximum footprint of material to be removed cannot exceed 350 square metres in a single dredge campaign. \"Heritage designation\" is defined as:- Protected wrecks designated under the Protection of Wrecks Act 1973; Scheduled monuments designated under the Ancient Monuments and Archaeological Areas Act 1979; and Listed buildings designated under The Planning (Listed Buildings and Conservation Area) Act 1990. \"Wreck site\" the location of any aircraft or vessel lying wrecked on or in the seabed or of any objects contained or formerly contained in it lying on or in the seabed near the wreck."
+        },
+        {
+          "id": "CLEARANCE_DREDGING_OPERATIONAL",
+          "text": "Non-navigational clearance dredging (for operational purposes)",
+          "hint": "The removal of material which has accumulated around/within a structure described in the associated application, that is clearly impacting the structures ability to operate, subject to the criteria and conditions contained in the licence document. This may include but is not limited to removing silt from: intake pipes, outfalls, valves or beneath pontoons. The maximum amount of material removed cannot exceed 500 cubic metres in a single dredge campaign and cannot exceed 1500 cubic metres in any 12 month period. Individual dredge campaigns must be separated by at least one month. The maximum footprint of material to be removed cannot exceed 350 square metres in a single dredge campaign."
+        },
+        {
+          "id": "OTHER_CLEARANCE_DREDGING",
+          "text": "Other clearance dredging"
+        }
+      ]
+    },
+    {
+      "route": "/dredging/beach-maintenance/activities",
+      "text": "Please select sub-activites that match with activities proposed to be carried out.",
+      "section": "subactivityType",
+      "mcmsAppFormMapping": "BEACH_MAINTENANCE_ACTIVITIES",
+      "multiSelect": {
+        "questionRoute": "/activity/completion",
+        "outcomeRoute": "/standard-marine-licence-application/other-beach-maintenance",
+        "outcomeAnswerId": "OTHER_BEACH_MAINTENANCE"
+      },
+      "answers": [
+        {
+          "id": "BEACH_REPROFILING",
+          "text": "Beach re-profiling",
+          "hint": "The re-profiling of a beach described in the associated application, subject to the criteria and conditions contained in the licence document.  'Re-profiling' is defined as the movement of beach material up or down the beach. The profile must be consistent with one that existed at the location in the previous 10 years."
+        },
+        {
+          "id": "BEACH_RECYCLING",
+          "text": "Beach recycling",
+          "hint": "The recycling of material on a beach described in the associated application, subject to the criteria and conditions contained in the licence document. 'Recycling' is defined as the movement of material along the beach from areas of accretion to areas of erosion within the beach."
+        },
+        {
+          "id": "REPLACING_WIND_BLOWN_SAND",
+          "text": "Replacing wind blown sand",
+          "hint": "The direct return of recently deposited wind-blown sand to its area of origin on a beach, described in the associated application, subject to the criteria and conditions contained in the licence document."
+        },
+        {
+          "id": "OTHER_BEACH_MAINTENANCE",
+          "text": "Other beach maintenance"
+        }
+      ]
+    },
+    {
+      "route": "/deposit/markers/activities",
+      "text": "Please select sub-activites that match with activities proposed to be carried out.",
+      "section": "subactivityType",
+      "mcmsAppFormMapping": "DEPOSIT_MARKERS_ACTIVITIES",
+      "multiSelect": {
+        "questionRoute": "/activity/completion",
+        "outcomeRoute": "/standard-marine-licence-application/other-deposits",
+        "outcomeAnswerId": "OTHER_DEPOSITS"
+      },
+      "answers": [
+        {
+          "id": "MARKER_POSTS",
+          "text": "Marker posts",
+          "hint": "The deposit of marker posts for the purpose of marking channels, shallow water areas, points of interest, the end of outfalls, groynes and similar, described in the associated application, subject to the criteria and conditions contained in the licence document."
+        },
+        {
+          "id": "MARKER_BUOYS",
+          "text": "Marker buoys",
+          "hint": "The deposit and subsequent removal of marker buoys for the purpose of marking channels, shallow water areas, points of interest, the end of outfalls, groynes and similar, including racing markers, described in the associated application, subject to the criteria and conditions contained in the licence document."
+        },
+        {
+          "id": "OTHER_DEPOSITS",
+          "text": "Other deposits"
+        }
+      ]
+    },
+    {
+      "route": "/activity/completion",
+      "text": "Will the proposed activities be completed within 12 months from the date of submission?",
+      "hint": "Activities which cannot be completed within the 12 month period following the issue of the licence are not suitable for self-service marine licensing.",
+      "section": "durationOfWorks",
+      "answers": [
+        {
+          "id": "YES",
+          "text": "Yes",
+          "nextQuestionRoute": "/public-register"
+        },
+        {
+          "id": "NO",
+          "text": "No",
+          "outcomeRoute": "/standard-marine-licence-application/duration"
+        }
+      ]
+    },
+    {
+      "route": "/public-register",
+      "text": "Is there any information in your application (including supporting documents) that you believe should be withheld from the MMO Public Register?",
+      "hint": "<p>The MMO is required to maintain a register of activities. Information contained within or provided in support of applications will therefore be placed on the MMO's Public Register. Information may be withheld if the MMO determines that:<ul><li>its disclosure would be contrary to the interests of national security; or</li><li>its disclosure would adversely affect confidentiality of commercial or industrial information where such confidentiality is provided by law to protect legitimate commercial interest.</li></ul></p><p>Self-service applications and supporting information will be published on the MMO public register in full. If you indicate any of the information provided should be withheld for one of the reasons set out you will be redirected to standard licensing so that the request can be considered against the appropriate framework.</p>",
+      "section": "publicRegister",
+      "answers": [
+        {
+          "id": "YES",
+          "text": "Yes",
+          "outcomeRoute": "/standard-marine-licence-application/public-register"
+        },
+        {
+          "id": "NO",
+          "text": "No",
+          "nextQuestionRoute": "/part-of-larger-project"
+        }
+      ]
+    },
+    {
+      "route": "/part-of-larger-project",
+      "text": "Are the activities part of a larger project?",
+      "hint": "Self-service marine licensing is intended to enable small scale low risk activities to be regulated in a proportionate manner. Activities forming part of active larger projects which require environmental impact assessment will not be suitable for self-service.<p><p>Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/marine-licensing-impact-assessments#EIA\"> EIA </a>",
+      "section": "largerProject",
+      "answers": [
+        {
+          "id": "YES",
+          "text": "Yes",
+          "nextQuestionRoute": "/eia-directive"
+        },
+        {
+          "id": "NO",
+          "text": "No",
+          "nextQuestionRoute": "/single-location"
+        }
+      ]
+    },
+    {
+      "route": "/eia-directive",
+      "text": "Does the project include any of the following: </li><li> construction of something new; </li><li>dismantling or decommissioning; </li><li>the reclamation of land from the sea.",
+      "hint": "The question seeks to establish whether the project that the activity forms part of is one that is likely to fall within <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2007/1518/schedule/A1\"> schedule A1</a> or <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2007/1518/schedule/A2\"> schedule A2 </a>  of the Marine Works (Environmental Impact Assessment) Regulations 2007 (As amended). If you believe your project is one capable of falling within schedule A1 or A2 you should answer 'yes'.",
+      "section": "eiaDirective",
+      "answers": [
+        {
+          "id": "YES",
+          "text": "Yes",
+          "nextQuestionRoute": "/activities/ground"
+        },
+        {
+          "id": "NO",
+          "text": "No",
+          "nextQuestionRoute": "/single-location"
+        }
+      ]
+    },
+    {
+      "route": "/activities/ground",
+      "text": "Are the activities related to ground investigations or similar, the purpose of which is to inform assessment of the likely impacts of the project?",
+      "section": "groundInvestigation",
+      "answers": [
+        {
+          "id": "YES",
+          "text": "Yes",
+          "nextQuestionRoute": "/single-location"
+        },
+        {
+          "id": "NO",
+          "text": "No",
+          "nextQuestionRoute": "/screening-screened-out"
+        }
+      ]
+    },
+    {
+      "route": "/screening-screened-out",
+      "text": "Has a screening opinion been requested and project \"screened out\" by the MMO?",
+      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/marine-licensing-impact-assessments#EIA\">screening</a>",
+      "section": "screeningOpinion",
+      "answers": [
+        {
+          "id": "YES",
+          "text": "Yes",
+          "nextQuestionRoute": "/single-location"
+        },
+        {
+          "id": "NO",
+          "text": "No",
+          "outcomeRoute": "/not-screened-out"
+        }
+      ]
+    },
+    {
+      "route": "/single-location",
+      "text": "Will the proposed activity be carried out at a single location not exceeding an area covering 10 square miles?",
+      "hint": "Self-service marine licensing is intended to enable small scale low risk activities to be regulated in a proportionate manner and as such activities carried out at locations that exceed an area covering 10 square miles will not be suitable for self-service.<p><p> Despite the maximum coverage extent of 10 square miles you should always be as specific as possible when defining the area(s) that your activity will be carried out. This means that in circumstances where you intend to carry out multiple activities over a larger area the MMO advises that these areas are broken down into individual sites rather than being treated as a single overarching site. In order to do this you must answer 'No' to the above question. <p> The <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\">MMO GIS site search tool</a> contains a measuring tool to assist. <p>Further, to find out how to use the drawing tool in <a target=\"_blank\" href=\"https://magic.defra.gov.uk/MagicMap.aspx\"> Magic Maps</a> to produce a shapefile that can be used to easily upload site locations to any future application watch the <a target=\"_blank\" href=\"https://www.youtube.com/watch?v=q9OT4wSD2JE \"> MMO coordinate video </a>.",
+      "section": "activityLocation",
+      "mcmsAppFormMapping": "SINGLE_LOCATION",
+      "answers": [
+        {
+          "id": "YES",
+          "text": "Yes",
+          "nextQuestionRoute": "/military-defence-area"
+        },
+        {
+          "id": "NO",
+          "text": "No",
+          "nextQuestionRoute": "/multiple-locations"
+        }
+      ]
+    },
+    {
+      "route": "/multiple-locations",
+      "text": "If multiple activity locations are proposed will each activity location be within 10 miles of the other and not exceed a total area of 10 square miles?",
+      "hint": "Self-service marine licensing is intended to enable small scale low risk activities to be regulated in a proportionate manner and as such activities carried out at locations that exceed an area covering 10 square miles will not be suitable for self-service.<p><p> Despite the maximum coverage extent of 10 square miles you should always be as specific as possible when defining the area(s) that your activity will be carried out. This means that in circumstances where you intend to carry out multiple activities over a larger area the MMO advises that these areas are broken down into individual sites rather than being treated as a single overarching site. <p> The <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\">MMO GIS site search tool</a> contains a measuring tool to assist. <p>Further, to find out how to use the drawing tool in <a target=\"_blank\" href=\"https://magic.defra.gov.uk/MagicMap.aspx\"> Magic Maps</a> to produce a shapefile that can be used to easily upload site locations to any future application watch the <a target=\"_blank\" href=\"https://www.youtube.com/watch?v=q9OT4wSD2JE \"> MMO coordinate video </a>.",
+      "section": "multipleLocations",
+      "answers": [
+        {
+          "id": "YES",
+          "text": "Yes",
+          "nextQuestionRoute": "/military-defence-area"
+        },
+        {
+          "id": "NO",
+          "text": "No",
+          "outcomeRoute": "/standard-marine-licence-application/ten-square-miles"
+        }
+      ]
+    },
+    {
+      "route": "/military-defence-area",
+      "text": "Will the activities be carried out in an area used for military or defence purposes?",
+      "hint": "<p>UK waters are a crucial environment in which MOD (Ministry of Defence - including HM Armed Forces and the Royal Fleet Auxiliary) must maintain and deploy the operational capability required to achieve security for the people of the UK and Overseas Territories.</p><p>The MOD has the power to regulate sea areas and restrict their use either temporarily or permanently. Marine activities should not prejudice the interest of defence and national security.</p><p>Activities proposed to be carried out in areas used for military or defence purposes will not be suitable for self-service unless the activity is carried out by or on behalf of the MOD or the MOD has been consulted and permission to carry out the activity has been granted.</p><p>If you are unsure of whether the activity falls within such an area you should select the appropriate layer(s) in the <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\">MMO self-service GIS tool</a>.</p>",
+      "section": "defence",
+      "answers": [
+        {
+          "id": "YES",
+          "text": "Yes",
+          "nextQuestionRoute": "/ministry-of-defence"
+        },
+        {
+          "id": "NO",
+          "text": "No",
+          "nextQuestionRoute": "/admiralty-chart"
+        }
+      ]
+    },
+    {
+      "route": "/ministry-of-defence",
+      "text": "Will the activity be carried out by or on behalf of the MOD?",
+      "section": "modActivity",
+      "answers": [
+        {
+          "id": "YES",
+          "text": "Yes",
+          "nextQuestionRoute": "/admiralty-chart"
+        },
+        {
+          "id": "NO",
+          "text": "No",
+          "nextQuestionRoute": "/ministry-of-defence/permission"
+        }
+      ]
+    },
+    {
+      "route": "/ministry-of-defence/permission",
+      "text": "Has permission from the MOD been sought and granted?",
+      "hint": "<p>For queries regarding permissions to carry out activities within military/defence areas, please contact the MOD at:<br/><ul><li>Jon Wilson (DIO estates safeguarding)</li><li>DIOSEE-EPSSG3@mod.uk</li></ul></p>",
+      "section": "modPermission",
+      "answers": [
+        {
+          "id": "YES",
+          "text": "Yes",
+          "nextQuestionRoute": "/admiralty-chart"
+        },
+        {
+          "id": "NO",
+          "text": "No",
+          "outcomeRoute": "/mod-permission"
+        }
+      ]
+    },
+    {
+      "route": "/admiralty-chart",
+      "text": "Will the activity be carried out on a site that is shown on an admiralty chart as hosting cables, pipelines or other structures?",
+      "hint": "<p>The UK marine area has many existing uses. Self-service marine licensing is intended to enable small scale low risk activities to be regulated in a proportionate manner. New activities have the potential to impact or conflict with existing uses where they are not related and therefore more detailed consideration ensuring compliance with the Marine Policy Statement and relevant Marine plans where they exist is necessary.</p><p>Activities proposed to be carried out on a site that is shown on an admiralty chart as hosting cables, pipelines or other existing assets or structures will not be suitable for self-service unless the proposed activity is for the purpose of marking, maintaining or otherwise enabling the continued use of the asset or structure.</p><p>If you are unsure of whether the activity falls within such an area you should select the appropriate layer(s) in the <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\">MMO self-service GIS tool</a>.</p>",
+      "section": "otherUsesOfTheSea",
+      "answers": [
+        {
+          "id": "YES",
+          "text": "Yes",
+          "nextQuestionRoute": "/admiralty-chart/continued-use"
+        },
+        {
+          "id": "NO",
+          "text": "No",
+          "nextQuestionRoute": "/routing-measure"
+        }
+      ]
+    },
+    {
+      "route": "/admiralty-chart/continued-use",
+      "text": "Is the proposed activity for the purpose of marking, maintenance or otherwise to enable the continued use of the asset or structure?",
+      "section": "otherUsesOfTheSea",
+      "answers": [
+        {
+          "id": "YES",
+          "text": "Yes",
+          "nextQuestionRoute": "/routing-measure"
+        },
+        {
+          "id": "NO",
+          "text": "No",
+          "nextQuestionRoute": "/intrusive-nature"
+        }
+      ]
+    },
+    {
+      "route": "/intrusive-nature",
+      "text": "Is the proposed activity intrusive in nature (dredging, boreholes, trial pits, grab samples etc)?",
+      "section": "otherUsesOfTheSea",
+      "answers": [
+        {
+          "id": "YES",
+          "text": "Yes",
+          "outcomeRoute": "/standard-marine-licence-application/intrusive-in-nature"
+        },
+        {
+          "id": "NO",
+          "text": "No",
+          "nextQuestionRoute": "/routing-measure"
+        }
+      ]
+    },
+    {
+      "route": "/routing-measure",
+      "text": "Will the activity take place within an International Maritime Organisation (IMO) routing measure?",
+      "hint": "<p>IMO routing measures are part of a system which helps ships to follow predetermined routes to avoid hazards to navigation at sea. Navigational hazards include but are not limited to risk of collision with traffic in areas of high transit volume, shallow water areas, and areas where certain ships have potential to damage the marine environment and ecology.</p><p>Activities proposed to be carried out within an IMO routing measure are not suitable for self-service unless the proposed activity is related to the maintenance or management of the measure.</p><p>If you are unsure of whether the activity falls within such an area you should select the appropriate layer(s) in the <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\">MMO self-service GIS tool</a>.</p>",
+      "section": "otherUsesOfTheSea",
+      "answers": [
+        {
+          "id": "YES",
+          "text": "Yes",
+          "nextQuestionRoute": "/routing-measure/management"
+        },
+        {
+          "id": "NO",
+          "text": "No",
+          "nextQuestionRoute": "/protected-place"
+        }
+      ]
+    },
+    {
+      "route": "/routing-measure/management",
+      "text": "Is the proposed activity related to the management of the routing measure?",
+      "section": "otherUsesOfTheSea",
+      "answers": [
+        {
+          "id": "YES",
+          "text": "Yes",
+          "nextQuestionRoute": "/protected-place"
+        },
+        {
+          "id": "NO",
+          "text": "No",
+          "outcomeRoute": "/standard-marine-licence-application/routing-measure"
+        }
+      ]
+    },
+    {
+      "route": "/protected-place",
+      "text": "Will the activity take place within a 'protected place' or 'controlled site' under the Protection of Military Remains Act (1986)?",
+     "hint": "<p>Activities within sites protected under the Protection of Military Remains Act 1986 are not suitable for self-service marine licensing in any circumstances. All crashed military aircraft are automatically 'protected remains' and sunken military vessels are designated as 'protected places' even where their location is not presently known. <p>The <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\">MMO self-service GIS tool</a> only records known sites and is therefore not exhaustive. <p>Applicants will need to satisfy themselves that they meet the criteria based on their specific circumstances and through their own enquiries where appropriate.",
+      "section": "protectionOfHeritage",
+      "answers": [
+        {
+          "id": "YES",
+          "text": "Yes",
+          "outcomeRoute": "/standard-marine-licence-application/protected-place"
+        },
+        {
+          "id": "NO",
+          "text": "No",
+          "nextQuestionRoute": "/heritage-designation"
+        }
+      ]
+    },
+    {
+      "route": "/heritage-designation",
+      "text": "Will the activity take place in or require vehicle access through a heritage designation?",
+      "hint": "<p>Activities taking place in or requiring vehicle access through a 'heritage designation' will require valid consent or an agreed method statement from Historic England (or relevant local authority in respect of listed buildings) in order to be considered suitable for self-service marine licensing.</p><p>'Heritage designation' is defined as:<ul><li>Protected wrecks designated under the Protection of Wrecks Act 1973;</li><li>Scheduled monuments designated under the Ancient Monuments and Archaeological areas Act 1979;</li><li>Listed Buildings designated under The Planning (Listed Building and Conservation Area) Act 1990.</li></ul></p><p>If you are unsure of whether the activity falls within such an area you should select the appropriate layer in the <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\">MMO self-service GIS tool</a>.</p><p>Note: the MMO self-service GIS tool does not capture listed buildings as designated under the Planning (Listed Building and Conservation Area) Act 1990 and applicants must make their own enquiries in this regard.</p>",
+      "section": "heritageDesignations",
+      "answers": [
+        {
+          "id": "YES",
+          "text": "Yes",
+          "nextQuestionRoute": "/historic-england"
+        },
+        {
+          "id": "NO",
+          "text": "No",
+          "nextQuestionRoute": "/archaeological-heritage-historic-assets"
+        }
+      ]
+    },
+    {
+      "route": "/archaeological-heritage-historic-assets",
+      "text": "Does the activity involve the removal of items of archaeological or historic interest or any other activity, the purpose of which is to establish the presence or nature of such items?",
+       "hint": "<p>Activities carried out for the purposes set out will require a valid consent or an agreed method statement from Historic England (or relevant local authority in respect of listed buildings) in order to be considered suitable for self-service marine licensing.<p><p>'Archaeological or historic interest' includes all traces of human existence having a cultural, historical or archaeological character such as:<ol type=\"i\"><li>sites, structures, buildings, artefacts and human remains, together with their archaeological and natural context;</li><li>vessels, aircraft, other vehicles or any part thereof, their cargo or other contents, together with their archaeological and natural context; and</li><li>objects of prehistoric character.</li></ol></p>",
+      "section": "archaeologicalHeritageHistoricAssets",
+      "answers": [
+        {
+          "id": "YES",
+          "text": "Yes",
+          "nextQuestionRoute": "/historic-england"
+        },
+        {
+          "id": "NO",
+          "text": "No",
+          "nextQuestionRoute": "/marine-protected-area"
+        }
+      ]
+    },
+    {
+      "route": "/historic-england",
+      "text": "Do you have a valid consent from Historic England for the proposed activity or an agreed method statement?",
+      "section": "historicEngland",
+      "mcmsAppFormMapping": "HISTORIC_ENGLAND",
+      "answers": [
+        {
+          "id": "YES",
+          "text": "Yes",
+          "nextQuestionRoute": "/marine-protected-area"
+        },
+        {
+          "id": "NO",
+          "text": "No",
+          "outcomeRoute": "/historic-england/not-agreed"
+        }
+      ]
+    },
+    {
+      "route": "/marine-protected-area",
+      "text": "Will the activity be carried out in, or within 200m of, a Marine Protected Area (MPA)?",
+      "hint": "<p>MPAs are an important part of the marine environment. It is essential that measures are in place to protect them.</p><p> Activities taking place in or near MPAs will be unsuitable for self-service licensing if they have the potential to cause adverse effects and/or affect protected features of the site. In these situations, before a self-service licence can be issued, additional assurance must be provided to demonstrate that the activity will not cause adverse effects or will not affect, other than insignificantly, protected features. You can discuss the implications of your activity with Natural England or the Joint Nature Conservation Committee (JNCC). To continue to apply for a self-service licence you may have to agree a method statement with Natural England.</p><p>\"Marine protected areas\" mean:<ul><li>Highly Protected Marine Area (HPMA) (designated and candidate)</li><li>Marine Conservation Zones (MCZs) (designated and proposed)</li><li>Special Areas of Conservation (SACs) (designated and candidate)</li><li>Special Protection Areas (SPAs) (designated and potential)</li><li>Ramsar's</li><li>SSSIs</li></ul></p><p>If you are unsure of whether the activity falls within an MPA you should select the appropriate layer in the <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\">MMO self-service GIS tool</a>.",
+      "section": "marineProtectedArea200",
+      "answers": [
+        {
+          "id": "YES",
+          "text": "Yes",
+          "nextQuestionRoute": "/HPMA-Check"
+        },
+        {
+          "id": "NO",
+          "text": "No",
+          "nextQuestionRoute": "/vehicular-access"
+        }
+      ]
+    },
+{
+      "route": "/HPMA-Check",
+"text": "Is the area in which you intend to carry out your activity a Highly Protected Marine Area (HPMA)?",
+      "hint": "<p>A HPMA is an area of the sea that has been given the highest level of protection in which almost all licensable activities will be unsuitable for self-service licensing. In limited circumstances it may be possible to agree a methodology with Natural England to undertake the activity.</p><p>You can find out more about HPMAs on <a target=\"_blank\" href=\"https://www.gov.uk/government/collections/highly-protected-marine-areas\">GOV.UK</a>.",
+      "section": "marineProtectedArea200",
+      "answers": [
+        {
+          "id": "YES",
+          "text": "Yes",
+          "nextQuestionRoute": "/natural-england"
+        },
+        {
+          "id": "NO",
+          "text": "No",
+          "nextQuestionRoute": "/fast-track-activity-limits"
+        }
+      ]
+    },
+{
+      "route": "/fast-track-activity-limits",
+      "text": "Are the proposed activities limited to any or all of the following?",
+      "hint": "<p><ul><li>Deposit of marker buoys</li><li>Removal of marine growth from structures or assets</li><li>Repainting of structures or assets</li><li>Deposit of scaffolding or access towers</li></ul></p>",
+      "section": "marineProtectedAreaActivity",
+      "answers": [
+        {
+          "id": "YES",
+          "text": "Yes",
+          "nextQuestionRoute": "/vehicular-access"
+        },
+        {
+          "id": "NO",
+          "text": "No",
+          "nextQuestionRoute": "/natural-england"
+        }
+      ]
+    },
+    {
+      "route": "/vehicular-access",
+      "text": "Will the activity require vehicular access across intertidal coastal habitats which form part of an MPA?",
+      "hint": "<p>Activities involving vehicular access across such areas will not be suitable for self-service marine licensing unless they are accompanied by an agreed method statement from Natural England. </p><p>'Marine protected areas' mean:<ul><li>Highly Protected Marine Area (HPMA) (designated and candidate)</li><li>Marine Conservation Zones (MCZs) (designated and proposed)</li><li>Special Areas of Conservation (SACs) (designated and candidate)</li><li>Special Protection Areas (SPAs) (designated and potential)</li><li>Ramsar's</li><li>SSSIs</li></ul></p><p>If you are unsure of whether the activity falls within an MPA you should select the appropriate layer in the <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\">MMO self-service GIS tool</a>.",
+      "section": "vehicularAccess",
+      "answers": [
+        {
+          "id": "YES",
+          "text": "Yes",
+          "nextQuestionRoute": "/natural-england"
+        },
+        {
+          "id": "NO",
+          "text": "No",
+          "outcomeRoute": "/fast-track-mla/activity"
+        }
+      ]
+    },
+    {
+      "route": "/natural-england",
+      "text": "Has a method been agreed with Natural England?",
+      "hint": "<p>You must have agreed a method statement with Natural England before proceeding to apply for a self-service licence. </p><p>You <u><b>will</b></u> be required to upload the agreed method statement when you apply for a self-service licence.</p>",      
+      "section": "naturalEngland",
+      "mcmsAppFormMapping": "NATURAL_ENGLAND",
+      "answers": [
+        {
+          "id": "YES",
+          "text": "Yes",
+          "outcomeRoute": "/fast-track-mla/activity"
+        },
+        {
+          "id": "NO",
+          "text": "No",
+          "outcomeRoute": "/natural-england/not-agreed"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction",
+      "text": "What is the purpose of your construction activity?",
+      "section": "construction",
+      "mcmsAppFormMapping": "EXE_ACTIVITY_SUBTYPE_CONSTRUCTION",
+      "answers": [
+        {
+          "id": "maintenance",
+          "text": "Maintenance of existing structures and assets",
+          "nextQuestionRoute": "/exemption/construction/maintenance",
+          "hint": "'Maintenance' means the upkeep or repair of an existing structure or asset wholly <u>within</U> its existing 3 dimensional boundaries"
+        },
+        {
+          "id": "new",
+          "text": "Construction of something new",
+          "hint": "Includes activities undertaken primarily for maintenance purposes where an element of the works extend beyond the existing boundaries of the structure of asset being maintained.", 
+          "nextQuestionRoute": "/exemption/construction/new"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/maintenance",
+      "text": "What does the maintenance activity relate to?",
+      "section": "constructionMaintenance",
+      "answers": [
+        {
+          "id": "mooringOrNavigation",
+          "text": "Moorings or aids to navigation",
+          "nextQuestionRoute": "/exemption/construction/maintenance/moorings"
+        },
+        {
+          "id": "pontoons",
+          "text": "Pontoons",
+          "nextQuestionRoute": "/exemption/construction/maintenance/pontoons"
+        },
+        {
+          "id": "coastalProtectionDrainageOrFloodDefence",
+          "text": "Coastal protection, drainage or flood defence",
+          "nextQuestionRoute": "/exemption/construction/maintenance/coastal-drainage-flood"
+        },
+        {
+          "id": "harbourWorks",
+          "text": "Harbour works",
+          "nextQuestionRoute": "/exemption/construction/maintenance/harbour-works",
+          "hint": "Maintenance carried out by or on behalf of harbour authorities only."
+        },
+        {
+          "id": "cables",
+          "text": "Cables",
+          "nextQuestionRoute": "/exemption/construction/maintenance/cables"
+        },
+        {
+          "id": "pipelines",
+          "text": "Pipelines",
+          "nextQuestionRoute": "/exemption/construction/maintenance/pipelines"
+        },
+        {
+          "id": "carbonStorage",
+          "text": "Carbon Dioxide Storage",
+          "nextQuestionRoute": "/exemption/construction/maintenance/carbon-storage"
+        },
+        {
+          "id": "boredTunnel",
+          "text": "Bored tunnels",
+          "nextQuestionRoute": "/exemption/construction/maintenance/bored-tunnel"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue",
+          "hint": "Maintenance for purposes not set out above"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/maintenance/moorings",
+      "text": "What is the purpose of the activity?",
+      "section": "constructionMaintenance",
+      "answers": [
+        {
+          "id": "pileMooring",
+          "text": "To provide a pile mooring",
+          "nextQuestionRoute": "/exemption/construction/maintenance/moorings/undertaker"
+        },
+        {
+          "id": "swingingMooring",
+          "text": "To provide a swinging mooring",
+          "nextQuestionRoute": "/exemption/construction/maintenance/moorings/undertaker"
+        },
+        {
+          "id": "trotMooring",
+          "text": "To provide a trot mooring",
+          "nextQuestionRoute": "/exemption/construction/maintenance/moorings/undertaker"
+        },
+        {
+          "id": "aidToNavigation",
+          "text": "To provide a aid to navigation",
+          "nextQuestionRoute": "/exemption/construction/maintenance/moorings/undertaker"
+        },
+        {
+          "id": "other",
+          "text": "Something else",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/maintenance/moorings/undertaker",
+      "text": "Who will carry out the activity?",
+      "section": "constructionMaintenance",
+      "answers": [
+        {
+          "id": "harbourAuthority",
+          "text": "A harbour authority or someone on behalf of a harbour authority",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-25"
+        },
+        {
+          "id": "lighthouseAuthority",
+          "text": "A lighthouse authority or someone on behalf of a lighthouse authority",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-25"
+        },
+        {
+          "id": "someoneElse",
+          "text": "Someone else",
+          "nextQuestionRoute": "/exemption/construction/maintenance/moorings/undertaker/consent"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/maintenance/moorings/undertaker/consent",
+      "text": "does the activity require consent (e.g. a licence) from either a harbour authority or a lighthouse authority under their local legislation?",
+      "hint": "The permission or agreement of the authority does not constitute consent for these purposes.",
+      "section": "constructionMaintenance",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/construction/maintenance/moorings/undertaker/approval"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/maintenance/moorings/undertaker/approval",
+      "text": "Has consent been granted?",
+      "section": "constructionMaintenance",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-25-notification"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/maintenance/pontoons",
+      "text": "Is the purpose of the activity to provide a pontoon?",
+      "section": "constructionMaintenance",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/construction/maintenance/pontoons/undertaker"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/maintenance/pontoons/undertaker",
+      "text": "Who will carry out the activity?",
+      "section": "constructionMaintenance",
+      "answers": [
+        {
+          "id": "harbourAuthority",
+          "text": "A harbour authority or someone on behalf of a harbour authority",
+          "nextQuestionRoute": "/exemption/construction/maintenance/pontoons/deck"
+        },
+        {
+          "id": "someoneElse",
+          "text": "Someone else",
+          "nextQuestionRoute": "/exemption/construction/maintenance/pontoons/consent"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/maintenance/pontoons/consent",
+      "text": "Does the activity require consent (e.g. a licence) from a harbour authority under local legislation?",
+      "hint": "The permission or agreement of the authority does not constitute consent for these purposes.",
+      "section": "constructionMaintenance",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/construction/maintenance/pontoons/approval"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/maintenance/pontoons/approval",
+      "text": "Has consent been granted?",
+      "section": "constructionMaintenance",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/construction/maintenance/pontoons/deck"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/maintenance/pontoons/deck",
+      "text": "When complete will the deck of the pontoon be an area greater than 30m2?",
+      "hint": "NOTE: If the pontoon will be attached to one or more pontoons already in place the question refers to the total deck area of all pontoons combined.",
+      "section": "constructionMaintenance",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/construction/maintenance/pontoons/quantity"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/maintenance/pontoons/quantity",
+      "text": "In the 6 months prior to the commencement of this activity will 10 or more pontoons have been constructed or deposited at the location?",
+      "section": "constructionMaintenance",
+      "hint": "either by or on behalf of the harbour authority or with the consent required from and granted by the harbour authority",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-25A-mmo-approval"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-25A"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/maintenance/harbour-works",
+      "text": "Will the activity be carried out wholly within the existing 3 dimensional boundary of the works being maintained?",
+      "section": "constructionMaintenance",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/construction/maintenance/harbour-works/undertaker"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/maintenance/harbour-works/undertaker",
+      "text": "Who will carry out the activity?",
+      "section": "constructionMaintenance",
+      "answers": [
+        {
+          "id": "harbourAuthority",
+          "text": "A harbour authority or someone on behalf of a harbour authority",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-23"
+        },
+        {
+          "id": "someoneElse",
+          "text": "Someone else",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/maintenance/cables",
+      "text": "What is the cable to be maintained used for?",
+      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities--2#cables-pipelines-oil-and-gas-and-carbon-capture-storage\"> cables </a>",
+      "section": "constructionMaintenance",
+      "answers": [
+        {
+          "id": "transferOfData",
+          "text": "The transfer of data",
+          "nextQuestionRoute": "/exemption/construction/maintenance/cables/location",
+          "hint": "This type of cable transfers data from one place to another."
+        },
+        {
+          "id": "transfer of electricity",
+          "text": "The transfer of electricity",
+          "nextQuestionRoute": "/exemption/construction/maintenance/cables/location",
+          "hint": "This type of cable allows the transfers of electricity from one place to another. This includes interconnector cables, which exchange electricity to and from continental Europe and beyond."
+        },
+        {
+          "id": "renewableEnergyExportCable",
+          "text": "Renewable energy export ",
+          "nextQuestionRoute": "/exemption/construction/maintenance/cables/inspection-repair",
+          "hint": "This type of cable exports electricity generated by an offshore wind farm or wave/tidal array to a substation on land."
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "nextQuestionRoute": "/exemption/construction/maintenance/cables/inspection-repair",
+          "hint": "Cables supplying offshore structures, cables utilised in exploration or exploitation of natural resources and or pollution control etc."
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/maintenance/cables/location",
+      "text": "Where will the activity take place?",
+      "section": "constructionMaintenance",
+      "answers": [
+        {
+          "id": "inside12NM",
+          "text": "Wholly inside 12NM",
+          "nextQuestionRoute": "/exemption/construction/maintenance/cables/inspection-repair"
+        },
+        {
+          "id": "outside12NM",
+          "text": "Wholly outside 12NM",
+          "outcomeRoute": "/exemption/licence-not-required-cables/maintenance"
+        },
+        {
+          "id": "bothInsideOutside12NM",
+          "text": "Part inside 12NM part outside 12NM",
+          "outcomeRoute": "/exemption/licence-not-required-cables/maintenance/both"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/maintenance/cables/inspection-repair",
+      "text": "Does the activity relate to the inspection or repair of an existing cable?",
+      "section": "constructionMaintenance",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/construction/maintenance/cables/emergency"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/maintenance/cables/emergency",
+      "text": "Are the circumstances serious, unexpected and potentially dangerous requiring immediate action?",
+      "section": "constructionMaintenance",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/construction/maintenance/cables/protection"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/maintenance/cables/protection",
+      "text": "Will the activity proposed include the deposit of rock or other materials for the purpose of providing <u>new</U> cable protection?",
+      "hint": "Deposits for these purposes, i.e. those beyond the replenishment or replacement of materials wholly within the three dimensional boundaries of those previously consented and deposited, will require a marine licence. If the maintenance, inspection or repair can be carried out without the need for new protection you are advised to adapt your proposed approach.<p><p>NOTE: If you intend to apply for a marine licence in respect of the addition of new or extended protection, where relevant, please select ‘No’ to continue.",
+      "section": "constructionMaintenance",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/construction/maintenance/cables/explosives"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/maintenance/cables/explosives",
+      "text": "Does the activity involve the deposit or use of explosives?",
+      "section": "constructionMaintenance",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-34"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/maintenance/coastal-drainage-flood",
+      "text": "Who will carry out the activity?",
+      "section": "constructionMaintenance",
+      "answers": [
+        {
+          "id": "environmentAgency",
+          "text": "The Environment Agency or someone on behalf of the Environment Agency",
+          "nextQuestionRoute": "/exemption/construction/maintenance/coastal-drainage-flood/EA"
+        },
+        {
+          "id": "coastProtectionAuthority",
+          "text": "The Coast Protection Authority or someone on behalf of the Coast Protection Authority",
+          "nextQuestionRoute": "/exemption/construction/maintenance/coastal-drainage-flood/CPA"
+        },
+        {
+          "id": "localAuthority",
+          "text": "The Local Authority or someone on behalf of the Local Authority",
+          "nextQuestionRoute": "/exemption/construction/maintenance/coastal-drainage-flood/CPA"
+        },
+        {
+          "id": "secretaryStateDefence",
+          "text": "The Secretary of State for Defence or someone on behalf of the Secretary of State for Defence",
+          "nextQuestionRoute": "/exemption/construction/maintenance/coastal-drainage-flood/CPA"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/maintenance/coastal-drainage-flood/EA",
+      "text": "Will the activity be carried out wholly within the existing 3 dimensional boundary of the works being maintained?",
+      "section": "constructionMaintenance",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/construction/maintenance/coastal-drainage-flood/EA/beach-replenishment"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/construction/maintenance/coastal-drainage-flood/EA/emergency"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/maintenance/coastal-drainage-flood/EA/beach-replenishment",
+      "text": "Does the activity involve beach replenishment?",
+      "hint": "'Beach replenishment' means the addition of material from land-based, off-shore or other coastal sources not connected to the beach or its associated sediment system to replace material permanently lost from the system.",
+      "section": "constructionMaintenance",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-19"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/maintenance/coastal-drainage-flood/EA/emergency",
+      "text": "Are the circumstances serious, unexpected and potentially dangerous requiring immediate action in response to flood or imminent risk of flood?",
+      "section": "construction",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-20"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/maintenance/coastal-drainage-flood/CPA",
+      "text": "Is the activity for the purpose of maintaining coast protection works?",
+      "hint": "'Coast protection works' include: </li><li><u>beach re-profiling</U>, which involves the movement of beach material in a cross-shore direction up or down the beach; and </li><li><u>beach recycling</u>, which involves the movement of beach material along the beach from areas of accretion to areas of erosion within the beach or associated sediment system.",
+      "section": "constructionMaintenance",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/construction/maintenance/coastal-drainage-flood/CPA/boundaries"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/maintenance/coastal-drainage-flood/CPA/boundaries",
+      "text": "Will the activity be carried out wholly within the existing 3 dimensional boundary of the works being maintained?",
+      "section": "constructionMaintenance",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/construction/maintenance/coastal-drainage-flood/CPA/beach-replenishment"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/maintenance/coastal-drainage-flood/CPA/beach-replenishment",
+      "text": "Does the activity involve beach replenishment?",
+            "hint": "'Beach replenishment' means the addition of material from land-based, off-shore or other coastal sources not connected to the beach or its associated sediment system to replace material permanently lost from the system.",
+      "section": "constructionMaintenance",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-19"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/maintenance/pipelines",
+      "text": "What kind of pipeline will be maintained?",
+      "section": "constructionMaintenance",
+      "answers": [
+        {
+          "id": "oilAndGas",
+          "text": "Oil and gas pipeline",
+          "nextQuestionRoute": "/exemption/construction/maintenance/pipeline/oil-and-gas/purpose"
+        },
+        {
+          "id": "otherPipelines",
+          "text": "Other pipelines",
+          "nextQuestionRoute": "/exemption/construction/maintenance/pipeline/inspection-repair"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/maintenance/pipeline/oil-and-gas/purpose",
+      "text": "What is the purpose of the activity?",
+      "section": "constructionMaintenance",
+      "answers": [
+        {
+          "id": "section3PetroleumAct",
+          "text": "something done in the course of carrying on an activity for which a licence under section 3 of the Petroleum Act 1998 or section 2 of the Petroleum (Production) Act 1934 is required",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-Section-77",
+          "hint": "Activities are to be regarded as activities for which a licence is required if, by virtue of such a licence, they are activities which may be carried out only with the consent of the Secretary of State or another person."
+        },
+        {
+          "id": "part3PetroleumAct",
+          "text": "something done for the purpose of constructing or maintaining a pipeline as respects any part of which an authorisation (within the meaning of Part 3 of the Petroleum Act 1998) is in force;",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-Section-77"
+        },
+        {
+          "id": "part4PetroleumAct",
+          "text": "something done for the purpose of establishing or maintaining an offshore installation (within the meaning of Part 4 of the Petroleum Act 1998;",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-Section-77",
+          "hint": "Activities are to be regarded as activities for which a licence is required if, by virtue of such a licence, they are activities which may be carried out only with the consent of the Secretary of State or another person."
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "nextQuestionRoute": "/exemption/construction/maintenance/pipeline/inspection-repair"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/maintenance/pipeline/inspection-repair",
+      "text": "Does the activity relate to the inspection or repair of an existing pipeline?",
+      "section": "constructionMaintenance",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/construction/maintenance/pipeline/emergency"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/maintenance/pipeline/emergency",
+      "text": "Are the circumstances serious, unexpected and potentially dangerous requiring immediate action?",
+      "section": "construction",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/construction/maintenance/pipeline/protection"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/maintenance/pipeline/protection",
+      "text": "Will the activity proposed include the deposit of rock or other materials for the purpose of providing <u>new</U> pipeline protection?",
+      "hint": "Deposits for these purposes, i.e. those beyond the replenishment or replacement of materials within the three dimensional boundaries of those previously consented and deposited, will require a marine licence. If the maintenance, inspection or repair can be carried out without the need for new protection you are advised to adapt your proposed approach. <P><P>NOTE: If you intend to apply for a marine licence in respect of the addition of new or extended protection, where relevant, please select ‘No’ to continue.",
+      "section": "constructionMaintenance",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/construction/maintenance/pipeline/explosives"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/maintenance/pipeline/explosives",
+      "text": "Does the activity involve the deposit or use of explosives?",
+      "section": "constructionMaintenance",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-34"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/maintenance/carbon-storage",
+      "text": "Is the proposed activity something that will be done in the course of carrying on an activity for which a licence under section 4 or 18 of the Energy Act 2008 is required (gas unloading, storage and recovery, and carbon dioxide storage)?",
+      "section": "constructionMaintenance",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-Section-77"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/maintenance/bored-tunnel",
+      "text": "Will the activity be carried out wholly under the 'Seabed' and relate directly to the construction or operation of a bored tunnel?",
+      "section": "constructionMaintenance",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/construction/maintenance/bored-tunnel/affect"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/maintenance/bored-tunnel/affect",
+      "text": "Will the activity significantly adversely affect any part of the environment of the UK marine area or the living resources that it supports?",
+      "section": "constructionMaintenance",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-35"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/new",
+      "text": "What does the contruction activity relate to?",
+      "section": "construction",
+      "answers": [
+        {
+          "id": "mooringOrNavigation",
+          "text": "Moorings or aids to navigation",
+          "nextQuestionRoute": "/exemption/construction/new/moorings"
+        },
+        {
+          "id": "pontoon",
+          "text": "Pontoons",
+          "nextQuestionRoute": "/exemption/construction/new/pontoons"
+        },
+        {
+          "id": "floodEmergency",
+          "text": "Flood or flood risk",
+          "nextQuestionRoute": "/exemption/construction/new/flood-emergency"
+        },
+        {
+          "id": "cables",
+          "text": "Cables",
+          "nextQuestionRoute": "/exemption/construction/new/cables"
+        },
+        {
+          "id": "pipelines",
+          "text": "Pipelines",
+          "nextQuestionRoute": "/exemption/construction/new/pipelines"
+        },
+        {
+          "id": "miscellaneous",
+          "text": "Other",
+          "nextQuestionRoute": "/exemption/construction/new/miscellaneous",
+          "hint": "Construction activities for purposes not set out above"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/new/moorings",
+      "text": "What is the purpose of the activity?",
+      "section": "construction",
+      "answers": [
+        {
+          "id": "pileMooring",
+          "text": "To provide a pile mooring",
+          "nextQuestionRoute": "/exemption/construction/new/moorings/undertaker"
+        },
+        {
+          "id": "swingingMooring",
+          "text": "To provide a swinging mooring",
+          "nextQuestionRoute": "/exemption/construction/new/moorings/undertaker"
+        },
+        {
+          "id": "trotMooring",
+          "text": "To provide a trot Mooring",
+          "nextQuestionRoute": "/exemption/construction/new/moorings/undertaker"
+        },
+        {
+          "id": "aidToNavigation",
+          "text": "To provide a aid to Navigation",
+          "nextQuestionRoute": "/exemption/construction/new/moorings/undertaker"
+        },
+        {
+          "id": "other",
+          "text": "Something else",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/new/moorings/undertaker",
+      "text": "Who will carry out the activity?",
+      "section": "construction",
+      "answers": [
+        {
+          "id": "harbourAuthority",
+          "text": "A harbour authority or someone on behalf of a harbour authority",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-25"
+        },
+        {
+          "id": "lighthouseAuthority",
+          "text": "A lighthouse authority or someone on behalf of a lighthouse authority",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-25"
+        },
+        {
+          "id": "someoneElse",
+          "text": "Someone else",
+          "nextQuestionRoute": "/exemption/construction/new/moorings/undertaker/consent"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/new/moorings/undertaker/consent",
+      "text": "does the activity require consent (e.g. a licence) from a harbour authority under their local legislation?",
+      "hint": "The permission or agreement of the authority does not constitute consent for these purposes.",
+      "section": "construction",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/construction/new/moorings/undertaker/approval"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/new/moorings/undertaker/approval",
+      "text": "Has consent been granted?",
+      "section": "construction",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-25-notification"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/new/pontoons",
+      "text": "Is the purpose of the activity to provide a pontoon?",
+      "section": "construction",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/construction/new/pontoons/undertaker"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/new/pontoons/undertaker",
+      "text": "Who will carry out the activity?",
+      "section": "construction",
+      "answers": [
+        {
+          "id": "harbourAuthority",
+          "text": "A harbour authority or someone on behalf of a harbour authority",
+          "nextQuestionRoute": "/exemption/construction/new/pontoons/deck"
+        },
+        {
+          "id": "someoneElse",
+          "text": "Someone else",
+          "nextQuestionRoute": "/exemption/construction/new/pontoons/consent"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/new/pontoons/consent",
+      "text": "Does the activity require consent (e.g. a licence) from a harbour authority under local legislation?",
+      "hint": "The permission or agreement of the authority does not constitute consent for these purposes.",
+      "section": "construction",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/construction/new/pontoons/approval"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/new/pontoons/approval",
+      "text": "Has consent been granted?",
+      "section": "construction",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/construction/new/pontoons/deck"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/new/pontoons/deck",
+      "text": "When complete will the deck of the pontoon be an area greater than 30m2?",
+            "hint": "NOTE: If the pontoon will be attached to one or more pontoons already in place the question refers to the total deck area of all pontoons combined.",
+      "section": "construction",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/construction/new/pontoons/quantity"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/new/pontoons/quantity",
+      "text": "In the 6 months prior to the commencement of this activity will 10 or more pontoons have been constructed or deposited at the location?",
+      "section": "construction",
+      "hint": "either by or on behalf of the harbour authority or with the consent required from and granted by the harbour authority",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-25A-mmo-approval"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-25A"
+        }
+      ]
+    },
+    {
+      "route": "/sea/article99",
+      "text": "Where will the activity take place?",
+      "section": "doINeedAMarineLicence",
+      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/marine-licensing-definitions#mean-high-water-springs\"> mean high water springs (MHWS)</a>, the <a target=\"_blank\" href=\"https://www.gov.uk/guidance/marine-licensing-definitions#normal-tidal-limit\"> normal tidal limit (NTL) </a>, or the MMO's <a target=\"_blank\" href=\"https://www.gov.uk/guidance/marine-licensing-definitions#jurisdiction\">jurisdiction</a>.",
+      "answers": [
+        {
+          "id": "inSea",
+          "text": "In the 'Sea'",
+          "nextQuestionRoute": "/jurisdiction/article99",
+          "hint": "'Sea' includes any area which is <u>submerged</u> at MHWS and the waters of every <u>estuary, river or channel</u> where the tide flows at MHWS tide up to the NTL. Even waters in areas which are closed permanently or intermittently by a lock or other artificial means against the regular action of the tide are included, where seawater flows into or out from the area, either continuously or from time to time."
+        },
+        {
+          "id": "overSea",
+          "text": "Over the 'Sea'",
+          "nextQuestionRoute": "/jurisdiction/article99",
+          "hint": "'Over' the 'Sea' includes a location directly above or overhanging the 'Sea' such as a bridge, open piled structure or cantilever."
+        },
+        {
+          "id": "onOrUnderSea",
+          "text": "On or under the 'Seabed'",
+          "nextQuestionRoute": "/jurisdiction/article99",
+          "hint": "'Seabed' means the ground under the 'Sea' and anything resting on it such as a wreck. It includes the intertidal area of the sea or any river at such time as it is exposed temporarily at low tide."
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/licence-not-required/sea",
+          "hint": "In an area <u>other</u> than those defined above. For example the part of beach <u>above MHWS</u>, the upper extent of a river <u>beyond the NTL</u> and or a land locked body of water such as a lake."
+        }
+      ]
+    },
+    {
+      "route": "/jurisdiction/article99",
+      "text": "In which waters will the activity take place?",
+      "hint": "See an illustration of these 'waters' or find out more about the MMO's <a target=\"_blank\" href=\"https://www.gov.uk/guidance/marine-licensing-definitions#jurisdiction\">jurisdiction</a>.",
+      "section": "doINeedAMarineLicence",
+      "answers": [
+        {
+          "id": "englishWaters",
+          "text": "In English waters",
+          "nextQuestionRoute": "/activity-type/article99",
+          "hint": "'English waters' is the area of 'Sea' within the limits of territorial waters (12 nautical miles) adjacent to the English coastline (the 'inshore' area). This also includes any area of sea beyond the territorial limit (the 'offshore' area), that is within the exclusive economic zone (EEZ) and the UK sector of the continental shelf (up to 200 nautical miles). This excludes the waters of any devolved administration."
+        },
+        {
+          "id": "northernIrishOffshoreWaters",
+          "text": "In Northern Ireland offshore waters",
+          "nextQuestionRoute": "/activity-type",
+          "hint": "'Northern Ireland offshore waters' is the area of 'Sea', adjacent to Northern Ireland beyond the territorial limit, providing it includes the EEZ and the UK sector of the continental shelf (excluding the waters of any other administration)."
+        },
+        {
+          "id": "otherUkWaters",
+          "text": "In other UK waters",
+          "outcomeRoute": "/licence-not-required-devolved",
+          "hint": "'Other UK waters'means the waters of the devolved administrations of Wales, Scotland or Northern Ireland (excluding Northern Ireland offshore waters)."
+        },
+        {
+          "id": "elsewhere",
+          "text": "Somewhere else in the world",
+          "nextQuestionRoute": "/elsewhere-in-the-world/activity-type"
+        }
+      ]
+    },
+    {
+      "route": "/activity-type/article99",
+      "mcmsAppFormMapping": "ACTIVITY_TYPE",
+      "text": "What type of activity will be carried out?",
+      "hint": "HINT: Try to think about what you intend to do at a basic level. For example if you plan to take sediment samples for testing or analysis, the type of activity that will take place is a removal activity. If the activity involves the building of something new, or the maintenance, alteration or improvement of something that already exists, then the activity that will take place is a construction activity.<p> </br> Doing more than one thing? If your project involves multiple activities make sure you check each separately starting with the main or most significant activity.",
+      "section": "doINeedAMarineLicence",
+      "answers": [
+        {
+          "id": "CON",
+          "text": "Construction",
+          "outcomeRoute": "/construction/journey-select/article99",
+          "hint": "Including maintenance, alteration and improvement of works and the laying of cables or pipelines.<br/>Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/construction-alteration-or-improvement-of-works\">construction, maintenance, alteration and improvement</a>"
+        },
+        {
+          "id": "DEPO",
+          "text": "Deposit",
+          "outcomeRoute": "/deposit/journey-select",
+          "hint": "Including the deliberate disposal, dumping, placing, tipping or unloading of any substance or object.<br/>Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/deposit-of-substances-and-objects-below-mhws\">deposit activities</a>"
+        },
+        {
+          "id": "REMO",
+          "text": "Removal",
+          "outcomeRoute": "/removal/journey-select",
+          "hint": "Including dredging for the purpose of improving navigation, taking samples for scientific analysis, borrow pits, capital and maintenance dredging, and beach replenishment.<br/>Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/dredging\">dredging and removal activities</a>"
+        },
+        {
+          "id": "SCUTTLE",
+          "text": "Scuttling",
+          "outcomeRoute": "/scuttling/journey-select",
+          "hint": "Deliberately sinking a vessel or floating container.<br/>Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/scuttling-vessels\">scuttling</a>"
+        },
+        {
+          "id": "INCINERATION",
+          "text": "Incineration",
+          "outcomeRoute": "/incineration/journey-select",
+          "hint": "Burning substances or objects.<br/>Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/incineration-of-substances-and-objects\">incineration</a>"
+        }
+      ]
+    },
+    {
+      "route": "/construction/journey-select/article99",
+      "heading": "Marine licence may be required",
+      "text": "<b>Please select the service you require.</b><p><p> Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/do-i-need-a-marine-licence#exemptions\">exemptions</a>, <a target=\"_blank\" href=\"https://www.gov.uk/guidance/do-i-need-a-marine-licence#self-service\">self-service</a>, or <a target=\"_blank\" href=\"https://www.gov.uk/guidance/do-i-need-a-marine-licence#standard-marine-licence\">standard marine licensing</a>.<p><p>Note: If you select either option 1 or option 2 but it is subsequently determined in the course of the check that the activity does not meet relevant qualifying criteria you will have the opportunity to continue your journey and select a different option once the check is concluded.",
+      "section": "doINeedAMarineLicenceConstruction",
+      "outcomeTypes": [
+        "WO_CON_EXEMPTION_JOURNEY_ARTICLE99",
+        "WO_CON_SELF_SERVICE_JOURNEY",
+        "WO_STANDARD_MLA"
+      ]
+    },
+    {
+      "route": "/exemption/construction/article99",
+      "text": "What is the purpose of your construction activity?",
+      "section": "construction",
+      "mcmsAppFormMapping": "EXE_ACTIVITY_SUBTYPE_CONSTRUCTION",
+      "answers": [
+        {
+          "id": "maintenance",
+          "text": "Maintenance of existing structures and assets",
+          "hint": "'Maintenance' means the upkeep or repair of an existing structure or asset wholly within its existing 3 dimensional boundaries",
+          "nextQuestionRoute": "/exemption/construction/maintenance-alteration"
+        },
+        {
+          "id": "new",
+          "text": "Construction of something new",
+          "hint": "Includes activities undertaken primarily for maintenance purposes where an element of the works extend beyond the existing boundaries of the structure of asset being maintained.", 
+          "nextQuestionRoute": "/exemption/construction/new/article99"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/new/article99",
+      "text": "What does the construction activity relate to?",
+      "section": "construction",
+      "answers": [
+        {
+          "id": "mooringOrNavigation",
+          "text": "Moorings or aids to navigation",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        },
+        {
+          "id": "pontoon",
+          "text": "Pontoons",
+          "nextQuestionRoute": "/exemption/construction/new/pontoons/article99"
+        },
+        {
+          "id": "floodEmergency",
+          "text": "Flood or flood risk",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        },
+        {
+          "id": "cables",
+          "text": "Cables",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        },
+        {
+          "id": "pipelines",
+          "text": "Pipelines",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        },
+        {
+          "id": "miscellaneous",
+          "text": "Other",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue",
+          "hint": "Construction activities for purposes not set out above"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/new/pontoons/article99",
+      "text": "Is the purpose of the activity to provide a pontoon?",
+      "section": "construction",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/construction/new/pontoons/undertaker/article99"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/new/pontoons/undertaker/article99",
+      "text": "Who will carry out the activity?",
+      "section": "construction",
+      "answers": [
+        {
+          "id": "harbourAuthority",
+          "text": "A harbour authority or someone on behalf of a harbour authority",
+          "nextQuestionRoute": "/exemption/construction/new/pontoons/deck/article99"
+        },
+        {
+          "id": "someoneElse",
+          "text": "Someone else",
+          "nextQuestionRoute": "/exemption/construction/new/pontoons/consent/article99"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/new/pontoons/consent/article99",
+      "text": "Does the activity require consent (e.g. a licence) from a harbour authority under local legislation?",
+      "hint": "The permission or agreement of the authority does not constitute consent for these purposes.",
+      "section": "construction",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/construction/new/pontoons/approval/article99"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/new/pontoons/approval/article99",
+      "text": "Has consent been granted?",
+      "section": "construction",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/construction/new/pontoons/deck/article99"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/new/pontoons/deck/article99",
+      "text": "When complete will the deck of the pontoon be an area greater than 30m2?",
+      "hint": "NOTE: If the pontoon will be attached to one or more pontoons already in place the question refers to the total deck area of all pontoons combined.",
+      "section": "construction",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/construction/new/pontoons/quantity/article99"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/new/pontoons/quantity/article99",
+      "text": "In the 6 months prior to the commencement of this activity will 10 or more pontoons have been constructed or deposited at the location?",
+      "section": "construction",
+      "hint": "either by or on behalf of the harbour authority or with the consent required from and granted by the harbour authority",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/removal/scientific-research/samples/obstruction/article99"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/removal/scientific-research/samples/obstruction/article99"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/scientific-research/samples/obstruction/article99",
+      "text": "Will the activity cause or be likely to cause an obstruction or danger to navigation?",
+      "section": "removal",
+      "hint": " Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#navigational-risk\"> navigational risk </a> and the steps you can take to ensure your proposal is not one that will cause or be likely to cause and obstruction or danger.",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/removal/scientific-research/samples/mpa/article99"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/scientific-research/samples/mpa/article99",
+      "text": "Will the activity take place in or within 200m of a Marine Protected Area (MPA)?",
+      "section": "removal",
+      "hint": "<p>MPA's are an important part of the marine environment. </p><p>You are responsible for making sure you understand the status of the location where the activity is proposed. </p><p> 'Marine protected areas' mean:<ul><li>Highly Protected Marine Area (HPMA) (designated and candidate)</li><li>Marine Conservation Zones (MCZs) (designated and proposed)</li><li>Special Areas of Conservation (SACs) (designated and candidate)</li><li>Special Protection Areas (SPAs) (designated and potential)</li><li>Ramsar's</li><li>SSSIs</li></ul></p><p> If you are unsure of whether the activity falls within an MPA you should select the appropriate layer in the MMO's <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\"> GIS tool </a> to check.",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/removal/scientific-research/samples/mpa-management/article99"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-25A"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/scientific-research/samples/mpa-management/article99",
+      "text": "Is the activity directly connected with or necessary to the management of the Marine Protected Area?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-25A"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/removal/scientific-research/samples/lse/article99"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/scientific-research/samples/lse/article99",
+      "text": "Is the activity....",
+      "section": "removal",
+      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#marine-protected-areas\"> marine protected areas </a>.",
+      "answers": [
+        {
+          "id": "europeanSiteSamples",
+          "text": "Likely to have a significant effect on a European site?",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
+          "hint": "either alone or in combination with other plans and projects"
+        },
+        {
+          "id": "ramsarSiteSamples",
+          "text": "Likely to have a significant effect on a Ramsar site?",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
+          "hint": "either alone or in combination with other plans and projects"
+        },
+        {
+          "id": "mczSamples",
+          "text": "Capable of affecting (other than insignificantly), the protected features of a Marine Conservation Zone or Highly Protected Marine Area?",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
+          "hint": "including any ecological or geomorphological process on which the conservation of any protected feature of an MCZ or HPMA is (wholly or in Part) dependant"
+        },
+        {
+          "id": "otherSamples",
+          "text": "Unlikely to have any relevant effect on any sites specified above",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-25A"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/new/flood-emergency",
+      "text": "Will the activity be carried out by or on behalf on the Environment Agency?",
+      "section": "construction",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/construction/new/flood-emergency/validation"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/new/flood-emergency/validation",
+      "text": "Are the circumstances serious, unexpected, and potentially dangerous requiring immediate action in response to either flooding or imminent risk of flooding?",
+      "section": "construction",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-20"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/new/cables",
+      "text": "What will the cable to be laid be used for?",
+      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities--2#cables-pipelines-oil-and-gas-and-carbon-capture-storage\"> cables </a>.",
+      "section": "construction",
+      "answers": [
+        {
+          "id": "transferOfData",
+          "text": "The transfer of data",
+          "nextQuestionRoute": "/exemption/construction/new/cables/location",
+          "hint": "This type of cable transfers data from one place to another."
+        },
+        {
+          "id": "transferOfElectricity",
+          "text": "The transfer of electricity",
+          "nextQuestionRoute": "/exemption/construction/new/cables/location",
+          "hint": "This type of cable allows the transfers of electricity from one place to another. This includes interconnector cables, which exchange electricity to and from continental Europe and beyond."
+        },
+        {
+          "id": "renewableEnergyExportCable",
+          "text": "Renewable energy export ",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue",
+          "hint": "This type of cable exports electricity generated by an offshore wind farm or wave/tidal array to a substation on land."
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue",
+          "hint": "Cables supplying offshore structures, cables utilised in exploration or exploitation of natural resources and or pollution control etc."
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/new/cables/location",
+      "text": "Where will the cable be laid?",
+      "section": "construction",
+      "answers": [
+        {
+          "id": "inside12NM",
+          "text": "Wholly inside 12NM",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        },
+        {
+          "id": "outside12NM",
+          "text": "Wholly outside 12NM",
+          "outcomeRoute": "/exemption/licence-not-required-cables"
+        },
+        {
+          "id": "bothInsideOutside12NM",
+          "text": "Part inside 12NW part outside 12NM",
+          "outcomeRoute": "/exemption/licence-required-no-exemption-part-cables"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/new/pipelines",
+      "text": "What kind of pipeline does the construction activity relate to?",
+      "section": "construction",
+      "answers": [
+        {
+          "id": "oilAndGas",
+          "text": "Oil and gas pipeline",
+          "nextQuestionRoute": "/exemption/construction/new/pipelines/oil-and-gas/purpose"
+        },
+        {
+          "id": "otherPipelines",
+          "text": "Other pipelines",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/new/pipelines/oil-and-gas/purpose",
+      "text": "What is the purpose of the activity?",
+      "section": "construction",
+      "answers": [
+        {
+          "id": "section3PetroleumAct",
+          "text": "something done in the course of carrying on an activity for which a licence under section 3 of the Petroleum Act 1998 or section 2 of the Petroleum (Production) Act 1934 is required",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-Section-77",
+          "hint": "Activities are to be regarded as activities for which a licence is required if, by virtue of such a licence, they are activities which may be carried out only with the consent of the Secretary of State or another person."
+        },
+        {
+          "id": "part3PetroleumAct",
+          "text": "something done for the purpose of constructing or maintaining a pipeline as respects any part of which an authorisation (within the meaning of Part 3 of the Petroleum Act 1998) is in force;",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-Section-77"
+        },
+        {
+          "id": "part4PetroleumAct",
+          "text": "something done for the purpose of establishing or maintaining an offshore installation (within the meaning of Part 4 of the Petroleum Act 1998;",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-Section-77",
+          "hint": "Activities are to be regarded as activities for which a licence is required if, by virtue of such a licence, they are activities which may be carried out only with the consent of the Secretary of State or another person."
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/new/carbon-storage",
+      "text": "Is the proposed activity something that will be done in the course of carrying on an activity for which a licence under section 4 or 18 of the Energy Act 2008 is required (gas unloading, storage and recovery, and carbon dioxide storage)?",
+      "section": "construction",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-Section-77"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/licence-required-no-exemption"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/new/miscellaneous",
+      "text": "What does the construction activity relate to?",
+      "section": "construction",
+      "answers": [
+        {
+          "id": "boredTunnels",
+          "text": "Bored tunnels",
+          "nextQuestionRoute": "/exemption/construction/new/miscellaneous/bored-tunnel"
+        },
+        {
+          "id": "deepseaMining",
+          "text": "Licensed deepsea mining",
+          "nextQuestionRoute": "/exemption/construction/new/miscellaneous/deepsea-mining"
+        },
+        {
+          "id": "crossrailAct",
+          "text": "Scheduled works authorised under the Crossrail Act 2008",
+          "nextQuestionRoute": "/exemption/construction/new/miscellaneous/crossrail-act"
+        },
+        {
+          "id": "carbonStorage",
+          "text": "Carbon Dioxide Storage",
+          "nextQuestionRoute": "/exemption/construction/new/carbon-storage"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue",
+          "hint": "Other construction or alteration activities for purposes not set out above"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/new/miscellaneous/deepsea-mining",
+      "text": "Is the activity carried out?",
+      "section": "construction",
+      "answers": [
+        {
+          "id": "explorationExploitationLicence",
+          "text": "In pursuance of an exploration or exploitation licence issued under the Deep Sea Mining (Temporary Provision) Act 1981",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-30"
+        },
+        {
+          "id": "reciprocalauthorisation",
+          "text": "In pursuance of a reciprocal authorisation within the meaning given by section 3(3) of the Deep Sea Mining (Temporary Provision) Act 1981",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-30"
+        },
+        {
+          "id": "other",
+          "text": "for another reason",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/new/miscellaneous/crossrail-act",
+      "text": "Will the activity be carried out within the limits of deviation for scheduled works in exercise of powers conferred by the Crossrail Act 2008 in relation to those works or any work connected with them?",
+      "section": "construction",
+      "hint": "'limits of deviation' means the limits of deviation which are shown on the deposited plans. 'Scheduled works are defined in section 1(1) of the 2008 Act.",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-29"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/new/miscellaneous/bored-tunnel",
+      "text": "Will the activity be carried out wholly under the 'Seabed' and relate directly to the construction or operation of a bored tunnel?",
+      "section": "construction",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/construction/new/miscellaneous/bored-tunnel/affect"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/construction/new/miscellaneous/bored-tunnel/affect",
+      "text": "Will the activity significantly adversely affect any part of the environment of the UK marine area or the living resources that it supports?",
+      "section": "construction",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-35"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/activity-type",
+      "text": "What does the deposit activity relate to?",
+      "section": "deposit",
+      "mcmsAppFormMapping": "EXE_ACTIVITY_SUBTYPE_DEPOSIT",
+      "answers": [
+        {
+          "id": "fishing",
+          "text": "Fishing and shellfish propogation and cultivation",
+          "nextQuestionRoute": "/exemption/deposit/fishing"
+        },
+        {
+          "id": "markersMooringsAidsToNavigation",
+          "text": "Markers, moorings and aids to navigation",
+          "nextQuestionRoute": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation"
+        },
+        {
+          "id": "pontoons",
+          "text": "Pontoons",
+          "nextQuestionRoute": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/pontoons"
+        },
+        {
+          "id": "scientificResearch",
+          "text": "Scientific investigation or research",
+          "nextQuestionRoute": "/exemption/deposit/scientific-research",
+          "hint": "Scientific instruments, associated equipment and tracers"
+        },
+        {
+          "id": "hullCleaning",
+          "text": "Hull cleaning",
+          "nextQuestionRoute": "/exemption/deposit/vessels/hull-cleaning"
+        },
+        {
+          "id": "maintenance",
+          "text": "Maintenance of existing structures or assets",
+          "nextQuestionRoute": "/exemption/deposit/maintenance",
+          "hint": "'Maintenance' means the upkeep or repair of an existing structure or asset wholly within its existing 3 dimensional boundaries"
+        },
+        {
+          "id": "dredgedMaterial",
+          "text": "Deposit or disposal of dredged material",
+          "nextQuestionRoute": "/exemption/deposit/dredged-material"
+        },
+        {
+          "id": "emergency",
+          "text": "Emergency, safety and training",
+          "nextQuestionRoute": "/exemption/deposit/emergency-safety-accident-investigation"
+        },
+        {
+          "id": "pollutionResponse",
+          "text": "Pollution prevention and discharge of chemicals",
+          "nextQuestionRoute": "/exemption/deposit/pollution"
+        },
+        {
+          "id": "defenceMiningCrossrail",
+          "text": "Miscellaneous",
+          "nextQuestionRoute": "/exemption/deposit/miscellaneous",
+          "hint": "Other deposit activities for purposes not set out above"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/maintenance",
+      "text": "What does the maintenance activity relate to?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "coastalProtectionDrainageFloodDefence",
+          "text": "Coast protection, drainage or flood defence works",
+          "nextQuestionRoute": "/exemption/deposit/maintenance/coastal-drainage-flood"
+        },
+        {
+          "id": "harbourWorkMaintenance",
+          "text": "Harbour works",
+          "nextQuestionRoute": "/exemption/deposit/maintenance/harbour-works",
+          "hint": "Maintenance carried out by or on behalf of harbour authorities only."
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/maintenance/coastal-drainage-flood",
+      "text": "Who will carry out the activity?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "environmentAgency",
+          "text": "The Environment Agency or someone on behalf of the Environment Agency",
+          "nextQuestionRoute": "/exemption/deposit/maintenance/coastal-drainage-flood/EA"
+        },
+        {
+          "id": "coastProtectionAuthority",
+          "text": "The Coast Protection Authority or someone on behalf of the Coast Protection Authority",
+          "nextQuestionRoute": "/exemption/deposit/maintenance/coastal-drainage-flood/CPA"
+        },
+        {
+          "id": "localAuthority",
+          "text": "The Local Authority or someone on behalf of the Local Authority",
+          "nextQuestionRoute": "/exemption/deposit/maintenance/coastal-drainage-flood/CPA"
+        },
+        {
+          "id": "secretaryStateDefence",
+          "text": "The Secretary of State for Defence or someone on behalf of the Secretary of State for Defence",
+          "nextQuestionRoute": "/exemption/deposit/maintenance/coastal-drainage-flood/CPA"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/maintenance/coastal-drainage-flood/EA",
+      "text": "Will the activity be carried out wholly within the existing 3 dimensional boundary of the works being maintained?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/deposit/maintenance/coastal-drainage-flood/EA/beach-replenishment"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/deposit/maintenance/coastal-drainage-flood/EA/emergency-flood"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/maintenance/coastal-drainage-flood/EA/beach-replenishment",
+      "text": "Does the activity involve beach replenishment?",
+            "hint": "'Beach replenishment' means the addition of material from land-based, off-shore or other coastal sources not connected to the beach or its associated sediment system to replace material permanently lost from the system.",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-19"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/maintenance/coastal-drainage-flood/CPA",
+      "text": "Is the activity for the purpose of maintaining coast protection works?",
+            "hint": "'Coast protection works' include: </li><li><u>beach re-profiling</U>, which involves the movement of beach material in a cross-shore direction up or down the beach; and </li><li><u>beach recycling</u>, which involves the movement of beach material along the beach from areas of accretion to areas of erosion within the beach or associated sediment system.",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/deposit/maintenance/coastal-drainage-flood/CPA/beach-replenishment"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/maintenance/coastal-drainage-flood/CPA/beach-replenishment",
+      "text": "Does the activity involve beach replenishment?",
+            "hint": "'Beach replenishment' means the addition of material from land-based, off-shore or other coastal sources not connected to the beach or its associated sediment system to replace material permanently lost from the system.",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-19"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/maintenance/coastal-drainage-flood/EA/emergency-flood",
+      "text": "Are the circumstances serious, unexpected, and potentially dangerous requiring immediate action in response to either flooding or imminent risk of flooding?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-20"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/maintenance/harbour-works",
+      "text": "Is the activity for the purpose of maintaining harbour works?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/deposit/maintenance/harbour-works/boundaries"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/maintenance/harbour-works/boundaries",
+      "text": "Will the activity be carried out within the 3 dimensional boundaries of the existing works?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/deposit/maintenance/harbour-works/undertaker"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/maintenance/harbour-works/undertaker",
+      "text": "Will the activity be carried out by or on behalf of the harbour authority?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-23"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/fishing",
+      "text": "What does the deposit activity relate to?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "shellfishPropogationCultivation",
+          "text": "Shellfish propogation and cultivation",
+          "nextQuestionRoute": "/exemption/deposit/fishing/shellfish-propagation-cultivation"
+        },
+        {
+          "id": "fishingOperations",
+          "text": "Fishing operations",
+          "nextQuestionRoute": "/exemption/deposit/fishing/fishing-operations"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/fishing/shellfish-propagation-cultivation",
+      "text": "Will the activity involve the deposit of a shellfish, trestle, raft, cage, pole, rope, marker or line in the course of propagation or cultivation of shellfish?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/deposit/fishing/shellfish-propagation-cultivation/obstruction"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/fishing/shellfish-propagation-cultivation/obstruction",
+      "text": "Will the deposit cause or be likely to cause an obstruction or danger to navigation?",
+      "section": "deposit",
+      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#navigational-risk\"> navigational risk </a> and the steps you can take to ensure your proposal is not one that will cause or be likely to cause and obstruction or danger.",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/deposit/fishing/shellfish-propagation-cultivation/disposal-artificial-reef"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/fishing/shellfish-propagation-cultivation/disposal-artificial-reef",
+      "text": "Is the deposit for the purpose of",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "disposal",
+          "text": "Disposal",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        },
+        {
+          "id": "creatingAlertingMaintainingArtificialReef",
+          "text": "Creating, altering or maintaining an artificial reef",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-13"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/fishing/fishing-operations",
+      "text": "What will be deposited",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "depositFishingGear",
+          "text": "Fishing Gear",
+          "nextQuestionRoute": "/exemption/deposit/fishing/fishing-operations/fishing-gear",
+          "hint": "'Fishing gear' includes gear used to fish for or take shellfish, but does not include anything used in connection with propagation or cultivation of shellfish."
+        },
+        {
+          "id": "depositReturns",
+          "text": "Fish or other objects caught and returned in the course of a fishing operation",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-12",
+          "hint": "'Fish' includes any part of a fish and also shellfish."
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/fishing/fishing-operations/fishing-gear",
+      "text": "Is the purpose of the deposit to dispose of the gear?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-12"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/dredged-material",
+      "text": "Will the activity be carried out by or on behalf of the harbour authority?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/deposit/dredged-material/authorisation"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/dredged-material/authorisation",
+      "text": "Is the activity authorised by",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "localAct",
+          "text": "A local Act",
+          "nextQuestionRoute": "/exemption/deposit/dredged-material/method"
+        },
+        {
+          "id": "harboursAct",
+          "text": "An order under Section 14 or 16 of the Harbours Act 1964",
+          "nextQuestionRoute": "/exemption/deposit/dredged-material/method"
+        },
+        {
+          "id": "section1HaNorthernIreland",
+          "text": "An order under Section 1 of the Harbours Act (Northern ireland) 1970",
+          "nextQuestionRoute": "/exemption/deposit/dredged-material/method"
+        },
+        {
+          "id": "section10HaNorthernIreland",
+          "text": "An order under Section 10(3) of the Harbours Act (Northern ireland) 1970",
+          "nextQuestionRoute": "/exemption/deposit/dredged-material/method"
+        },
+        {
+          "id": "other",
+          "text": "None of the above",
+           "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/dredged-material/method",
+      "text": "Will the activity be carried out in accordance with the relevant authorisation?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/deposit/dredged-material/location"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/dredged-material/location",
+      "text": "Will the material be disposed of inside surface waters?",
+      "section": "deposit",
+      "hint": "'Surface waters' is defined in Article 2 of the <a target=\"_blank\" href=\"https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32000L0060\">EU Waste Framework Directive (2000/60/EC)</a>.",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/deposit/dredged-material/purpose"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/dredging-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/dredged-material/purpose",
+      "text": "What is the purpose of the project the disposal relates to?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "watersWaterways",
+          "text": "Managing waters or waterways",
+          "nextQuestionRoute": "/exemption/deposit/dredged-material/non-hazardous"
+        },
+        {
+          "id": "preventingFloods",
+          "text": "Preventing floods",
+          "nextQuestionRoute": "/exemption/deposit/dredged-material/non-hazardous"
+        },
+        {
+          "id": "floodsDroughts",
+          "text": "Mitigating the effects of floods or droughts",
+          "nextQuestionRoute": "/exemption/deposit/dredged-material/non-hazardous"
+        },
+        {
+          "id": "landReclamation",
+          "text": "Land reclamation",
+          "nextQuestionRoute": "/exemption/deposit/dredged-material/non-hazardous"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/dredged-material/non-hazardous",
+      "text": "Can you demonstrate that the material to be deposited or disposed is non-hazardous?",
+      "hint": "The properties that determine if waste is 'hazardous' are set out in annex III <a target=\"_blank\" href=\"https://ec.europa.eu/environment/waste/framework/list.htm\">EU Waste Framework Directive (2008/98/EC)</a>.",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-Section-75-disposal"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/emergency-safety-accident-investigation",
+      "text": "What does the deposit activity relate to?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "floodFloodRisk",
+          "text": "Flood or flood risk",
+          "nextQuestionRoute": "/exemption/deposit/emergency-safety-accident-investigation/flood"
+        },
+        {
+          "id": "cablesPipelines",
+          "text": "Cables and pipelines",
+          "nextQuestionRoute": "/exemption/deposit/emergency-safety-accident-investigation/cables-pipelines"
+        },
+        {
+          "id": "coastguardActivities",
+          "text": "Coastguard activities - safety purposes and training",
+          "nextQuestionRoute": "/exemption/deposit/emergency-safety-accident-investigation/coastguard"
+        },
+        {
+          "id": "flares",
+          "text": "Flares - Safety purposes and training",
+          "nextQuestionRoute": "/exemption/deposit/emergency-safety-accident-investigation/flares"
+        },
+        {
+          "id": "salvageOperation",
+          "text": "Salvage Operation",
+          "nextQuestionRoute": "/exemption/deposit/emergency-safety-accident-investigation/salvage"
+        },
+        {
+          "id": "safetyDirections",
+          "text": "Safety directions under the Merchant Shipping Act 1995",
+          "nextQuestionRoute": "/exemption/deposit/emergency-safety-accident-investigation/safety-directions"
+        },
+        {
+          "id": "firefighting",
+          "text": "Fire Fighting",
+          "nextQuestionRoute": "/exemption/deposit/emergency-safety-accident-investigation/fire-fighting"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue",
+          "hint": "Other deposit activities for purposes not set out above"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/emergency-safety-accident-investigation/flood",
+      "text": "Will the activity be carried out by or on behalf of the Environment Agency?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/deposit/emergency-safety-accident-investigation/flood/emergency"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/emergency-safety-accident-investigation/flood/emergency",
+      "text": "Are the circumstances serious, unexpected and potentially dangerous requiring immediate action in response to flood or imminent risk of flood?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-20"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/emergency-safety-accident-investigation/cables-pipelines",
+      "text": "Does the deposit activity relate to the inspection or repair of an existing cable or pipeline",
+      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities--2#cables-pipelines-oil-and-gas-and-carbon-capture-storage\"> cables and pipelines </a>.",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/deposit/emergency-safety-accident-investigation/cables-pipelines/emergency"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/emergency-safety-accident-investigation/cables-pipelines/emergency",
+      "text": "Are the circumstances serious, unexpected and potentially dangerous requiring immediate action?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/deposit/emergency-safety-accident-investigation/cables-pipelines/protection"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/emergency-safety-accident-investigation/cables-pipelines/protection",
+      "text": "Will the activity proposed include the deposit of rock or other materials for the purpose of providing <u>new</U> pipeline protection?",
+      "hint": "Deposits for these purposes, i.e. those beyond the replenishment or replacement of materials within the three dimensional boundaries of those previously consented and deposited, will require a marine licence. If the maintenance, inspection or repair can be carried out without the need for new protection you are advised to adapt your proposed approach. <P><P>NOTE: If you intend to apply for a marine licence in respect of the addition of new or extended protection, where relevant, please select ‘No’ to continue.",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/deposit/emergency-safety-accident-investigation/cables-pipelines/explosives"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/emergency-safety-accident-investigation/cables-pipelines/explosives",
+      "text": "Does the activity involve the deposit or use of explosives?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-34"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/emergency-safety-accident-investigation/coastguard",
+      "text": "Will the activity be carried out by or on behalf the Secretary of State for Transport, acting through the Maritime and Coastguard Agency?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/deposit/emergency-safety-accident-investigation/coastguard/purpose"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/emergency-safety-accident-investigation/coastguard/purpose",
+      "text": "What is the purpose of the activity?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "securingVesselAircraftMarineStructureSafety",
+          "text": "Securing the safety of a vessel, aircraft or marine structure ",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-32",
+          "hint": "'marine structure' means a platform or other artificial structure at 'Sea', other than a pipeline."
+        },
+        {
+          "id": "savingLife",
+          "text": "Saving life",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-32"
+        },
+        {
+          "id": "training",
+          "text": "Training for either of the above two purposes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-32"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/emergency-safety-accident-investigation/flares",
+      "text": "Will the activity involve the deposit or use of a distress flare, smoke float or similar pyrotechnic substance or object",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/deposit/emergency-safety-accident-investigation/flares/purpose"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/emergency-safety-accident-investigation/flares/purpose",
+      "text": "What is the purpose of the activity?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "securingVesselAircraftMarineStructureSafety",
+          "text": "Securing the safety of a vessel, aircraft or marine structure ",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-33",
+          "hint": "'marine structure' means a platform or other artificial structure at 'Sea', other than a pipeline."
+        },
+        {
+          "id": "savingLife",
+          "text": "Saving life",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-33"
+        },
+        {
+          "id": "training",
+          "text": "Training for either of the above two purposes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-33"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/emergency-safety-accident-investigation/salvage",
+      "text": "Will the deposit be made in the course of an official salvage operation for the purpose of ensuring the safety of a vessel or preventing pollution?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-9"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/emergency-safety-accident-investigation/safety-directions",
+      "text": "What is the purpose of the deposit",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "secretaryOfStateSchedule3A",
+          "text": "In exercise of a power under Schedule 3A to the Merchant Shipping Act 1995 (safety directions) by or on behalf of the Secretary of State",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-8"
+        },
+        {
+          "id": "schedule3ACompliance",
+          "text": "Compliance with a direction under Schedule 3A to the Merchant Shipping Act 1995 (safety directions)",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-8"
+        },
+        {
+          "id": "avoidingInterference",
+          "text": "Avoiding interference with action taken under Schedule 3A to the Merchant Shipping Act 1995 (safety directions)",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-8"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/emergency-safety-accident-investigation/fire-fighting",
+      "text": "Will the activity be carried out for the purpose of fighting or preventing the spread of fire?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-10"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/emergency-safety-accident-investigation/air-accident-investigation",
+      "text": "Will the activity be carried out for the purpose of recovering a substance or object as part of an official investigation into an accident involving aircraft?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-11"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/pollution",
+      "text": "What does the deposit activity relate to?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "pollutionPreventionAndTreatment",
+          "text": "Pollution prevention and treatment",
+          "nextQuestionRoute": "/exemption/deposit/pollution/pollution-prevention-treatment"
+        },
+        {
+          "id": "dischargeOffshoreChemicalsOil",
+          "text": "Discharge of offshore chemicals and oil",
+          "hint": "Activities authorised under the Offshore Chemical Regulations 2002 or the Offshore Petroleum Activities (Oil and Pollution Prevention and Control) Regulations 2005.",
+          "nextQuestionRoute": "/exemption/deposit/pollution/offshore-chemical-oil"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/pollution/pollution-prevention-treatment",
+      "text": "What does the deposit activity relate to?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "equipmentContainControlRecoverOilsEtc",
+          "text": "Equipment to contain, control or recover oils etc",
+          "nextQuestionRoute": "/exemption/deposit/pollution/pollution-response-equipment"
+        },
+        {
+          "id": "marineChemicalMarineOilTreatment",
+          "text": "Marine chemical and marine oil treatment substances",
+          "nextQuestionRoute": "/exemption/deposit/pollution/chemical-oil-treatment"
+        },
+        {
+          "id": "pollutionPreventionPart6MerchantShippingAct1995",
+          "text": "Activities within Part 6 of the Merchant Shipping Act 1995",
+          "nextQuestionRoute": "/exemption/deposit/pollution/pollution-prevention"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/pollution/pollution-response-equipment",
+      "text": "Is the equipment to be deposited for the purpose of controlling, containing or recovering oil, a mixture containing oil, chemicals, flotsam or algae blooms?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/deposit/pollution/pollution-response-equipment/explosives"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/pollution/pollution-response-equipment/explosives",
+      "text": "Will the activity involve the deposit or use of an explosive substance or object?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-16"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/pollution/chemical-oil-treatment",
+      "text": "What is the purpose of the deposit",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "oilSpills",
+          "text": "Dispersing or treating oil spills",
+          "nextQuestionRoute": "/exemption/deposit/pollution/chemical-oil-treatment/approved"
+        },
+        {
+          "id": "chemicalPollution",
+          "text": "Treat chemical pollution",
+          "nextQuestionRoute": "/exemption/deposit/pollution/chemical-oil-treatment/approved"
+        },
+        {
+          "id": "seabedFouling",
+          "text": "Remove fouling matter from the surface of the 'Sea' or 'Seabed'",
+          "nextQuestionRoute": "/exemption/deposit/pollution/chemical-oil-treatment/approved"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/pollution/chemical-oil-treatment/approved",
+      "text": "Is the substance to be deposited one which is approved for the purposes by the MMO?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/deposit/pollution/chemical-oil-treatment/conditions"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/pollution/chemical-oil-treatment/conditions",
+      "text": "Will the substance be used in accordance with conditions to which the approval is subject?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-15"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/pollution/offshore-chemical-oil",
+      "text": "Is a permit required to carry out the activity under the Offshore Chemical Regulations 2002?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-14"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/deposit/pollution/offshore-chemical-oil/Permit2"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/pollution/offshore-chemical-oil/Permit2",
+      "text": "Is a permit required to carry out the activity under the Offshore Petroleum Activities (Oil and Pollution Prevention and Control) Regulations 2005?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-14"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/pollution/pollution-prevention",
+      "text": "Does the activity proposed to be carried out fall within the subject matter of Part 6 of the Merchant Shipping Act 1995 (prevention of pollution)?",
+      "hint": "Find out more about <a target=\"_blank\" href=\" http://www.legislation.gov.uk/ukpga/1995/21/part/VI\"> Part 6 of the Merchant Shipping Act 1995</a>",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-7"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation",
+      "text": "What does the deposit activity relate to?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "temporaryMarkers",
+          "text": "Temporary markers",
+          "nextQuestionRoute": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/temporary-markers"
+        },
+        {
+          "id": "mooringsAidsToNavigation",
+          "text": "Moorings or aids to navigation",
+          "nextQuestionRoute": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/moorings",
+          "hint": "Activities carried out by or on behalf of Lighthouse and Harbour authorities only"
+        },
+        {
+          "id": "marineSiteMarkers",
+          "text": "Markers for European marine sites and marine conservation zones",
+          "nextQuestionRoute": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/marine-site-markers"
+        },
+        {
+          "id": "diverTrails",
+          "text": "Diver trails",
+          "nextQuestionRoute": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/dive-trails"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/temporary-markers",
+      "text": "What is the purpose of the activity?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "markerLess24Hours",
+          "text": "Placing a marker that will be in place for less than 24 hours",
+          "nextQuestionRoute": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/temporary-markers24/obstruction"
+        },
+        {
+          "id": "markerLess28Days",
+          "text": "Placing a marker that will be in place for longer than 24 hours but less than 28 days",
+          "nextQuestionRoute": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/temporary-markers/obstruction"
+        },
+        {
+          "id": "markerGreater28Days",
+          "text": "Placing a marker that will be in place for longer than than 28 days",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/temporary-markers24/obstruction",
+      "text": "Will the activity cause or be likely to cause an obstruction or danger to navigation?",
+      "section": "deposit",
+      "hint": " Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#navigational-risk\"> navigational risk </a> and the steps you can take to ensure your proposal is not one that will cause or be likely to cause and obstruction or danger.",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/temporary-markers24/mpa"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/temporary-markers24/mpa",
+      "text": "Will the activity take place in or within 200m of a Marine Protected Area (MPA)?",
+      "section": "deposit",
+   "hint": "<p>MPA's are an important part of the marine environment. </p><p>You are responsible for making sure you understand the status of the location where the activity is proposed. </p><p> ‘Marine protected areas’ mean:<ul><li>Highly Protected Marine Area (HPMA) (designated and candidate)</li><li>Marine Conservation Zones (MCZs) (designated and proposed)</li><li>Special Areas of Conservation (SACs) (designated and candidate)</li><li>Special Protection Areas (SPAs) (designated and potential)</li><li>Ramsar's</li><li>SSSIs</li></ul></p><p> If you are unsure of whether the activity falls within an MPA you should select the appropriate layer in the MMO’s <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\"> GIS tool </a> to check.",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/temporary-markers24/mpa-management"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-26a-no-notification"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/temporary-markers24/mpa-management",
+      "text": "Is the activity directly connected with or necessary to the management of the Marine Protected Area?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-26a-no-notification"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/temporary-markers24/lse"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/temporary-markers24/lse",
+      "text": "Is the activity....",
+      "section": "deposit",
+      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#marine-protected-areas\"> marine protected areas </a>.",
+      "answers": [
+        {
+          "id": "europeanSiteTemporaryMarkers",
+          "text": "Likely to have a significant effect on a European site?",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue",
+          "hint": "either alone or in combination with other plans and projects"
+        },
+        {
+          "id": "ramsarSiteTemporaryMarkers",
+          "text": "Likely to have a significant effect on a Ramsar site?",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue",
+          "hint": "either alone or in combination with other plans and projects"
+        },
+        {
+          "id": "mczTemporaryMarkers",
+          "text": "Capable of affecting (other than insignificantly), the protected features of a Marine Conservation Zone or Highly Protected Marine Area?",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue",
+          "hint": "including any ecological or geomorphological process on which the conservation of any protected feature of an MCZ or HPMA is (wholly or in Part) dependant"
+        },
+        {
+          "id": "otherTemporaryMarkers",
+          "text": "Unlikely to have any relevant effect on any sites specified above?",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-26a-no-notification"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/temporary-markers/obstruction",
+      "text": "Will the activity cause or be likely to cause an obstruction or danger to navigation?",
+      "section": "deposit",
+      "hint": " Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#navigational-risk\"> navigational risk </a> and the steps you can take to ensure your proposal is not one that will cause or be likely to cause and obstruction or danger.",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/temporary-markers/mpa"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/temporary-markers/mpa",
+      "text": "Will the activity take place in or within 200m of a Marine Protected Area (MPA)?",
+      "section": "deposit",
+  "hint": "<p>MPA's are an important part of the marine environment. </p><p>You are responsible for making sure you understand the status of the location where the activity is proposed. </p><p> ‘Marine protected areas’ mean:<ul><li>Highly Protected Marine Area (HPMA) (designated and candidate)</li><li>Marine Conservation Zones (MCZs) (designated and proposed)</li><li>Special Areas of Conservation (SACs) (designated and candidate)</li><li>Special Protection Areas (SPAs) (designated and potential)</li><li>Ramsar's</li><li>SSSIs</li></ul></p><p> If you are unsure of whether the activity falls within an MPA you should select the appropriate layer in the MMO’s <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\"> GIS tool </a> to check.",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/temporary-markers/mpa-management"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-26a"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/temporary-markers/mpa-management",
+      "text": "Is the activity directly connected with or necessary to the management of the Marine Protected Area?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-26a"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/temporary-markers/lse"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/temporary-markers/lse",
+      "text": "Is the activity....",
+      "section": "deposit",
+      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#marine-protected-areas\"> marine protected areas </a>.",
+      "answers": [
+        {
+          "id": "europeanSiteTemporaryMarkers",
+          "text": "Likely to have a significant effect on a European site?",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue",
+          "hint": "either alone or in combination with other plans and projects"
+        },
+        {
+          "id": "ramsarSiteTemporaryMarkers",
+          "text": "Likely to have a significant effect on a Ramsar site?",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue",
+          "hint": "either alone or in combination with other plans and projects"
+        },
+        {
+          "id": "mczTemporaryMarkers",
+          "text": "Capable of affecting (other than insignificantly), the protected features of a Marine Conservation Zone or Highly Protected Marine Area?",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue",
+          "hint": "including any ecological or geomorphological process on which the conservation of any protected feature of an MCZ or HPMA is (wholly or in Part) dependant"
+        },
+        {
+          "id": "otherTemporaryMarkers",
+          "text": "Unlikely to have any relevant effect on any sites specified above?",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-26a"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/marine-site-markers",
+      "text": "Who will carry out the activity?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "naturalEngland",
+          "text": "Natural England",
+          "nextQuestionRoute": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/marine-site-markers/ne-purpose"
+        },
+        {
+          "id": "publicAuthority",
+          "text": "A public authority",
+          "nextQuestionRoute": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/marine-site-markers/pa-purpose"
+        },
+        {
+          "id": "other",
+          "text": "Someone else",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/marine-site-markers/ne-purpose",
+      "text": "What is the purpose of the activity?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "marineSiteExistence",
+          "text": "Installing a marker to indicate the existence and extent of a European Marine Site",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-26"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/marine-site-markers/pa-purpose",
+      "text": "What is the purpose of the activity?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "marineSiteExistence",
+          "text": "Installing a marker to indicate the existence and extent of a Marine Conservation Zone",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-26"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/moorings",
+      "text": "What will be deposited?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "pileMooring",
+          "text": "Pile mooring",
+          "nextQuestionRoute": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/moorings/undertaker"
+        },
+        {
+          "id": "swingingMooring",
+          "text": "Swinging mooring",
+          "nextQuestionRoute": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/moorings/undertaker"
+        },
+        {
+          "id": "trotMooring",
+          "text": "Trot Mooring",
+          "nextQuestionRoute": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/moorings/undertaker"
+        },
+        {
+          "id": "aidToNavigation",
+          "text": "Aid to Navigation",
+          "nextQuestionRoute": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/moorings/undertaker"
+        },
+        {
+          "id": "other",
+          "text": "Something else",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/moorings/undertaker",
+      "text": "Who will carry out the activity?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "harbourAuthority",
+          "text": "A harbour authority or someone on behalf of a harbour authority",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-25"
+        },
+        {
+          "id": "lighthouseAuthority",
+          "text": "A lighthouse authority or someone on behalf of a lighthouse authority",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-25"
+        },
+        {
+          "id": "someoneElse",
+          "text": "Someone else",
+          "nextQuestionRoute": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/moorings/consent"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/moorings/consent",
+      "text": "Does the activity require consent (e.g. a licence) from a harbour authority under local legislation?",
+      "hint": "The permission or agreement of the authority does not constitute consent for these purposes.",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/moorings/approval"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/moorings/approval",
+      "text": "Has consent been granted?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-25-notification"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/pontoons",
+      "text": "Is the purpose of the activity to provide a pontoon?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/pontoons/undertaker"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/pontoons/undertaker",
+      "text": "Who will carry out the activity?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "harbourAuthority",
+          "text": "A harbour authority or someone on behalf of a harbour authority",
+          "nextQuestionRoute": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/pontoon/deck"
+        },
+        {
+          "id": "someoneElse",
+          "text": "Someone else",
+          "nextQuestionRoute": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/pontoon/consent"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/pontoon/consent",
+      "text": "Does the activity require consent (e.g. a licence) from a harbour authority under local legislation?",
+      "hint": "The permission or agreement of the authority does not constitute consent for these purposes.",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/pontoon/approval"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/pontoon/approval",
+      "text": "Has consent been granted?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/pontoon/deck"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/pontoon/deck",
+      "text": "When complete will the deck of the pontoon be an area greater than 30m2?",
+            "hint": "NOTE: If the pontoon will be attached to one or more pontoons already in place the question refers to the total deck area of all pontoons combined.",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/pontoon/quantity"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/pontoon/quantity",
+      "text": "In the 6 months prior to the commencement of this activity will 10 or more pontoons have been constructed or deposited at the location?",
+      "section": "deposit",
+      "hint": "either by or on behalf of the harbour authority or with the consent required from and granted by the harbour authority",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-25A-mmo-approval"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-25A"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/dive-trails",
+      "text": "Is the purpose of the activity to place or secure signage or other identifying markers relating to:",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "protectionWrecksAct",
+          "text": "a wreck within an area designated as a restricted area within the meaning of section 1 of the Protection of Wrecks Act 1973",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-31"
+        },
+        {
+          "id": "monumentsArchaeologicalAreasAct",
+          "text": "a monument designated as a scheduled monument under section 1 of the Ancient Monuments and Archaeological Areas Act 1979",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-31"
+        },
+        {
+          "id": "protectionMilitaryRemainsAct",
+          "text": "an area designated as a controlled site under section 1(2)(b) of the Protection of Military Remains Act 1986",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-31"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/scientific-research",
+      "text": "What does the depsoit activity relate to?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "scientificInstruments",
+          "text": "Scientific instruments and associated equipment",
+          "nextQuestionRoute": "/exemption/deposit/scientific-research/scientific-equipment"
+        },
+        {
+          "id": "tracersReagents",
+          "text": "Tracers and reagents",
+          "nextQuestionRoute": "/exemption/deposit/scientific-research/tracers-reagents"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/scientific-research/scientific-equipment",
+      "text": "Is the object to be deposited a scientific instrument or equipment associated with such an instrument?",
+      "hint": "'Scientific instrument' means a specialist device or tool, designed to measure, record or analyse data for scientific purposes. ‘Associated equipment’ means equipment fundamental to the functioning or operation of the instrument itself.",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/deposit/scientific-research/scientific-equipment/survey"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/scientific-research/scientific-equipment/survey",
+      "text": "Is the instrument or equipment to be deposited as part of a scientific experiment or survey?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/deposit/scientific-research/scientific-equipment/tethered"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/scientific-research/scientific-equipment/tethered",
+      "text": "Will the scientific instrument or associated equipment to be deposited be tethered to the 'Seabed'?",
+      "hint": "'Tethered' means to fasten, fix or attach by any means to limit the instruments range of movement.<p><p>'Seabed' means the ground under the 'Sea' and anything resting on it such as a wreck. It includes the intertidal area of the sea or any river at such time as it is exposed temporarily at low tide.<p><p>'Sea' includes any area which is submerged at MHWS and the waters of every estuary, river or channel where the tide flows at MHWS tide up to the NTL. Even waters in areas which are closed permanently or intermittently by a lock or other artificial means against the regular action of the tide are included, where seawater flows into or out from the area, either continuously or from time to time.<p><p>Find out more about the MMO’s <a target=\"_blank\" href=\"https://www.gov.uk/guidance/marine-licensing-definitions#what-do-we-mean-by-the-sea\">jurisdiction</a>.",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/deposit/scientific-research/scientific-equipment/navigational-clearance"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/scientific-research/scientific-equipment/navigational-clearance",
+      "text": "Will the scientific instrument or associated equipment to be deposited reduce navigational clearance by more than 5% by reference to 'chart datum'?",
+      "section": "deposit",
+      "hint": "'Chart Datum' is the plane below which all depths are published on a navigational chart. It is also the plane to which all tidal heights are referred, so by adding the tidal height to the charted depth, the true depth of water is determined. By international agreement Chart Datum is defined as a level so low that the tide will not frequently fall below it. In the United Kingdom, this level is normally approximately the level of Lowest Astronomical Tide.",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/deposit/scientific-research/scientific-equipment/obstruction"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/scientific-research/scientific-equipment/obstruction",
+      "text": "Will the activity cause or be likely to cause an obstruction or danger to navigation?",
+      "section": "deposit",
+      "hint": " Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#navigational-risk\"> navigational risk </a> and the steps you can take to ensure your proposal is not one that will cause or be likely to cause and obstruction or danger.",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/deposit/scientific-research/scientific-equipment/mpa"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/scientific-research/scientific-equipment/mpa",
+      "text": "Will the activity take place in or within 200m of a Marine Protected Area (MPA)?",
+      "section": "deposit",
+  "hint": "<p>MPA's are an important part of the marine environment. </p><p>You are responsible for making sure you understand the status of the location where the activity is proposed. </p><p> ‘Marine protected areas’ mean:<ul><li>Highly Protected Marine Area (HPMA) (designated and candidate)</li><li>Marine Conservation Zones (MCZs) (designated and proposed)</li><li>Special Areas of Conservation (SACs) (designated and candidate)</li><li>Special Protection Areas (SPAs) (designated and potential)</li><li>Ramsar's</li><li>SSSIs</li></ul></p><p> If you are unsure of whether the activity falls within an MPA you should select the appropriate layer in the MMO’s <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\"> GIS tool </a> to check.",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/deposit/scientific-research/scientific-equipment/mpa-management"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/deposit/scientific-research/scientific-equipment/disposal"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/scientific-research/scientific-equipment/mpa-management",
+      "text": "Is the activity directly connected with or necessary to the management of the Marine Protected Area?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/deposit/scientific-research/scientific-equipment/disposal"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/deposit/scientific-research/scientific-equipment/lse"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/scientific-research/scientific-equipment/lse",
+      "text": "Is the activity....",
+      "section": "deposit",
+      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#marine-protected-areas\"> marine protected areas </a>.",
+      "answers": [
+        {
+          "id": "europeanSiteScientificEquipment",
+          "text": "Likely to have a significant effect on a European site?",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue",
+          "hint": "either alone or in combination with other plans and projects"
+        },
+        {
+          "id": "ramsarSiteScientificEquipment",
+          "text": "Likely to have a significant effect on a Ramsar site?",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue",
+          "hint": "either alone or in combination with other plans and projects"
+        },
+        {
+          "id": "mczScientificEquipment",
+          "text": "Capable of affecting (other than insignificantly), the protected features of a Marine Conservation Zone or Highly Protected Marine Area?",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue",
+          "hint": "including any ecological or geomorphological process on which the conservation of any protected feature of an MCZ or HPMA is (wholly or in Part) dependant"
+        },
+        {
+          "id": "otherScientificEquipment",
+          "text": "Unlikely to have any relevant effect on any sites specified above",
+          "nextQuestionRoute": "/exemption/deposit/scientific-research/scientific-equipment/disposal"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/scientific-research/scientific-equipment/disposal",
+      "text": "Is the deposit made for the purpose of disposal?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-17"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/scientific-research/tracers-reagents",
+      "text": "Is the reagent or tracer approved for use by the MMO?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/deposit/scientific-research/tracers-reagents/obstruction"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/scientific-research/tracers-reagents/obstruction",
+      "text": "Will the activity cause or be likely to cause an obstruction or danger to navigation?",
+      "section": "deposit",
+      "hint": " Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#navigational-risk\"> navigational risk </a> and the steps you can take to ensure your proposal is not one that will cause or be likely to cause and obstruction or danger.",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/deposit/scientific-research/tracers-reagents/mpa"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/scientific-research/tracers-reagents/mpa",
+      "text": "Will the activity take place in or within 200m of a Marine Protected Area (MPA)?",
+      "section": "deposit",
+   "hint": "<p>MPA's are an important part of the marine environment. </p><p>You are responsible for making sure you understand the status of the location where the activity is proposed. </p><p> ‘Marine protected areas’ mean:<ul><li>Highly Protected Marine Area (HPMA) (designated and candidate)</li><li>Marine Conservation Zones (MCZs) (designated and proposed)</li><li>Special Areas of Conservation (SACs) (designated and candidate)</li><li>Special Protection Areas (SPAs) (designated and potential)</li><li>Ramsar's</li><li>SSSIs</li></ul></p><p> If you are unsure of whether the activity falls within an MPA you should select the appropriate layer in the MMO’s <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\"> GIS tool </a> to check.",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/deposit/scientific-research/tracers-reagents/mpa-management"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-17"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/scientific-research/tracers-reagents/mpa-management",
+      "text": "Is the activity directly connected with or necessary to the management of the Marine Protected Area?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-17"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/deposit/scientific-research/tracers-reagents/lse"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/scientific-research/tracers-reagents/lse",
+      "text": "Is the activity....",
+      "section": "deposit",
+      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#marine-protected-areas\"> marine protected areas </a>.",
+      "answers": [
+        {
+          "id": "europeanSiteTracers",
+          "text": "Likely to have a significant effect on a European site",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue",
+          "hint": "either alone or in combination with other plans and projects"
+        },
+        {
+          "id": "ramsarSiteTracers",
+          "text": "Likely to have a significant effect on a Ramsar site?",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue",
+          "hint": "either alone or in combination with other plans and projects"
+        },
+        {
+          "id": "mczTracers",
+          "text": "Capable of affecting (other than insignificantly), the protected features of a Marine Conservation Zone or Highly Protected Marine Area?",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue",
+          "hint": "including any ecological or geomorphological process on which the conservation of any protected feature of an MCZ or HPMA is (wholly or in Part) dependant"
+        },
+        {
+          "id": "otherTracers",
+          "text": "Unlikely to have any relevant effect on any sites specified above",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-17"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/vessels",
+      "text": "What is the purpose of the activity?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "launchingVessels",
+          "text": "Launching of vessels etc",
+          "nextQuestionRoute": "/exemption/deposit/vessels/launch"
+        },
+        {
+          "id": "normalNavigation",
+          "text": "Deposits in the normal course of navigation or maintenance",
+          "nextQuestionRoute": "/exemption/deposit/vessels/navigation"
+        },
+        {
+          "id": "aggregateDredging",
+          "text": "Deposits in the course of aggregate dredging",
+          "nextQuestionRoute": "/exemption/deposit/vessels/aggregate-dredging"
+        },
+        {
+          "id": "dismantlingShips",
+          "text": "Dismantling of ships",
+          "nextQuestionRoute": "/exemption/deposit/vessels/dismantling-ships"
+        },
+        {
+          "id": "foreignVessels",
+          "text": "Exercising rights of foreign vessels",
+          "nextQuestionRoute": "/exemption/deposit/vessels/foreign-vessels"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/vessels/launch",
+      "text": "Is the purpose of the deposit to facilitate the launching of a vehicle, vessel, aircraft, marine structure or floating container?",
+      "section": "deposit",
+      "hint": "'marine structure' means a platform or other artificial structure at 'Sea', other than a pipeline.",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/deposit/vessels/launch/construction"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/vessels/launch/construction",
+      "text": "Will the activity involve construction of any kind?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-27"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/vessels/hull-cleaning",
+      "text": "Does the deposit consist of a substance resulting from the cleaning of the hull of a vessel?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/deposit/vessels/hull-cleaning/method"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/vessels/hull-cleaning/method",
+      "text": "What method will be used to clean the hull?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "cloth",
+          "text": "By hand using a soft cloth",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-27A"
+        },
+        {
+          "id": "sponge",
+          "text": "By hand using a sponge",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-27A"
+        },
+        {
+          "id": "softBrush",
+          "text": "By hand using the bristles of a soft brush",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-27A"
+        },
+        {
+          "id": "sandpaper",
+          "text": "By hand using sandpaper with a grit size of at least P2000",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-27A"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue",
+          "hint": "ISO 6344-3:2013 sets standards for the determination of grain size distribution in relation to coated abrasives."
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/vessels/navigation",
+      "text": "Will the deposit be made from a vehicle, vessel, aircraft or marine structure in the normal course of its maintenance or navigation?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/deposit/vessels/navigation/disposal"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/vessels/navigation/disposal",
+      "text": "Will the substance or object deposited be recovered at any point?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/deposit/vessels/navigation/explosives"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/vessels/navigation/explosives",
+      "text": "Will the activity involve the deposit or use of any explosive substance or article?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-22"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/vessels/aggregate-dredging",
+      "text": "Was the substance or object to be deposited taken from the 'Sea' in the course of dredging for aggregates?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/deposit/vessels/aggregate-dredging/object-type"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/vessels/aggregate-dredging/object-type",
+      "text": "What will be deposited?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "aggregateMinerals",
+          "text": "Aggregate or minerals",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        },
+        {
+          "id": "water",
+          "text": "Water",
+          "nextQuestionRoute": "/exemption/deposit/vessels/aggregate-dredging/water-location"
+        },
+        {
+          "id": "somethingElse",
+          "text": "Something else",
+          "nextQuestionRoute": "/exemption/deposit/vessels/aggregate-dredging/something-else-location"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/vessels/aggregate-dredging/water-location",
+      "text": "Will the water be deposited by overflow or pumped discharge from the hold of the vessel at the site of dredging, either during or following its completion, and or on the return journey of the vessel?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-18"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/vessels/aggregate-dredging/something-else-location",
+      "text": "Will the substance or object be deposited at the site where the dredging took place?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-18"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+ {
+      "route": "/exemption/deposit/vessels/dismantling-ships",
+      "text": "Will the deposit be made as part of the dismantling of a ship that is waste?",
+      "section": "deposit",
+      "hint": "'Ship' is intended to refer to large commercial or flag bearing vessels, the dismantling of which is regulated under alternative relevant legislation. It does <u>not</u> include ‘houseboats’. <p><p>'Waste' is defined in Article 3 of the EU Waste Framework Directive (2008/98/EC) as 'any substance or object which the holder discards or intends or is required to discard'.<p><p> Please refer to the <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/waste-classification-technical-guidance\">Technical guidance WM3</a> on Waste classification. <p><p>If there is any doubt about whether the vessel you intend to dismantle is a ship you should seek advice from the marine licensing team.",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/deposit/vessels/dismantling-ships/disposal"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/vessels/dismantling-ships/disposal",
+      "text": "Is the deposit made for the purpose of disposal?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+         "nextQuestionRoute": "/exemption/deposit/vessels/dismantling-ships/explosives"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/vessels/dismantling-ships/explosives",
+      "text": "Will the activity involve the deposit or use of any explosive substance or article?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-28"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/vessels/foreign-vessels",
+      "text": "Will the activity be carried out in exercise of a right under rules of international law?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/deposit/vessels/foreign-vessels/undertaker"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/vessels/foreign-vessels/undertaker",
+      "text": "Will the activity be carried out by or in relation to",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "thirdCountry",
+          "text": "A third country vessel",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-37",
+          "hint": "Third country vessel” means a vessel which is flying the flag of, or is registered in, any State or territory (other than Gibraltar) which is not a member State and is not registered in a member State."
+        },
+        {
+          "id": "warship",
+          "text": "A warship, naval auxiliary, other vessel or aircraft owned or operated by a state and used, for the time being, only on government non-commercial service (whether or not the warship, naval auxiliary, other vessel is a third country vessel)",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-37"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/miscellaneous",
+      "text": "What does the deposit activity relate to?",
+      "section": "deposit",
+      "answers": [
+          {
+          "id": "vessels",
+          "text": "Vessels",
+          "nextQuestionRoute": "/exemption/deposit/vessels",
+          "hint": "Launching of a vessel, exercising rights of foreign vessels, normal navigation, aggregate or mineral dredging and dismantling of ships"
+        },
+        {
+          "id": "defenceActivities",
+          "text": "Defence activities",
+          "nextQuestionRoute": "/exemption/deposit/miscellaneous/defence-activities"
+        },
+        {
+          "id": "deepseaMining",
+          "text": "Licensed deepsea mining",
+          "nextQuestionRoute": "/exemption/deposit/miscellaneous/deepsea-mining"
+        },
+        {
+          "id": "crossrailAct",
+          "text": "Scheduled works authorised under the Crossrail Act 2008",
+          "nextQuestionRoute": "/exemption/deposit/miscellaneous/crossrail-act"
+        },
+        {
+          "id": "airAccidentInvestigation",
+          "text": "Air accident investigation",
+          "nextQuestionRoute": "/exemption/deposit/emergency-safety-accident-investigation/air-accident-investigation"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue",
+          "hint": "Other deposit activities for purposes not set out above"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/miscellaneous/defence-activities",
+      "text": "Who will carry out the activity?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "ukForces",
+          "text": "The naval, military or air forces of the crown (including reserve forces and the Royal Fleet Auxiliary)",
+          "nextQuestionRoute": "/exemption/deposit/miscellaneous/defence-activities/restriction"
+        },
+        {
+          "id": "visiting forces",
+          "text": "A visiting force within the meaning given by Section 12 of the Visiting Forces Act 1952",
+          "nextQuestionRoute": "/exemption/deposit/miscellaneous/defence-activities/restriction"
+        },
+        {
+          "id": "someoneElse",
+          "text": "Someone else",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/miscellaneous/defence-activities/restriction",
+      "text": "Will the activity involve construction or dredging of any kind?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/deposit/miscellaneous/defence-activities/purpose"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/miscellaneous/defence-activities/purpose",
+      "text": "What is the purpose of the activity?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "defenceOfTheRealm",
+          "text": "Defence of the Realm",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-36"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/miscellaneous/deepsea-mining",
+      "text": "Is the activity carried out?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "explorationExploitationLicence",
+          "text": "In pursuance of an exploration or exploitation licence issued under the Deep Sea Mining (Temporary Provision) Act 1981",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-30"
+        },
+        {
+          "id": "reciprocalauthorisation",
+          "text": "In pursuance of a reciprocal authorisation within the meaning given by section 3(3) of the Deep Sea Mining (Temporary Provision) Act 1981",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-30"
+        },
+        {
+          "id": "other",
+          "text": "for another reason",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/deposit/miscellaneous/crossrail-act",
+      "text": "Will the activity be carried out within the limits of deviation for scheduled works in exercise of powers conferred by the Crossrail Act 2008 in relation to those works or any work connected with them?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-29"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/activity-type",
+      "text": "What does the removal activity relate to?",
+      "section": "removal",
+      "mcmsAppFormMapping": "EXE_ACTIVITY_SUBTYPE_REMOVAL",
+      "answers": [
+        {
+          "id": "fishing",
+          "text": "Fishing and shellfish propogation and cultivation",
+          "nextQuestionRoute": "/exemption/removal/fishing"
+        },
+        {
+          "id": "markersMooringsAndAidToNavigation",
+          "text": "Markers, moorings and aids to navigation",
+          "nextQuestionRoute": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation"
+        },
+        {
+          "id": "pontoons",
+          "text": "Pontoons",
+          "nextQuestionRoute": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/pontoons"
+        },
+        {
+          "id": "scientificResearch",
+          "text": "Scientific investigation or research",
+          "nextQuestionRoute": "/exemption/removal/scientific-research",
+          "hint": "Scientific instruments and associated equipment, samples for testing and analysis"
+        },
+        {
+          "id": "maintenance",
+          "text": "Maintenance of existing strucutres or assets",
+          "nextQuestionRoute": "/exemption/removal/maintenance",
+          "hint":"'Maintenance' means the upkeep or repair of an existing structure or asset wholly within its existing 3 dimensional boundaries"
+        },
+        {
+          "id": "waste",
+          "text": "Litter and Dead animals",
+          "nextQuestionRoute": "/exemption/removal/waste"
+        },
+        {
+          "id": "ObstructionsDanger",
+          "text": "Obstructions, danger to navigation and accidental deposits",
+          "nextQuestionRoute": "/exemption/removal/obstruction"
+        },
+        {
+          "id": "emergency",
+          "text": "Emergency, safety and training",
+          "nextQuestionRoute": "/exemption/removal/emergency-safety-pollution-response-accident-investigation"
+        },
+        {
+          "id": "miscellaneous",
+          "text": "Other",
+          "nextQuestionRoute": "/exemption/removal/miscellaneous",
+          "hint": "Removal activities for purposes not set out above"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation",
+      "text": "What does the removal activity relate to?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "temporaryMarkers",
+          "text": "Temporary markers",
+          "nextQuestionRoute": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/temporary-markers"
+        },
+        {
+          "id": "mooringsAidsToNavigation",
+          "text": "Moorings and aids to navigation",
+          "nextQuestionRoute": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/moorings",
+          "hint": "Activities carried out by or on behalf of Lighthouse and Harbour authorities only"
+        },
+        {
+          "id": "marineSiteMarkers",
+          "text": "Markers for European marine sites and marine conservation zones",
+          "nextQuestionRoute": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/marine-site-markers"
+        },
+        {
+          "id": "diverTrails",
+          "text": "Diver trails",
+          "nextQuestionRoute": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/dive-trails"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/temporary-markers",
+      "text": "What is the purpose of the activity?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "markerLess24Hours",
+          "text": "The removal of a marker and its appurtenances that has been in place for less than 24 hours",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-26a-no-notification"
+        },
+        {
+          "id": "markerLess28Days",
+          "text": "The removal of a marker and its appurtenances that has been in place for longer than 24 hours but less than 28 days and for which notification of the intention to carry out the activity under article 26A has previously been given to the MMO",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-26a"
+        },
+        {
+          "id": "markerGreater28Days",
+          "text": "The removal of a marker and its appurtenances that has been in place for longer than than 28 days",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/marine-site-markers",
+      "text": "Who will carry out the activity?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "naturalEngland",
+          "text": "Natural England",
+          "nextQuestionRoute": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/marine-site-markers/ne-purpose"
+        },
+        {
+          "id": "publicAuthority",
+          "text": "A public authority",
+          "nextQuestionRoute": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/marine-site-markers/pa-purpose"
+        },
+        {
+          "id": "other",
+          "text": "Someone else",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/marine-site-markers/ne-purpose",
+      "text": "What is the purpose of the activity?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "marineSiteExistence",
+          "text": "Removal of a marker installed to indicate the existence and extent of a European Marine Site",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-26"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/marine-site-markers/pa-purpose",
+      "text": "What is the purpose of the activity?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "marineSiteExistence",
+          "text": "Removal of a marker installed to indicate the existence and extent of a Marine Conservation Zone",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-26"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/moorings",
+      "text": "What will be removed?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "pileMooring",
+          "text": "Pile mooring",
+          "nextQuestionRoute": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/moorings/undertaker"
+        },
+        {
+          "id": "swingingMooring",
+          "text": "Swinging mooring",
+          "nextQuestionRoute": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/moorings/undertaker"
+        },
+        {
+          "id": "trotMooring",
+          "text": "Trot Mooring",
+          "nextQuestionRoute": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/moorings/undertaker"
+        },
+        {
+          "id": "aidToNavigation",
+          "text": "Aid to Navigation",
+          "nextQuestionRoute": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/moorings/undertaker"
+        },
+        {
+          "id": "other",
+          "text": "Something else",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/moorings/undertaker",
+      "text": "Who will carry out the activity?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "harbourAuthority",
+          "text": "A harbour authority or someone on behalf of a harbour authority",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-25"
+        },
+        {
+          "id": "lighthouseAuthority",
+          "text": "A lighthouse authority or someone on behalf of a lighthouse authority",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-25"
+        },
+        {
+          "id": "someoneElse",
+          "text": "Someone else",
+          "nextQuestionRoute": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/moorings/consent"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/moorings/consent",
+      "text": "Does the activity require consent (e.g. a licence) from a harbour authority under local legislation?",
+      "hint": "The permission or agreement of the authority does not constitute consent for these purposes.",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/moorings/approval"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/moorings/approval",
+      "text": "Has consent been granted?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-25-notification"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/pontoons",
+      "text": "Is the purpose of the activity to remove a pontoon?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/pontoons/undertaker"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/pontoons/undertaker",
+      "text": "Who will carry out the activity?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "harbourAuthority",
+          "text": "A harbour authority or someone on behalf of a harbour authority",
+          "nextQuestionRoute": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/pontoon/deck"
+        },
+        {
+          "id": "someoneElse",
+          "text": "Someone else",
+          "nextQuestionRoute": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/pontoon/consent"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/pontoon/consent",
+      "text": "Does the activity require consent (e.g. a licence) from a harbour authority under local legislation?",
+      "hint": "The permission or agreement of the authority does not constitute consent for these purposes.",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/pontoon/approval"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/pontoon/approval",
+      "text": "Has consent been granted?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/pontoon/deck"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/pontoon/deck",
+      "text": "When complete will the deck of the pontoon be an area greater than 30m2?",
+            "hint": "NOTE: If the pontoon will be attached to one or more pontoons already in place the question refers to the total deck area of all pontoons combined.",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-25A"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/dive-trails",
+      "text": "Is the purpose of the activity to remove signage or other identifying markers relating:",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "protectionWrecksAct",
+          "text": "a wreck within an area designated as a restricted area within the meaning of section 1 of the Protection of Wrecks Act 1973",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-31"
+        },
+        {
+          "id": "monumentsArchaeologicalAreasAct",
+          "text": "a monument designated as a scheduled monument under section 1 of the Ancient Monuments and Archaeological Areas Act 1979",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-31"
+        },
+        {
+          "id": "protectionMilitaryRemainsAct",
+          "text": "an area designated as a controlled site under section 1(2)(b) of the Protection of Military Remains Act 1986",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-31"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/scientific-research",
+      "text": "What does the removal activity relate to?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "scientificInstruments",
+          "text": "Scientific instruments and associated equipment",
+          "nextQuestionRoute": "/exemption/removal/scientific-research/scientific-equipment"
+        },
+        {
+          "id": "samples",
+          "text": "Samples for testing and analysis",
+          "nextQuestionRoute": "/exemption/removal/scientific-research/samples"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/scientific-research/scientific-equipment",
+      "text": "Is the object to be removed a scientific instrument or equipment associated with such an instrument?",
+      "hint": "'Scientific instrument' means a specialist device or tool, designed to measure, record or analyse data for scientific purposes. ‘Associated equipment’ means equipment fundamental to the functioning or operation of the instrument itself.",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/removal/scientific-research/scientific-equipment/survey"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/scientific-research/scientific-equipment/survey",
+      "text": "Was the instrument or associated equipment originally deposited as part of a scientific experiment or survey?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/removal/scientific-research/scientific-equipment/mpa"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/scientific-research/scientific-equipment/mpa",
+      "text": "Will the activity take place in or within 200m of a Marine Protected Area (MPA)?",
+      "section": "removal",
+  "hint": "<p>MPA's are an important part of the marine environment. </p><p>You are responsible for making sure you understand the status of the location where the activity is proposed. </p><p> ‘Marine protected areas’ mean:<ul><li>Highly Protected Marine Area (HPMA) (designated and candidate)</li><li>Marine Conservation Zones (MCZs) (designated and proposed)</li><li>Special Areas of Conservation (SACs) (designated and candidate)</li><li>Special Protection Areas (SPAs) (designated and potential)</li><li>Ramsar's</li><li>SSSIs</li></ul></p><p> If you are unsure of whether the activity falls within an MPA you should select the appropriate layer in the MMO’s <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\"> GIS tool </a> to check.",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/removal/scientific-research/scientific-equipment/mpa-management"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-17"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/scientific-research/scientific-equipment/mpa-management",
+      "text": "Is the activity directly connected with or necessary to the management of the Marine Protected Area?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-17"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/removal/scientific-research/scientific-equipment/lse"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/scientific-research/scientific-equipment/lse",
+      "text": "Is the activity....",
+      "section": "removal",
+      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#marine-protected-areas\"> marine protected areas </a>.",
+      "answers": [
+        {
+          "id": "europeanSiteScientificEquipment",
+          "text": "Likely to have a significant effect on a European site?",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
+          "hint": "either alone or in combination with other plans and projects"
+        },
+        {
+          "id": "ramsarSiteScientificEquipment",
+          "text": "Likely to have a significant effect on a Ramsar site?",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
+          "hint": "either alone or in combination with other plans and projects"
+        },
+        {
+          "id": "mczScientificEquipment",
+          "text": "Capable of affecting (other than insignificantly), the protected features of a Marine Conservation Zone or Highly Protected Marine Area?",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
+          "hint": "including any ecological or geomorphological process on which the conservation of any protected feature of an MCZ or HPMA is (wholly or in Part) dependant"
+        },
+        {
+          "id": "otherScientificEquipment",
+          "text": "Unlikely to have any relevant effect on any sites specified above",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-17"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/scientific-research/samples",
+      "text": "Is the purpose of the activity to take a sample of material for testing or analysis?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/removal/scientific-research/samples/volume"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/scientific-research/samples/volume",
+      "text": "Will the sample to be collected be of a volume of 1m3 or less?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/removal/scientific-research/samples/obstruction"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/scientific-research/samples/obstruction",
+      "text": "Will the activity cause or be likely to cause an obstruction or danger to navigation?",
+      "section": "removal",
+      "hint": " Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#navigational-risk\"> navigational risk </a> and the steps you can take to ensure your proposal is not one that will cause or be likely to cause and obstruction or danger.",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/removal/scientific-research/samples/mpa"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/scientific-research/samples/mpa",
+      "text": "Will the activity take place in or within 200m of a Marine Protected Area (MPA)?",
+      "section": "removal",
+  "hint": "<p>MPA's are an important part of the marine environment. </p><p>You are responsible for making sure you understand the status of the location where the activity is proposed. </p><p> ‘Marine protected areas’ mean:<ul><li>Highly Protected Marine Area (HPMA) (designated and candidate)</li><li>Marine Conservation Zones (MCZs) (designated and proposed)</li><li>Special Areas of Conservation (SACs) (designated and candidate)</li><li>Special Protection Areas (SPAs) (designated and potential)</li><li>Ramsar's</li><li>SSSIs</li></ul></p><p> If you are unsure of whether the activity falls within an MPA you should select the appropriate layer in the MMO’s <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\"> GIS tool </a> to check.",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/removal/scientific-research/samples/mpa-management"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-17A"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/scientific-research/samples/mpa-management",
+      "text": "Is the activity directly connected with or necessary to the management of the Marine Protected Area?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-17A"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/removal/scientific-research/scientific-equipment/lse"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/scientific-research/samples/lse",
+      "text": "Is the activity....",
+      "section": "removal",
+      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#marine-protected-areas\"> marine protected areas </a>.",
+      "answers": [
+        {
+          "id": "europeanSiteSamples",
+          "text": "Likely to have a significant effect on a European site?",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
+          "hint": "either alone or in combination with other plans and projects"
+        },
+        {
+          "id": "ramsarSiteSamples",
+          "text": "Likely to have a significant effect on a Ramsar site?",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
+          "hint": "either alone or in combination with other plans and projects"
+        },
+        {
+          "id": "mczSamples",
+          "text": "Capable of affecting (other than insignificantly), the protected features of a Marine Conservation Zone or Highly Protected Marine Area?",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
+          "hint": "including any ecological or geomorphological process on which the conservation of any protected feature of an MCZ or HPMA is (wholly or in Part) dependant"
+        },
+        {
+          "id": "otherSamples",
+          "text": "Unlikely to have any relevant effect on any sites specified above",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-17A"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/maintenance",
+      "text": "What does the removal activity relate to?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "coastalProtectionDrainageFloodDefence",
+          "text": "Maintenance of coast protection, drainage or flood defence works",
+          "nextQuestionRoute": "/exemption/removal/maintenance/coastal-drainage-flood"
+        },
+        {
+          "id": "harbourWorkMaintenance",
+          "text": "Maintenance of harbour works",
+          "nextQuestionRoute": "/exemption/removal/maintenance/harbour-works",
+          "hint": "Maintenance carried out by or on behalf of harbour authorities only."
+        },
+        {
+          "id": "cablesPipelines",
+          "text": "Cables and pipelines",
+          "nextQuestionRoute": "/exemption/removal/maintenance/cables-pipelines"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/maintenance/coastal-drainage-flood",
+      "text": "Who will carry out the activity?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "environmentAgency",
+          "text": "The Environment Agency or someone on behalf of the Environment Agency",
+          "nextQuestionRoute": "/exemption/removal/maintenance/coastal-drainage-flood/EA"
+        },
+        {
+          "id": "coastProtectionAuthority",
+          "text": "The Coast Protection Authority or someone on behalf of the Coast Protection Authority",
+          "nextQuestionRoute": "/exemption/removal/maintenance/coastal-drainage-flood/CPA"
+        },
+        {
+          "id": "localAuthority",
+          "text": "The Local Authority or someone on behalf of the Local Authority",
+          "nextQuestionRoute": "/exemption/removal/maintenance/coastal-drainage-flood/CPA"
+        },
+        {
+          "id": "secretaryStateDefence",
+          "text": "The Secretary of State for Defence or someone on behalf of the Secretary of State for Defence",
+          "nextQuestionRoute": "/exemption/removal/maintenance/coastal-drainage-flood/CPA"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/maintenance/coastal-drainage-flood/EA",
+      "text": "Will the activity be carried out wholly within the existing 3 dimensional boundary of the works being maintained?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-19"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/removal/maintenance/coastal-drainage-flood/EA/emergency-flood"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/maintenance/coastal-drainage-flood/EA/emergency-flood",
+      "text": "Are the circumstances serious, unexpected, and potentially dangerous requiring immediate action in response to either flooding or imminent risk of flooding?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-20"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/maintenance/coastal-drainage-flood/CPA",
+      "text": "Is the activity for the purpose of maintaining coast protection works?",
+            "hint": "'Coast protection works' include: </li><li><u>beach re-profiling</U>, which involves the movement of beach material in a cross-shore direction up or down the beach; and </li><li><u>beach recycling</u>, which involves the movement of beach material along the beach from areas of accretion to areas of erosion within the beach or associated sediment system.",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-19"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/maintenance/harbour-works",
+      "text": "Is the activity for the purpose of maintaining harbour works?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/removal/maintenance/harbour-works/boundaries"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/maintenance/harbour-works/boundaries",
+      "text": "Will the activity be carried out within the 3 dimensional boundaries of the existing works?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/removal/maintenance/harbour-works/undertaker"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/maintenance/harbour-works/undertaker",
+      "text": "Will the activity be carried out by or on behalf of the harbour authority?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-23"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/maintenance/cables-pipelines",
+      "text": "Does the removal activity relate to the inspection or repair of an existing cable or pipeline?",
+      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities--2#cables-pipelines-oil-and-gas-and-carbon-capture-storage\"> cables and pipelines </a>.",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/removal/maintenance/cables-pipelines/emergency"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/maintenance/cables-pipelines/emergency",
+      "text": "Are the circumstances serious, unexpected, and potentially dangerous requiring immediate action?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-34"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/waste",
+      "text": "What does the removal activity relate to?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "deadAnimals",
+          "text": "Dead animals",
+          "nextQuestionRoute": "/exemption/removal/waste/dead-animals"
+        },
+        {
+          "id": "marineLitter",
+          "text": "Marine litter (by divers)",
+          "nextQuestionRoute": "/exemption/removal/waste/marine-litter",
+          "hint": "'marine litter' means any persistent, manufactured or processed solid material discarded, disposed of or abandoned in the marine and coastal environment"
+        },
+        {
+          "id": "litterSeaweed",
+          "text": "Litter and seaweed",
+          "nextQuestionRoute": "/exemption/removal/waste/litter-seaweed",
+          "hint": "by or on behalf of local authorities only"
+        },
+        {
+          "id": "litterDebris",
+          "text": "Marine litter and debris",
+          "nextQuestionRoute": "/exemption/removal/waste/litter-debris",
+          "hint": "by or on behalf of a harbour authority only"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+        {
+      "route": "/exemption/removal/obstruction",
+      "text": "What does the removal activity relate to?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "accidentalDeposits",
+          "text": "Accidental deposits",
+          "nextQuestionRoute": "/exemption/removal/waste/accidental-deposits"
+        },
+        {
+          "id": "dangerToNavigation",
+          "text": "Obstruction or danger to navigation",
+          "nextQuestionRoute": "/exemption/removal/waste/obstruction-danger-navigation"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/waste/dead-animals",
+      "text": "Will the activity involve the removal of a dead animal from a beach or intertidal area?",
+      "section": "removal",
+"hint": "’Beach’ means an area of sand or small stones near the sea.</br>'Intertidal area' means the area between the level of mean high water springs and the level of mean low water springs.",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/removal/waste/dead-animals/undertaker"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/waste/dead-animals/undertaker",
+      "text": "Will the activity be carried out by or on behalf of a local authority?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/removal/waste/dead-animals/undertaker/mpa"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/waste/dead-animals/undertaker/mpa",
+      "text": "Will the activity take place in or within 200m of a Marine Protected Area (MPA)?",
+      "section": "removal",
+  "hint": "<p>MPA's are an important part of the marine environment. </p><p>You are responsible for making sure you understand the status of the location where the activity is proposed. </p><p> ‘Marine protected areas’ mean:<ul><li>Highly Protected Marine Area (HPMA) (designated and candidate)</li><li>Marine Conservation Zones (MCZs) (designated and proposed)</li><li>Special Areas of Conservation (SACs) (designated and candidate)</li><li>Special Protection Areas (SPAs) (designated and potential)</li><li>Ramsar's</li><li>SSSIs</li></ul></p><p> If you are unsure of whether the activity falls within an MPA you should select the appropriate layer in the MMO’s <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\"> GIS tool </a> to check.",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/removal/waste/dead-animals/undertaker/mpa-management"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-21"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/waste/dead-animals/undertaker/mpa-management",
+      "text": "Is the activity directly connected with or necessary to the management of the Marine Protected Area?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-21"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/removal/waste/dead-animals/undertaker/lse"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/waste/dead-animals/undertaker/lse",
+      "text": "Is the activity....",
+      "section": "removal",
+      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#marine-protected-areas\"> marine protected areas </a>.",
+      "answers": [
+        {
+          "id": "europeanDeadAnimals",
+          "text": "Likely to have a significant effect on a European site?",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
+          "hint": "either alone or in combination with other plans and projects"
+        },
+        {
+          "id": "ramsarDeadAnimals",
+          "text": "Likely to have a significant effect on a Ramsar site?",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
+          "hint": "either alone or in combination with other plans and projects"
+        },
+        {
+          "id": "mczDeadAnimals",
+          "text": "Capable of affecting (other than insignificantly), the protected features of a Marine Conservation Zone or Highly Protected Marine Area?",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
+          "hint": "including any ecological or geomorphological process on which the conservation of any protected feature of an MCZ or HPMA is (wholly or in Part) dependant"
+        },
+        {
+          "id": "otherDeadAnimals",
+          "text": "Unlikely to have any relevant effect on any sites specified above",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-21"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/waste/marine-litter",
+      "text": "Will the activity involve the removal of marine litter or abandoned, discarded or lost fishing gear in the course of a diving activity?",
+      "section": "removal",
+      "hint": "'marine litter' means any persistent, manufactured or processed solid material discarded, disposed of or abandoned in the marine and coastal environment",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/removal/waste/marine-litter/historic-interest"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/waste/marine-litter/historic-interest",
+      "text": "Is the activity likely to cause damage to features of archaeological or historic interest in an area where the diving activities in question occur?",
+      "section": "removal",
+      "hint": "'Archaeological or historic interest' includes all traces of human existence having a cultural, historical or archaeological character such as:<ol type=\"i\"><li>sites, structures, buildings, artefacts and human remains, together with their archaeological and natural context;</li><li>vessels, aircraft, other vehicles or any part thereof, their cargo or other contents, together with their archaeological and natural context; and</li><li>objects of prehistoric character.</li></ol></p>",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/removal/waste/marine-litter/mpa"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/waste/marine-litter/mpa",
+      "text": "Will the activity take place in or within 200m of a Marine Protected Area (MPA)?",
+      "section": "removal",
+  "hint": "<p>MPA's are an important part of the marine environment. </p><p>You are responsible for making sure you understand the status of the location where the activity is proposed. </p><p> ‘Marine protected areas’ mean:<ul><li>Highly Protected Marine Area (HPMA) (designated and candidate)</li><li>Marine Conservation Zones (MCZs) (designated and proposed)</li><li>Special Areas of Conservation (SACs) (designated and candidate)</li><li>Special Protection Areas (SPAs) (designated and potential)</li><li>Ramsar's</li><li>SSSIs</li></ul></p><p> If you are unsure of whether the activity falls within an MPA you should select the appropriate layer in the MMO’s <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\"> GIS tool </a> to check.",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/removal/waste/marine-litter/mpa-management"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-21A"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/waste/marine-litter/mpa-management",
+      "text": "Is the activity directly connected with or necessary to the management of the Marine Protected Area?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-21A"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/removal/waste/marine-litter/lse"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/waste/marine-litter/lse",
+      "text": "Is the activity....",
+      "section": "removal",
+      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#marine-protected-areas\"> marine protected areas </a>.",
+      "answers": [
+        {
+          "id": "europeanSiteMarineLitter",
+          "text": "Likely to have a significant effect on a European site?",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
+          "hint": "either alone or in combination with other plans and projects"
+        },
+        {
+          "id": "ramsarSiteMarineLitter",
+          "text": "Likely to have a significant effect on a Ramsar site?",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
+          "hint": "either alone or in combination with other plans and projects"
+        },
+        {
+          "id": "mczMarineLitter",
+          "text": "Capable of affecting (other than insignificantly), the protected features of a Marine Conservation Zone or Highly Protected Marine Area?",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
+          "hint": "including any ecological or geomorphological process on which the conservation of any protected feature of an MCZ or HPMA is (wholly or in Part) dependant"
+        },
+        {
+          "id": "otherMarineLitter",
+          "text": "Unlikely to have any relevant effect on any sites specified above",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-21A"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/waste/litter-seaweed",
+      "text": "Will the activity involve the removal of litter or seaweed from a beach or intertidal area?",
+      "section": "removal",
+"hint": "’Beach’ means an area of sand or small stones near the sea.</br>'Intertidal area' means the area between the level of mean high water springs and the level of mean low water springs.",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/removal/waste/litter-seaweed/undertaker"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/waste/litter-seaweed/undertaker",
+      "text": "Will the activity be carried out by or on behalf of a local authority?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/removal/waste/litter-seaweed/mpa"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/waste/litter-seaweed/mpa",
+      "text": "Will the activity take place in or within 200m of a Marine Protected Area (MPA)?",
+        "hint": "<p>MPA's are an important part of the marine environment. </p><p>You are responsible for making sure you understand the status of the location where the activity is proposed. </p><p> ‘Marine protected areas’ mean:<ul><li>Highly Protected Marine Area (HPMA) (designated and candidate)</li><li>Marine Conservation Zones (MCZs) (designated and proposed)</li><li>Special Areas of Conservation (SACs) (designated and candidate)</li><li>Special Protection Areas (SPAs) (designated and potential)</li><li>Ramsar's</li><li>SSSIs</li></ul></p><p> If you are unsure of whether the activity falls within an MPA you should select the appropriate layer in the MMO’s <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\"> GIS tool </a> to check.",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/removal/waste/litter-seaweed/mpa-management"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-21-no-notification"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/waste/litter-seaweed/mpa-management",
+      "text": "Is the activity directly connected with or necessary to the management of the Marine Protected Area?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-21-no-notification"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/removal/waste/dead-animals/undertaker/lse"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/waste/litter-seaweed/lse",
+      "text": "Is the activity....",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "europeanSiteScientificEquipment",
+          "text": "Likely to have a significant effect on a European site?",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
+          "hint": "either alone or in combination with other plans and projects"
+        },
+        {
+          "id": "ramsarSiteScientificEquipment",
+          "text": "Likely to have a significant effect on a Ramsar site?",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
+          "hint": "either alone or in combination with other plans and projects"
+        },
+        {
+          "id": "mczScientificEquipment",
+          "text": "Capable of affecting (other than insignificantly), the protected features of a Marine Conservation Zone or Highly Protected Marine Area?",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
+          "hint": "including any ecological or geomorphological process on which the conservation of any protected feature of an MCZ or HPMA is (wholly or in Part) dependant"
+        },
+        {
+          "id": "otherScientificEquipment",
+          "text": "Unlikely to have any relevant effect on any sites specified above",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-21-no-notification"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/waste/litter-debris",
+      "text": " Will the activity involve the removal of marine litter or debris from within the jurisdiction of a harbour authority?",
+      "section": "removal",
+      "hint": "'marine litter' means any persistent, manufactured or processed solid material discarded, disposed of or abandoned in the marine and coastal environment.</br>'Debris' includes remnants from something that has been destroyed or pieces of unwanted or discarded material that are spread around.",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/removal/waste/litter-debris/undertaker"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/waste/litter-debris/undertaker",
+      "text": "Who will carry out the activity?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "harbourAuthority",
+          "text": "A harbour authority or someone on behalf of a harbour authority",
+          "nextQuestionRoute": "/exemption/removal/waste/litter-debris/historic-interest"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/waste/litter-debris/historic-interest",
+      "text": "Is the activity likely to cause damage to features of archaeological or historic interest in an area where the diving activities in question occur?",
+      "section": "removal",
+      "hint": "'Archaeological or historic interest' includes all traces of human existence having a cultural, historical or archaeological character such as:<ol type=\"i\"><li>sites, structures, buildings, artefacts and human remains, together with their archaeological and natural context;</li><li>vessels, aircraft, other vehicles or any part thereof, their cargo or other contents, together with their archaeological and natural context; and</li><li>objects of prehistoric character.</li></ol></p>",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/removal/waste/litter-debris/mpa"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/waste/litter-debris/mpa",
+      "text": "Will the activity take place in or within 200m of a Marine Protected Area (MPA)?",
+      "section": "removal",
+      "hint": "<p>MPA's are an important part of the marine environment. </p><p>You are responsible for making sure you understand the status of the location where the activity is proposed. </p><p> ‘Marine protected areas’ mean:<ul><li>Highly Protected Marine Area (HPMA) (designated and candidate)</li><li>Marine Conservation Zones (MCZs) (designated and proposed)</li><li>Special Areas of Conservation (SACs) (designated and candidate)</li><li>Special Protection Areas (SPAs) (designated and potential)</li><li>Ramsar's</li><li>SSSIs</li></ul></p><p> If you are unsure of whether the activity falls within an MPA you should select the appropriate layer in the MMO’s <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\"> GIS tool </a> to check.",
+      "answers": [ 
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/removal/waste/litter-debris/mpa-management"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-24A"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/waste/litter-debris/mpa-management",
+      "text": "Is the activity directly connected with or necessary to the management of the Marine Protected Area?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-24A"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/removal/waste/litter-debris/lse"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/waste/litter-debris/lse",
+      "text": "Is the activity....",
+      "section": "removal",
+      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#marine-protected-areas\"> marine protected areas </a>.",
+      "answers": [
+        {
+          "id": "europeanSiteMarineLitter",
+          "text": "Likely to have a significant effect on a European site?",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
+          "hint": "either alone or in combination with other plans and projects"
+        },
+        {
+          "id": "ramsarSiteMarineLitter",
+          "text": "Likely to have a significant effect on a Ramsar site?",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
+          "hint": "either alone or in combination with other plans and projects"
+        },
+        {
+          "id": "mczMarineLitter",
+          "text": "Capable of affecting (other than insignificantly), the protected features of a Marine Conservation Zone or Highly Protected Marine Area?",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
+          "hint": "including any ecological or geomorphological process on which the conservation of any protected feature of an MCZ or HPMA is (wholly or in Part) dependant"
+        },
+        {
+          "id": "otherMarineLitter",
+          "text": "Unlikely to have any relevant effect on any sites specified above",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-24A"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/waste/accidental-deposits",
+      "text": "Was the object to be removed deposited accidentally?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/removal/waste/accidental-deposits/within-12-months"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/waste/accidental-deposits/within-12-months",
+      "text": "Will the removal take place within 12 months of the date the object was accidentally deposited?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/removal/waste/accidental-deposits/obstruction"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/waste/accidental-deposits/obstruction",
+      "text": "Will the activity cause or be likely to cause an obstruction or danger to navigation?",
+      "section": "removal",
+      "hint": " Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#navigational-risk\"> navigational risk </a> and the steps you can take to ensure your proposal is not one that will cause or be likely to cause and obstruction or danger.",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/removal/waste/accidental-deposits/mpa"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/waste/accidental-deposits/mpa",
+      "text": "Will the activity take place in or within 200m of a Marine Protected Area (MPA)?",
+      "section": "removal",
+  "hint": "<p>MPA's are an important part of the marine environment. </p><p>You are responsible for making sure you understand the status of the location where the activity is proposed. </p><p> ‘Marine protected areas’ mean:<ul><li>Highly Protected Marine Area (HPMA) (designated and candidate)</li><li>Marine Conservation Zones (MCZs) (designated and proposed)</li><li>Special Areas of Conservation (SACs) (designated and candidate)</li><li>Special Protection Areas (SPAs) (designated and potential)</li><li>Ramsar's</li><li>SSSIs</li></ul></p><p> If you are unsure of whether the activity falls within an MPA you should select the appropriate layer in the MMO’s <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\"> GIS tool </a> to check.",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/removal/waste/accidental-deposits/mpa-management"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-17B"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/waste/accidental-deposits/mpa-management",
+      "text": "Is the activity directly connected with or necessary to the management of the Marine Protected Area?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-17B"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/removal/waste/accidental-deposits/lse"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/waste/accidental-deposits/lse",
+      "text": "Is the activity....",
+      "section": "removal",
+      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#marine-protected-areas\"> marine protected areas </a>.",
+      "answers": [
+        {
+          "id": "europeanAccidentalDeposits",
+          "text": "Likely to have a significant effect on a European site?",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
+          "hint": "either alone or in combination with other plans and projects"
+        },
+        {
+          "id": "ramsarAccidentalDeposits",
+          "text": "Likely to have a significant effect on a Ramsar site?",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
+          "hint": "either alone or in combination with other plans and projects"
+        },
+        {
+          "id": "mczAccidentalDeposits",
+          "text": "Capable of affecting (other than insignificantly), the protected features of a Marine Conservation Zone or Highly Protected Marine Area?",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
+          "hint": "including any ecological or geomorphological process on which the conservation of any protected feature of an MCZ or HPMA is (wholly or in Part) dependant"
+        },
+        {
+          "id": "otherAccidentalDeposits",
+          "text": "Unlikely to have any relevant effect on any sites specified above",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-17B"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/waste/obstruction-danger-navigation",
+      "text": "Who will carry out the activity?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "harbourAuthority",
+          "text": "A harbour authority",
+          "nextQuestionRoute": "/exemption/removal/waste/obstruction-danger-navigation/purpose"
+        },
+        {
+          "id": "conservancyAuthority",
+          "text": "A conservancy authority",
+          "nextQuestionRoute": "/exemption/removal/waste/obstruction-danger-navigation/purpose",
+          "hint": "within the meaning given by section 313(1) of the Merchant Shipping Act 1995."
+        },
+        {
+          "id": "lighthouseAuthority",
+          "text": "A lighthouse authority",
+          "nextQuestionRoute": "/exemption/removal/waste/obstruction-danger-navigation/purpose"
+        },
+        {
+          "id": "inlandNavigationAuthority",
+          "text": "A person with powers under any enactment or statutory order to work on or maintain a canal or other inland navigation including navigation in tidal water.",
+          "nextQuestionRoute": "/exemption/removal/waste/obstruction-danger-navigation/purpose"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/waste/obstruction-danger-navigation/purpose",
+      "text": "Is the purpose of the activity to remove an object causing or likely to cause an obstruction or danger to navigation?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-24"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/emergency-safety-pollution-response-accident-investigation",
+      "text": "What does the removal activity relate to?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "floodFloodRisk",
+          "text": "Flood or flood risk",
+          "nextQuestionRoute": "/exemption/removal/emergency-safety-pollution-response-accident-investigation/flood"
+        },
+        {
+          "id": "cablesPipelines",
+          "text": "Cables and pipelines",
+          "nextQuestionRoute": "/exemption/removal/emergency-safety-pollution-response-accident-investigation/cables-pipelines"
+        },
+        {
+          "id": "coastguardActivities",
+          "text": "Coastguard activities - safety purposes and training",
+          "nextQuestionRoute": "/exemption/removal/emergency-safety-pollution-response-accident-investigation/coastguard"
+        },
+        {
+          "id": "salvageOperation",
+          "text": "Salvage Operation",
+          "nextQuestionRoute": "/exemption/removal/emergency-safety-pollution-response-accident-investigation/salvage"
+        },
+        {
+          "id": "safetyDirections",
+          "text": "Safety directions under the Merchant Shipping Act 1995",
+          "nextQuestionRoute": "/exemption/removal/emergency-safety-pollution-response-accident-investigation/safety-directions"
+        },
+        {
+          "id": "pollutionPreventionPart6MerchantShippingAct1995",
+          "text": "Pollution prevention - activities within Part 6 of the Merchant Shipping Act 1995",
+          "nextQuestionRoute": "/exemption/removal/emergency-safety-pollution-response-accident-investigation/pollution-prevention"
+        },
+        {
+          "id": "firefighting",
+          "text": "Fire Fighting",
+          "nextQuestionRoute": "/exemption/removal/emergency-safety-pollution-response-accident-investigation/fire-fighting"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/emergency-safety-pollution-response-accident-investigation/flood",
+      "text": "Will the activity be carried out by or on behalf of the Environment Agency?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/removal/emergency-safety-pollution-response-accident-investigation/flood/emergency"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/emergency-safety-pollution-response-accident-investigation/flood/emergency",
+      "text": "Are the circumstances serious, unexpected and potentially dangerous requiring immediate action in response to flood or imminent risk of flood?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-20"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/emergency-safety-pollution-response-accident-investigation/cables-pipelines",
+      "text": "Does the removal activity relate to the inspection or repair of an existing cable or pipeline",
+      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities--2#cables-pipelines-oil-and-gas-and-carbon-capture-storage\"> cables and pipelines </a>.",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/removal/emergency-safety-pollution-response-accident-investigation/cables-pipelines/emergency"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/emergency-safety-pollution-response-accident-investigation/cables-pipelines/emergency",
+      "text": "Are the circumstances serious, unexpected and potentially dangerous requiring immediate action?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-34"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/emergency-safety-pollution-response-accident-investigation/coastguard",
+      "text": "Will the activity be carried out by or on behalf the Secretary of State for Transport, acting through the Maritime and Coastguard Agency?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/removal/emergency-safety-pollution-response-accident-investigation/coastguard/purpose"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/emergency-safety-pollution-response-accident-investigation/coastguard/purpose",
+      "text": "What is the purpose of the activity?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "securingVesselAircraftMarineStructureSafety",
+          "text": "Securing the safety of a vessel, aircraft or marine structure ",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-32",
+          "hint": "'marine structure' means a platform or other artificial structure at 'Sea', other than a pipeline."
+        },
+        {
+          "id": "savingLife",
+          "text": "Saving life",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-32"
+        },
+        {
+          "id": "training",
+          "text": "Training for either of the above two purposes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-32"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/emergency-safety-pollution-response-accident-investigation/salvage",
+      "text": "Will the activity be carried out in the course of an official salvage operation for the purpose of ensuring the safety of a vessel or preventing pollution?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-9"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/emergency-safety-pollution-response-accident-investigation/safety-directions",
+      "text": "What is the purpose of the activity?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "secretaryOfStateSchedule3A",
+          "text": "In exercise of a power under Schedule 3A to the Merchant Shipping Act 1995 (safety directions) by or on behalf of the Secretary of State",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-8"
+        },
+        {
+          "id": "schedule3ACompliance",
+          "text": "Compliance with a direction under Schedule 3A to the Merchant Shipping Act 1995 (safety directions)",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-8"
+        },
+        {
+          "id": "avoidingInterference",
+          "text": "Avoiding interference with action taken under Schedule 3A to the Merchant Shipping Act 1995 (safety directions)",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-8"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/emergency-safety-pollution-response-accident-investigation/pollution-prevention",
+      "text": "Does the activity proposed to be carried out fall within the subject matter of Part 6 of the Merchant Shipping Act 1995 (prevention of pollution)?",
+        "hint": "Find out more about <a target=\"_blank\" href=\" http://www.legislation.gov.uk/ukpga/1995/21/part/VI\"> Part 6 of the Merchant Shipping Act 1995</a>",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-7"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/emergency-safety-pollution-response-accident-investigation/fire-fighting",
+      "text": "Will the activity be carried out for the purpose of fighting or preventing the spread of fire?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-10"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/emergency-safety-pollution-response-accident-investigation/air-accident-investigation",
+      "text": "Will the activity be carried out for the purpose of recovering a substance or object as part of an official investigation into an accident involving aircraft?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-11"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/fishing",
+      "text": "What does the removal activity relate to?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "shellfishPropogationCultivation",
+          "text": "Shellfish propogation and cultivation",
+          "nextQuestionRoute": "/exemption/removal/fishing/shellfish-propagation-cultivation"
+        },
+        {
+          "id": "fishingOperations",
+          "text": "Fishing operations",
+          "nextQuestionRoute": "/exemption/removal/fishing/fishing-operations"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/fishing/shellfish-propagation-cultivation",
+      "text": "Will the activity be carried out for the purpose of moving shellfish within the 'Sea' in the course of its propagation or cultivation?",
+      "section": "removal",
+      "hint": "'shellfish' includes crustaceans and molluscs of any kind and any part of a shellfish.",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/removal/fishing/shellfish-propagation-cultivation/obstruction"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/fishing/shellfish-propagation-cultivation/obstruction",
+      "text": "Will the deposit cause or be likely to cause an obstruction or danger to navigation?",
+      "section": "removal",
+      "hint": " Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#navigational-risk\"> navigational risk </a> and the steps you can take to ensure your proposal is not one that will cause or be likely to cause and obstruction or danger.",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-13"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/fishing/fishing-operations",
+      "text": "What is the purpose of the activity?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "fishingTakingFish",
+          "text": "Fishing or taking fish",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-12"
+        },
+        {
+          "id": "removingFishingGear",
+          "text": "Removing fishing gear",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-12"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/miscellaneous",
+      "text": "What does the removal activity relate to?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "defenceActivities",
+          "text": "Defence activities",
+          "nextQuestionRoute": "/exemption/removal/miscellaneous/defence-activities"
+        },
+        {
+          "id": "deepseaMining",
+          "text": "Licensed deepsea mining",
+          "nextQuestionRoute": "/exemption/removal/miscellaneous/deepsea-mining"
+        },
+        {
+          "id": "crossrailAct",
+          "text": "Scheduled works authorised under the Crossrail Act 2008",
+          "nextQuestionRoute": "/exemption/removal/miscellaneous/crossrail-act"
+        },
+        {
+          "id": "dismantlingShips",
+          "text": "Dismantling Ships",
+          "nextQuestionRoute": "/exemption/removal/miscellaneous/dismantling-ships"
+        },
+        {
+          "id": "rightsOfForeignVessels",
+          "text": "Exercising rights of foreign vessels",
+          "nextQuestionRoute": "/exemption/removal/miscellaneous/foreign-vessels"
+        },
+        {
+          "id": "airAccidentInvestigation",
+          "text": "Air accident investigation",
+          "nextQuestionRoute": "/exemption/removal/emergency-safety-pollution-response-accident-investigation/air-accident-investigation"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
+          "hint": "Other removal activities for purposes not set out above"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/miscellaneous/defence-activities",
+      "text": "Who will carry out the activity?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "ukForces",
+          "text": "The naval, military or air forces of the crown (including reserve forces and the Royal Fleet Auxiliary)",
+          "nextQuestionRoute": "/exemption/removal/miscellaneous/defence-activities/restriction"
+        },
+        {
+          "id": "visiting forces",
+          "text": "A visiting force within the meaning given by Section 12 of the Visiting Forces Act 1952",
+          "nextQuestionRoute": "/exemption/removal/miscellaneous/defence-activities/restriction"
+        },
+        {
+          "id": "someoneElse",
+          "text": "Someone else",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/miscellaneous/defence-activities/restriction",
+      "text": "Will the activity involve construction or dredging of any kind?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/removal/miscellaneous/defence-activities/purpose"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/miscellaneous/defence-activities/purpose",
+      "text": "What is the purpose of the activity?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "defenceOfTheRealm",
+          "text": "Defence of the Realm",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-36"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/miscellaneous/deepsea-mining",
+      "text": "Is the activity carried out?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "explorationExploitationLicence",
+          "text": "In pursuance of an exploration or exploitation licence issued under the Deep Sea Mining (Temporary Provision) Act 1981",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-30"
+        },
+        {
+          "id": "reciprocalauthorisation",
+          "text": "In pursuance of a reciprocal authorisation within the meaning given by section 3(3) of the Deep Sea Mining (Temporary Provision) Act 1981",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-30"
+        },
+        {
+          "id": "other",
+          "text": "for another reason",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/miscellaneous/crossrail-act",
+      "text": "Will the activity be carried out within the limits of deviation for scheduled works in exercise of powers conferred by the Crossrail Act 2008 in relation to those works or any work connected with them?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-29"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/miscellaneous/dismantling-ships",
+      "text": "Will the activity be carried out as part of the dismantling of a ship that is waste?",
+      "section": "removal",
+      "hint": "'Ship' is intended to refer to large commercial or flag bearing vessels, the dismantling of which is regulated under alternative relevant legislation. It does <u>not</u> include ‘houseboats’. <p><p>'Waste' is defined in Article 3 of the EU Waste Framework Directive (2008/98/EC) as 'any substance or object which the holder discards or intends or is required to discard'.<p><p> Please refer to the <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/waste-classification-technical-guidance\">Technical guidance WM3</a> on Waste classification. <p><p>If there is any doubt about whether the vessel you intend to dismantle is a ship you should seek advice from the marine licensing team.",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-28"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/miscellaneous/foreign-vessels",
+      "text": "Will the activity be carried out in exercise of a right under rules of international law?",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/removal/miscellaneous/foreign-vessels/undertaker"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/removal/miscellaneous/foreign-vessels/undertaker",
+      "text": "Will the activity be carried out by or in relation to",
+      "section": "removal",
+      "answers": [
+        {
+          "id": "thirdCountry",
+          "text": "A third country vessel",
+          "hint": "Third country vessel” means a vessel which is flying the flag of, or is registered in, any State or territory (other than Gibraltar) which is not a member State and is not registered in a member State.",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-37"
+        },
+        {
+          "id": "warship",
+          "text": "A warship, naval auxiliary, other vessel or aircraft owned or operated by a state and used, for the time being, only on government non-commercial service (whether or not the warship, naval auxiliary, other vessel is a third country vessel)",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-37"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/dredging",
+      "text": "What does the dredging activity relate to?",
+      "section": "dredging",
+      "mcmsAppFormMapping": "EXE_ACTIVITY_SUBTYPE_DREDGING",
+      "answers": [
+        {
+          "id": "navigationalDredging",
+          "text": "Navigational dredging",
+          "hint": "Dredging to deepen berths or channels etc for the purpose of providing access to vessels and or otherwise facilite navigation.",
+          "nextQuestionRoute": "/exemption/dredging/navigational-dredging"
+        },
+        {
+          "id": "shellfish",
+          "text": "Shellfish propagation and cultivation",
+          "nextQuestionRoute": "/exemption/dredging/shellfish-propagation-cultivation"
+        },
+        {
+          "id": "coastalProtectionDrainageOrFloodDefence",
+          "text": "Coastal Protection, drainage or flood defence",
+          "nextQuestionRoute": "/exemption/dredging/coastal-drainage-flood"
+        },
+        {
+          "id": "emergency",
+          "text": "Emergency, safety and training",
+          "nextQuestionRoute": "/exemption/dredging/emergency"
+        },
+                {
+          "id": "deepseaMining",
+          "text": "Licensed deepsea mining",
+          "nextQuestionRoute": "/exemption/dredging/miscellaneous/deepsea-mining"
+        },
+        {
+          "id": "crossrailAct",
+          "text": "Scheduled works authorised under the Crossrail Act 2008",
+          "nextQuestionRoute": "/exemption/dredging/miscellaneous/crossrail-act"
+        },
+        {
+          "id": "miscellaneous",
+          "text": "Other",
+          "outcomeRoute": "/exemption/dredging-exe-not-available-continue",
+          "hint": "Dredging activities for purposes not set out above"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/dredging/navigational-dredging",
+      "text": "Will the activity be carried out by or on behalf of the harbour authority?",
+      "section": "dredging",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/dredging/navigational-dredging/authorisation"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/dredging/navigational-dredging/purpose"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/dredging/navigational-dredging/authorisation",
+      "text": "Is the activity authorised by",
+      "section": "dredging",
+      "answers": [
+        {
+          "id": "localAct",
+          "text": "A local Act",
+          "nextQuestionRoute": "/exemption/dredging/navigational-dredging/method"
+        },
+        {
+          "id": "harboursAct",
+          "text": "An order under Section 14 or 16 of the Harbours Act 1964",
+          "nextQuestionRoute": "/exemption/dredging/navigational-dredging/method"
+        },
+        {
+          "id": "section1HaNorthernIreland",
+          "text": "An order under Section 1 of the Harbours Act (Northern ireland) 1970",
+          "nextQuestionRoute": "/exemption/dredging/navigational-dredging/method"
+        },
+        {
+          "id": "section10HaNorthernIreland",
+          "text": "An order under Section 10(3) of the Harbours Act (Northern ireland) 1970",
+          "nextQuestionRoute": "/exemption/dredging/navigational-dredging/method"
+        },
+        {
+          "id": "other",
+          "text": "None of the above",
+          "nextQuestionRoute": "/exemption/dredging/navigational-dredging/purpose"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/dredging/navigational-dredging/method",
+      "text": "Will the activity be carried out in accordance with the relevant authorisation?",
+      "section": "dredging",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-Section-75"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/dredging/navigational-dredging/purpose"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/dredging/navigational-dredging/purpose",
+      "text": "Is the purpose of the activity to enable the continued use of a navigational channel or area of 'Sea' by vessels?",
+      "section": "dredging",
+      "hint": "Find out more about what we mean by <a target=\"_blank\" href=\"https://www.gov.uk/guidance/marine-licensing-definitions#what-do-we-mean-by-the-sea\">sea</a>",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/dredging/navigational-dredging/maintenance"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/dredging-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/dredging/navigational-dredging/maintenance",
+      "text": "Will the dredging be carried out at a site, where at least one previous dredging campaign has taken place, to the same depth or deeper, in the last 10 years?",
+      "section": "dredging",
+      "hint": "Find out more about <a target=\"_blank\" href=\" https://www.gov.uk/guidance/dredging#dredging-by-type\"> maintenance dredging</a>",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/dredging/navigational-dredging/previous-purpose"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/dredging-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/dredging/navigational-dredging/previous-purpose",
+      "text": "Was the purpose of the previous dredge to enable the continued use of the area of 'Sea' by vessels?",
+      "section": "dredging",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/dredging/navigational-dredging/quantity"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/dredging-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/dredging/navigational-dredging/quantity",
+      "text": "How many cubic meters will be dredged?",
+      "section": "dredging",
+      "answers": [
+        {
+          "id": "lessThan501",
+          "text": "500m3 or less",
+          "nextQuestionRoute": "/exemption/dredging/navigational-dredging/last-12months"
+        },
+        {
+          "id": "moreThan500",
+          "text": "More than 500m3",
+          "outcomeRoute": "/exemption/dredging-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/dredging/navigational-dredging/last-12months",
+      "text": "Has any other dredging taken place at the site of the proposed dredge in the previous 12 months?",
+      "section": "dredging",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/dredging/navigational-dredging/last-12-quantity"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/dredging/navigational-dredging/obstruction"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/dredging/navigational-dredging/last-12-quantity",
+      "text": "Does the quantity of material dredged at the site in the previous 12 months, combined with the amount proposed to be dredged, exceed 1500m3?",
+      "section": "dredging",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/dredging-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/dredging/navigational-dredging/obstruction"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/dredging/navigational-dredging/obstruction",
+      "text": "Is the activity one that will cause or be likely to cause obstruction or danger to navigation?",
+      "section": "dredging",
+      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#navigational-risk\"> navigational risk </a> and the steps you can take to ensure your proposal is not one that will cause or be likely to cause and obstruction or danger.",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/dredging-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/dredging/navigational-dredging/mpa"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/dredging/navigational-dredging/mpa",
+      "text": "Will the activity take place in or within 200m of a Marine Protected Area (MPA)?",
+      "section": "deposit",
+  "hint": "<p>MPA's are an important part of the marine environment. </p><p>You are responsible for making sure you understand the status of the location where the activity is proposed. </p><p> ‘Marine protected areas’ mean:<ul><li>Highly Protected Marine Area (HPMA) (designated and candidate)</li><li>Marine Conservation Zones (MCZs) (designated and proposed)</li><li>Special Areas of Conservation (SACs) (designated and candidate)</li><li>Special Protection Areas (SPAs) (designated and potential)</li><li>Ramsar's</li><li>SSSIs</li></ul></p><p> If you are unsure of whether the activity falls within an MPA you should select the appropriate layer in the MMO’s <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\"> GIS tool </a> to check.",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/dredging/navigational-dredging/mpa-management"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-18A"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/dredging/navigational-dredging/mpa-management",
+      "text": "Is the activity directly connected with or necessary to the management of the Marine Protected Area?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-18A"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/dredging/navigational-dredging/lse"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/dredging/navigational-dredging/lse",
+      "text": "Is the activity....",
+      "section": "deposit",
+      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#marine-protected-areas\"> marine protected areas </a>.",
+      "answers": [
+        {
+          "id": "europeanSiteNavigationalDredging",
+          "text": "Likely to have a significant effect on a European site?",
+          "outcomeRoute": "/exemption/dredging-exe-not-available-continue",
+          "hint": "either alone or in combination with other plans and projects"
+        },
+        {
+          "id": "ramsarSiteNavigationalDredging",
+          "text": "Likely to have a significant effect on a Ramsar site?",
+          "outcomeRoute": "/exemption/dredging-exe-not-available-continue",
+          "hint": "either alone or in combination with other plans and projects"
+        },
+        {
+          "id": "mczNavigationalDredging",
+          "text": "Capable of affecting (other than insignificantly), the protected features of a Marine Conservation Zone or Highly Protected Marine Area?",
+          "outcomeRoute": "/exemption/dredging-exe-not-available-continue",
+          "hint": "including any ecological or geomorphological process on which the conservation of any protected feature of an MCZ or HPMA is (wholly or in Part) dependant"
+        },
+        {
+          "id": "otherSNavigationalDredging",
+          "text": "Unlikely to have any relevant effect on any sites specified above",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-18A"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/dredging/shellfish-propagation-cultivation",
+      "text": "Will the activity be carried out for the purpose of moving shellfish within the 'Sea' in the course of its propagation or cultivation?",
+      "section": "dredging",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-13"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/dredging-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/dredging/coastal-drainage-flood",
+      "text": "What does the dredging activity relate to?",
+      "section": "dredging",
+      "answers": [
+        {
+          "id": "maintenanceCoastalDrainageFlood",
+          "text": "Maintenance of coast protection, drainage or flood defence works",
+          "nextQuestionRoute": "/exemption/dredging/coastal-drainage-flood/maintenance"
+        },
+        {
+          "id": "emergencyFloodRisk",
+          "text": "Emergency works in relation to flood or flood risk",
+          "nextQuestionRoute": "/exemption/dredging/coastal-drainage-flood/emergency"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/dredging-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/dredging/coastal-drainage-flood/maintenance",
+      "text": "Who will carry out the activity?",
+      "section": "dredging",
+      "answers": [
+        {
+          "id": "environmentAgency",
+          "text": "The Environment Agency or someone on behalf of the Environment Agency",
+          "nextQuestionRoute": "/exemption/dredging/coastal-drainage-flood/maintenance/EA"
+        },
+        {
+          "id": "coastProtectionAuthority",
+          "text": "The Coast Protection Authority or someone on behalf of the Coast Protection Authority",
+          "nextQuestionRoute": "/exemption/dredging/coastal-drainage-flood/maintenance/CPA"
+        },
+        {
+          "id": "localAuthority",
+          "text": "The Local Authority or someone on behalf of the Local Authority",
+          "nextQuestionRoute": "/exemption/dredging/coastal-drainage-flood/maintenance/CPA"
+        },
+        {
+          "id": "secretaryStateDefence",
+          "text": "The Secretary of State for Defence or someone on behalf of the Secretary of State for Defence",
+          "nextQuestionRoute": "/exemption/dredging/coastal-drainage-flood/maintenance/CPA"
+        },
+        {
+          "id": "other",
+          "text": "Someone else",
+          "outcomeRoute": "/exemption/dredging-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/dredging/coastal-drainage-flood/maintenance/EA",
+      "text": "Will the activity be carried out wholly within the existing 3 dimensional boundary of the works being maintained?",
+      "section": "dredging",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/dredging/coastal-drainage-flood/maintenance/EA/beach-replenishment"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/dredging/coastal-drainage-flood/emergency/validation"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/dredging/coastal-drainage-flood/maintenance/EA/beach-replenishment",
+      "text": "Does the activity involve beach replenishment?",
+            "hint": "'Beach replenishment' means the addition of material from land-based, off-shore or other coastal sources not connected to the beach or its associated sediment system to replace material permanently lost from the system.",
+      "section": "dredging",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/dredging-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-19"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/dredging/coastal-drainage-flood/maintenance/CPA",
+      "text": "Is the activity for the purpose of maintaining coast protection works?",
+            "hint": "'Coast protection works' include: </li><li><u>beach re-profiling</U>, which involves the movement of beach material in a cross-shore direction up or down the beach; and </li><li><u>beach recycling</u>, which involves the movement of beach material along the beach from areas of accretion to areas of erosion within the beach or associated sediment system.",
+      "section": "dredging",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/dredging/coastal-drainage-flood/maintenance/EA/beach-replenishment"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/dredging-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/dredging/coastal-drainage-flood/maintenance/CPA/beach-replenishment",
+      "text": "Does the activity involve beach replenishment?",
+            "hint": "'Beach replenishment' means the addition of material from land-based, off-shore or other coastal sources not connected to the beach or its associated sediment system to replace material permanently lost from the system.",
+      "section": "dredging",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/dredging-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-19"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/dredging/coastal-drainage-flood/emergency",
+      "text": "Will the activity be carried out by or on behalf on the Environment Agency?",
+      "section": "dredging",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/dredging/coastal-drainage-flood/emergency/validation"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/dredging-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/dredging/coastal-drainage-flood/emergency/validation",
+      "text": "Are the circumstances serious, unexpected, and potentially dangerous requiring immediate action in response to either flooding or imminent risk of flooding?",
+      "section": "deposit",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-20"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/dredging-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/dredging/emergency",
+      "text": "What does the dredging activity relate to?",
+      "section": "dredging",
+      "answers": [
+        {
+          "id": "floodFloodRisk",
+          "text": "Flood or flood risk",
+          "nextQuestionRoute": "/exemption/dredging/emergency/flood-flood-risk"
+        },
+        {
+          "id": "cablesPipelines",
+          "text": "Cables and pipelines",
+          "nextQuestionRoute": "/exemption/dredging/emergency/cables-pipelines"
+        },
+        {
+          "id": "coastguardActivities",
+          "text": "Coastguard activities",
+          "nextQuestionRoute": "/exemption/dredging/emergency/coastguard",
+          "hint": "safety purposes and training"
+        },
+        {
+          "id": "salvageOperation",
+          "text": "Salvage Operation",
+          "nextQuestionRoute": "/exemption/dredging/emergency/salvage-operation"
+        },
+        {
+          "id": "safetyDirections",
+          "text": "Safety directions under the Merchant Shipping Act 1995",
+          "nextQuestionRoute": "/exemption/dredging/safety-training/safety-directions"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/dredging-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/dredging/emergency/flood-flood-risk",
+      "text": "Will the activity be carried out by or on behalf of the Environment Agency?",
+      "section": "dredging",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/dredging/emergency/flood-flood-risk/emergency"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/dredging-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/dredging/emergency/flood-flood-risk/emergency",
+      "text": "Are the circumstances serious, unexpected and potentially dangerous requiring immediate action in response to flood or imminent risk of flood?",
+      "section": "dredging",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-20"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/dredging-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/dredging/emergency/cables-pipelines",
+      "text": "Does the dredging activity relate to the inspection or repair of an existing cable or pipeline",
+      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities--2#cables-pipelines-oil-and-gas-and-carbon-capture-storage\"> cables and pipelines </a>.",
+      "section": "dredging",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/dredging/emergency/cables-pipelines/emergency"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/dredging-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/dredging/emergency/cables-pipelines/emergency",
+      "text": "Are the circumstances serious, unexpected and potentially dangerous requiring immediate action?",
+      "section": "dredging",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/dredging/emergency/cables-pipelines/protection"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/dredging-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/dredging/emergency/cables-pipelines/protection",
+      "text": "Will the activity proposed include the deposit of rock or other materials for the purpose of providing <u>new</U> cable or pipeline protection?",
+      "hint": "Deposits for these purposes, i.e. those beyond the replenishment or replacement of materials wholly within the three dimensional boundaries of those previously consented and deposited, will require a marine licence. If the maintenance, inspection or repair can be carried out without the need for new protection you are advised to adapt your proposed approach. <P><P>NOTE: If you intend to apply for a marine licence in respect of the addition of new or extended protection, where relevant, please select ‘No’ to continue.",
+      "section": "dredging",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/dredging-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "nextQuestionRoute": "/exemption/dredging/emergency/cables-pipelines/protection/explosives"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/dredging/emergency/cables-pipelines/protection/explosives",
+      "text": "Does the activity involve the deposit or use of explosives?",
+      "section": "dredging",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/dredging-exe-not-available-continue"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-34"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/dredging/emergency/coastguard",
+      "text": "Will the activity be carried out by or on behalf the Secretary of State for Transport, acting through the Maritime and Coastguard Agency?",
+      "section": "dredging",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "nextQuestionRoute": "/exemption/dredging/emergency/coastguard/purpose"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/dredging-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/dredging/emergency/coastguard/purpose",
+      "text": "What is the purpose of the activity?",
+      "section": "dredging",
+      "answers": [
+        {
+          "id": "securingVesselAircraftMarineStructureSafety",
+          "text": "Securing the safety of a vessel, aircraft or marine structure ",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-32",
+          "hint": "'marine structure' means a platform or other artificial structure at 'Sea', other than a pipeline."
+        },
+        {
+          "id": "savingLife",
+          "text": "Saving life",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-32"
+        },
+        {
+          "id": "training",
+          "text": "Training for either of the above two purposes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-32"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/dredging-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/dredging/emergency/salvage-operation",
+      "text": "Will the activity be carried out in the course of an official salvage operation for the purpose of ensuring the safety of a vessel or preventing pollution?",
+      "section": "dredging",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-9"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/dredging-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/dredging/safety-training/safety-directions",
+      "text": "What is the purpose of the activity?",
+      "section": "dredging",
+      "answers": [
+        {
+          "id": "secretaryOfStateSchedule3A",
+          "text": "In exercise of a power under Schedule 3A to the Merchant Shipping Act 1995 (safety directions) by or on behalf of the Secretary of State",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-8"
+        },
+        {
+          "id": "schedule3ACompliance",
+          "text": "Compliance with a direction under Schedule 3A to the Merchant Shipping Act 1995 (safety directions)",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-8"
+        },
+        {
+          "id": "avoidingInterference",
+          "text": "Avoiding interference with action taken under Schedule 3A to the Merchant Shipping Act 1995 (safety directions)",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-8"
+        },
+        {
+          "id": "other",
+          "text": "Other",
+          "outcomeRoute": "/exemption/dredging-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/dredging/miscellaneous/deepsea-mining",
+      "text": "Is the activity carried out?",
+      "section": "dredging",
+      "answers": [
+        {
+          "id": "explorationExploitationLicence",
+          "text": "In pursuance of an exploration or exploitation licence issued under the Deep Sea Mining (Temporary Provision) Act 1981",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-30"
+        },
+        {
+          "id": "reciprocalauthorisation",
+          "text": "In pursuance of a reciprocal authorisation within the meaning given by section 3(3) of the Deep Sea Mining (Temporary Provision) Act 1981",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-30"
+        },
+        {
+          "id": "other",
+          "text": "for another reason",
+          "outcomeRoute": "/exemption/dredging-exe-not-available-continue"
+        }
+      ]
+    },
+    {
+      "route": "/exemption/dredging/miscellaneous/crossrail-act",
+      "text": "Will the activity be carried out within the limits of deviation for scheduled works in exercise of powers conferred by the Crossrail Act 2008 in relation to those works or any work connected with them?",
+      "section": "dredging",
+      "answers": [
+        {
+          "id": "yes",
+          "text": "Yes",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-29"
+        },
+        {
+          "id": "no",
+          "text": "No",
+          "outcomeRoute": "/exemption/dredging-exe-not-available-continue"
+        }
+      ]
+    }
+  ]
+}

--- a/app/data/iat.json
+++ b/app/data/iat.json
@@ -56,7 +56,7 @@
       "id": "construction",
       "text": "Exemption check - Construction activity"
     },
-        {
+    {
       "id": "constructionMaintenance",
       "text": "Exemption check - Construction activity - Maintenance"
     },
@@ -215,7 +215,7 @@
     {
       "id": "WO_STANDARD_TRACK_MLA_OTHER_CLEARANCE_DREDGING",
       "heading": "Apply for a standard marine licence",
-     "text": "You selected 'Other clearance dredging' which indicates that your proposed activity includes an activity not specified in the self-service sub-activity list provided. Only activities specified are suitable for self-service marine licensing. <p> Based on the information provided the activity requires a marine licence from the MMO but the activity is not suitable for self-service marine licensing.",
+      "text": "You selected 'Other clearance dredging' which indicates that your proposed activity includes an activity not specified in the self-service sub-activity list provided. Only activities specified are suitable for self-service marine licensing. <p> Based on the information provided the activity requires a marine licence from the MMO but the activity is not suitable for self-service marine licensing.",
       "module": "MMO_APP2_CONTROL",
       "entryTheme": "new"
     },
@@ -304,7 +304,7 @@
     },
     {
       "id": "WO_FAST_TRACK_MLA_BAS_BLOCK",
-      "text": "Based on the information provided the activity requires a marine licence from the MMO and qualifies for self-service marine licensing but a licence cannot be issued until the ‘relevant documentation’ is obtained."
+      "text": "Based on the information provided the activity requires a marine licence from the MMO and qualifies for self-service marine licensing but a licence cannot be issued until the \u2018relevant documentation\u2019 is obtained."
     },
     {
       "id": "WO_DOWNLOAD_TH_MARKERS_AGREED_METHOD_TEMPLATE",
@@ -352,7 +352,7 @@
     },
     {
       "id": "WO_EXE_NOT_LICENSABLE_SEA",
-      "text": "You have indicated that the activity will not take place in the ‘Sea’, over the ‘Sea’, or on or under the 'Seabed'. <p>Based on the information provided a marine licence is not required from the MMO. <p>The definition of ‘Sea’ under the Marine and Coastal Access Act 2009 is broad and includes any area which is submerged at Mean High Water Springs (MHWS) and the waters of every estuary, river or channel where the tide flows at MHWS tide up to the Normal Tidal Limit. Even waters in areas which are closed permanently or intermittently by a lock or other artificial means against the regular action of the tide are included, where seawater flows into or out from the area, either continuously or from time to time.<p>if you have cause to doubt whether the information you provided is correct you are advised to review the guidance provided and re-run the check where appropriate."
+      "text": "You have indicated that the activity will not take place in the \u2018Sea\u2019, over the \u2018Sea\u2019, or on or under the 'Seabed'. <p>Based on the information provided a marine licence is not required from the MMO. <p>The definition of \u2018Sea\u2019 under the Marine and Coastal Access Act 2009 is broad and includes any area which is submerged at Mean High Water Springs (MHWS) and the waters of every estuary, river or channel where the tide flows at MHWS tide up to the Normal Tidal Limit. Even waters in areas which are closed permanently or intermittently by a lock or other artificial means against the regular action of the tide are included, where seawater flows into or out from the area, either continuously or from time to time.<p>if you have cause to doubt whether the information you provided is correct you are advised to review the guidance provided and re-run the check where appropriate."
     },
     {
       "id": "WO_EXE_NOT_LICENSABLE_ELSEWHERE_ACTIVITY",
@@ -367,22 +367,22 @@
       "text": "You have indicated that the activity will not involve the removal of a substance or object using a vehicle or vessel, aircraft, marine structure, floating container or using a structure on land, constructed or adapted wholly or mainly for the purposes of depositing solids in the Sea. <p>Based on the information provided a marine licence is not required from the MMO.<p>if you have cause to doubt whether the information you provided is correct you are advised to review the guidance provided and re-run the check where appropriate."
     },
     {
-      "id":  "WO_EXE_NOT_LICENSABLE_REMOVAL_SEABED",
-      "text": "You have indicated that the activity will not involve the removal of a substance or object from the 'Seabed'. <p>Based on the information provided a marine licence is not required from the MMO.<p>The meaning of 'Seabed' is broad, it includes the ground under the 'Sea' and anything resting on it such as a wreck. It includes the intertidal area of the sea or any river at such time as it is exposed temporarily at low tide.<p>The definition of ‘Sea’ under the Marine and Coastal Access Act 2009 is also broad and includes any area which is submerged at Mean High Water Springs (MHWS) and the waters of every estuary, river or channel where the tide flows at MHWS tide up to the Normal Tidal Limit. Even waters in areas which are closed permanently or intermittently by a lock or other artificial means against the regular action of the tide are included, where seawater flows into or out from the area, either continuously or from time to time.<p>if you have cause to doubt whether the information you provided is correct you are advised to review the guidance provided and re-run the check where appropriate. " 
+      "id": "WO_EXE_NOT_LICENSABLE_REMOVAL_SEABED",
+      "text": "You have indicated that the activity will not involve the removal of a substance or object from the 'Seabed'. <p>Based on the information provided a marine licence is not required from the MMO.<p>The meaning of 'Seabed' is broad, it includes the ground under the 'Sea' and anything resting on it such as a wreck. It includes the intertidal area of the sea or any river at such time as it is exposed temporarily at low tide.<p>The definition of \u2018Sea\u2019 under the Marine and Coastal Access Act 2009 is also broad and includes any area which is submerged at Mean High Water Springs (MHWS) and the waters of every estuary, river or channel where the tide flows at MHWS tide up to the Normal Tidal Limit. Even waters in areas which are closed permanently or intermittently by a lock or other artificial means against the regular action of the tide are included, where seawater flows into or out from the area, either continuously or from time to time.<p>if you have cause to doubt whether the information you provided is correct you are advised to review the guidance provided and re-run the check where appropriate. "
     },
-   {
-      "id":  "WO_EXE_NOT_LICENSABLE_INCINERATION_ON",
+    {
+      "id": "WO_EXE_NOT_LICENSABLE_INCINERATION_ON",
       "text": "You have indicated that the activity will not take place on a vehicle or vessel, a marine structure, floating container. <p>Based on the information provided a marine licence is not required from the MMO.<p>if you have cause to doubt whether the information you provided is correct you are advised to review the guidance provided and re-run the check where appropriate."
     },
     {
       "id": "WO_EXE_NOT_LICENSABLE_DEPOSIT_METHOD_ELSEWHERE",
-     "text": "You have indicated that the activity will not involve the deposit of a substance or object from a British vessel, British aircraft, British marine structure or floating container controlled by any of the aforementioned. You also indicated that the substance or object to be deposited was not or will not be loaded anywhere in the United kingdom (except Scotland) or in the UK marine licensing area.  <p>Based on the information provided a marine licence is not required from the MMO.<p>if you have cause to doubt whether the information you provided is correct you are advised to review the guidance provided and re-run the check where appropriate."
+      "text": "You have indicated that the activity will not involve the deposit of a substance or object from a British vessel, British aircraft, British marine structure or floating container controlled by any of the aforementioned. You also indicated that the substance or object to be deposited was not or will not be loaded anywhere in the United kingdom (except Scotland) or in the UK marine licensing area.  <p>Based on the information provided a marine licence is not required from the MMO.<p>if you have cause to doubt whether the information you provided is correct you are advised to review the guidance provided and re-run the check where appropriate."
     },
     {
       "id": "WO_EXE_NOT_LICENSABLE_INCINERATION_METHOD_ELSEWHERE",
-     "text": "You have indicated that the activity will not take place on a British vessel, British marine structure or floating container controlled by a British vessel, British aircraft or British marine structure. You also indicated that the substance or object to be incinerated was not or will not be loaded anywhere in the United kingdom (except Scotland) or in the UK marine licensing area.  <p>Based on the information provided a marine licence is not required from the MMO.<p>if you have cause to doubt whether the information you provided is correct you are advised to review the guidance provided and re-run the check where appropriate."
+      "text": "You have indicated that the activity will not take place on a British vessel, British marine structure or floating container controlled by a British vessel, British aircraft or British marine structure. You also indicated that the substance or object to be incinerated was not or will not be loaded anywhere in the United kingdom (except Scotland) or in the UK marine licensing area.  <p>Based on the information provided a marine licence is not required from the MMO.<p>if you have cause to doubt whether the information you provided is correct you are advised to review the guidance provided and re-run the check where appropriate."
     },
-   {
+    {
       "id": "WO_EXE_NOT_LICENSABLE_SCUTTLING_METHOD_ELSEWHERE",
       "text": "You have indicated that the activity will not be controlled from a British vessel, British aircraft, British marine structure and will the will the vessel or container in question  will not be towed or propelled from either, the United Kingdom (Except Scotland) or the Uk marine licensing area (other than where towing or propelling began outside that area).  <p>Based on the information provided a marine licence is not required from the MMO.<p>if you have cause to doubt whether the information you provided is correct you are advised to review the guidance provided and re-run the check where appropriate."
     },
@@ -432,9 +432,11 @@
     {
       "id": "WO_EXE_AVAILABLE_ARTICLE_13",
       "heading": "Fill out an exemption notification",
-      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/13\"> Article 13 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption is subject to the requirement that notification of the intention to carry out the activity is given to the MMO prior to the commencement of the activity.",
+      "text": "Based on your answers, your activity is exempt under <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/13\"> Article 13 of the Marine Licence (Exempted Activities) Order 2011 (opens in new tab)</a> . <p><b><b>Your activity is only exempt on the condition that you provide further information before starting.</b></b>  <p> This is a 'beta' service -  <a target=\"_blank\" href=\"https://www.gov.uk/help/beta\"> find out what this means for you (opens in new tab). </a> <p> To use the service, you\u2019ll need:  <p> <ul><li> details of the site where the activity will take place</li>  <li>information about what the activity involves</li> <li>start and end dates for your activity</li></ul></p>  <p> You'll also need a Defra account to send this information. You can sign in with GOV.UK One Login or Government Gateway. If you do not have a Defra account, you’ll be asked to create one after you sign in.",
       "module": "MMO_ADVICE_CONTROL",
       "entryTheme": "new",
+      "overrideCtaButtonText": "Continue",
+      "overrideCtaButtonUrl": "https://get-permission-for-marine-work.defra.gov.uk/guidance/who-is-the-exemption-for/",
       "params": [
         {
           "name": "ADV_TYPE",
@@ -461,9 +463,11 @@
     {
       "id": "WO_EXE_AVAILABLE_ARTICLE_17",
       "heading": "Fill out an exemption notification",
-      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/17\"> Article 17 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption is subject to the requirement that notification of the intention to carry out the activity is given to the MMO prior to the commencement of the activity. <p> Kindly please click through this link to join us for the new private beta service we are developing <a target=\"_blank\" href=\"https://marine-licensing-prototype-5b7b33ca29e1.herokuapp.com/versions/2025-01-27/exemption/what-is-your-name\"> Private beta link </a>",
+      "text": "Based on your answers, your activity is exempt under <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/17\"> Article 17 of the Marine Licence (Exempted Activities) Order 2011 (opens in new tab)</a> . <p><b><b>Your activity is only exempt on the condition that you provide further information before starting.</b></b>  <p> This is a 'beta' service -  <a target=\"_blank\" href=\"https://www.gov.uk/help/beta\"> find out what this means for you (opens in new tab). </a> <p> To use the service, you\u2019ll need:  <p> <ul><li> details of the site where the activity will take place</li>  <li>information about what the activity involves</li> <li>start and end dates for your activity</li></ul></p>  <p> You'll also need a Defra account to send this information. You can sign in with GOV.UK One Login or Government Gateway. If you do not have a Defra account, you’ll be asked to create one after you sign in.",
       "module": "MMO_ADVICE_CONTROL",
       "entryTheme": "new",
+      "overrideCtaButtonText": "Continue",
+      "overrideCtaButtonUrl": "https://get-permission-for-marine-work.defra.gov.uk/guidance/who-is-the-exemption-for/",
       "params": [
         {
           "name": "ADV_TYPE",
@@ -478,9 +482,11 @@
     {
       "id": "WO_EXE_AVAILABLE_ARTICLE_17A",
       "heading": "Fill out an exemption notification",
-      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/17A\"> Article 17A of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption is subject to the requirement that notification of the intention to carry out the activity is given to the MMO prior to the commencement of the activity.",
+      "text": "Based on your answers, your activity is exempt under <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/17A\"> Article 17A of the Marine Licence (Exempted Activities) Order 2011 (opens in new tab)</a> . <p><b><b>Your activity is only exempt on the condition that you provide further information before starting.</b></b>  <p> This is a 'beta' service -  <a target=\"_blank\" href=\"https://www.gov.uk/help/beta\"> find out what this means for you (opens in new tab). </a> <p> To use the service, you\u2019ll need:  <p> <ul><li> details of the site where the activity will take place</li>  <li>information about what the activity involves</li> <li>start and end dates for your activity</li></ul></p>  <p> You'll also need a Defra account to send this information. You can sign in with GOV.UK One Login or Government Gateway. If you do not have a Defra account, you’ll be asked to create one after you sign in.",
       "module": "MMO_ADVICE_CONTROL",
       "entryTheme": "new",
+      "overrideCtaButtonText": "Continue",
+      "overrideCtaButtonUrl": "https://get-permission-for-marine-work.defra.gov.uk/guidance/who-is-the-exemption-for/",
       "params": [
         {
           "name": "ADV_TYPE",
@@ -495,9 +501,11 @@
     {
       "id": "WO_EXE_AVAILABLE_ARTICLE_17B",
       "heading": "Fill out an exemption notification",
-      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/17B\"> Article 17B of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption is subject to the requirement that notification of the intention to carry out the activity is given to the MMO prior to the commencement of the activity.",
+      "text": "Based on your answers, your activity is exempt under <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/17B\"> Article 17B of the Marine Licence (Exempted Activities) Order 2011 (opens in new tab)</a> . <p><b><b>Your activity is only exempt on the condition that you provide further information before starting.</b></b>  <p> This is a 'beta' service -  <a target=\"_blank\" href=\"https://www.gov.uk/help/beta\"> find out what this means for you (opens in new tab). </a> <p> To use the service, you\u2019ll need:  <p> <ul><li> details of the site where the activity will take place</li>  <li>information about what the activity involves</li> <li>start and end dates for your activity</li></ul></p>  <p> You'll also need a Defra account to send this information. You can sign in with GOV.UK One Login or Government Gateway. If you do not have a Defra account, you’ll be asked to create one after you sign in.",
       "module": "MMO_ADVICE_CONTROL",
       "entryTheme": "new",
+      "overrideCtaButtonText": "Continue",
+      "overrideCtaButtonUrl": "https://get-permission-for-marine-work.defra.gov.uk/guidance/who-is-the-exemption-for/",
       "params": [
         {
           "name": "ADV_TYPE",
@@ -516,9 +524,11 @@
     {
       "id": "WO_EXE_AVAILABLE_ARTICLE_18A",
       "heading": "Fill out an exemption notification",
-      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/18A\"> Article 18A of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption is subject to the requirement that notification of the intention to carry out the activity is given to the MMO prior to the commencement of the activity.",
+      "text": "Based on your answers, your activity is exempt under <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/18A\"> Article 18A of the Marine Licence (Exempted Activities) Order 2011 (opens in new tab)</a> . <p><b><b>Your activity is only exempt on the condition that you provide further information before starting.</b></b>  <p> This is a 'beta' service -  <a target=\"_blank\" href=\"https://www.gov.uk/help/beta\"> find out what this means for you (opens in new tab). </a> <p> To use the service, you\u2019ll need:  <p> <ul><li> details of the site where the activity will take place</li>  <li>information about what the activity involves</li> <li>start and end dates for your activity</li></ul></p>  <p> You'll also need a Defra account to send this information. You can sign in with GOV.UK One Login or Government Gateway. If you do not have a Defra account, you’ll be asked to create one after you sign in.",
       "module": "MMO_ADVICE_CONTROL",
       "entryTheme": "new",
+      "overrideCtaButtonText": "Continue",
+      "overrideCtaButtonUrl": "https://get-permission-for-marine-work.defra.gov.uk/guidance/who-is-the-exemption-for/",
       "params": [
         {
           "name": "ADV_TYPE",
@@ -537,9 +547,11 @@
     {
       "id": "WO_EXE_AVAILABLE_ARTICLE_20",
       "heading": "Fill out an exemption notification",
-      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/20\"> Article 20 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption is subject to the requirement that notification of the carrying on of the emergency works is given to the MMO within 168 hours of the commencement of the activity. The notification must set out the location of, the circumstances giving rise to and the nature of the emergency works",
+      "text": "Based on your answers, your activity is exempt under <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/20\"> Article 20 of the Marine Licence (Exempted Activities) Order 2011 (opens in new tab)</a> . <p><b><b>Your activity is only exempt on the condition that you provide further information before starting.</b></b>  <p> This is a 'beta' service -  <a target=\"_blank\" href=\"https://www.gov.uk/help/beta\"> find out what this means for you (opens in new tab). </a> <p> To use the service, you\u2019ll need:  <p> <ul><li> details of the site where the activity will take place</li>  <li>information about what the activity involves</li> <li>start and end dates for your activity</li></ul></p>  <p> You'll also need a Defra account to send this information. You can sign in with GOV.UK One Login or Government Gateway. If you do not have a Defra account, you’ll be asked to create one after you sign in.",
       "module": "MMO_ADVICE_CONTROL",
       "entryTheme": "new",
+      "overrideCtaButtonText": "Continue",
+      "overrideCtaButtonUrl": "https://get-permission-for-marine-work.defra.gov.uk/guidance/who-is-the-exemption-for/",
       "params": [
         {
           "name": "ADV_TYPE",
@@ -558,9 +570,11 @@
     {
       "id": "WO_EXE_AVAILABLE_ARTICLE_21",
       "heading": "Fill out an exemption notification",
-      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/21\"> Article 21 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption is subject to the requirement that notification of the intention to carry out the activity is given to the MMO prior to the commencement of the activity.",
+      "text": "Based on your answers, your activity is exempt under <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/21\"> Article 21 of the Marine Licence (Exempted Activities) Order 2011 (opens in new tab)</a> . <p><b><b>Your activity is only exempt on the condition that you provide further information before starting.</b></b>  <p> This is a 'beta' service -  <a target=\"_blank\" href=\"https://www.gov.uk/help/beta\"> find out what this means for you (opens in new tab). </a> <p> To use the service, you\u2019ll need:  <p> <ul><li> details of the site where the activity will take place</li>  <li>information about what the activity involves</li> <li>start and end dates for your activity</li></ul></p>  <p> You'll also need a Defra account to send this information. You can sign in with GOV.UK One Login or Government Gateway. If you do not have a Defra account, you’ll be asked to create one after you sign in.",
       "module": "MMO_ADVICE_CONTROL",
       "entryTheme": "new",
+      "overrideCtaButtonText": "Continue",
+      "overrideCtaButtonUrl": "https://get-permission-for-marine-work.defra.gov.uk/guidance/who-is-the-exemption-for/",
       "params": [
         {
           "name": "ADV_TYPE",
@@ -603,9 +617,11 @@
     {
       "id": "WO_EXE_AVAILABLE_ARTICLE_25_NOTIFICATION",
       "heading": "Fill out an exemption notification",
-      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/25\"> Article 25 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption is subject to the requirement that notification of the intention to carry out the activity is given to the MMO prior to the commencement of the activity.",
+      "text": "Based on your answers, your activity is exempt under <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/25\"> Article 25 of the Marine Licence (Exempted Activities) Order 2011 (opens in new tab)</a> . <p><b><b>Your activity is only exempt on the condition that you provide further information before starting.</b></b>  <p> This is a 'beta' service -  <a target=\"_blank\" href=\"https://www.gov.uk/help/beta\"> find out what this means for you (opens in new tab). </a> <p> To use the service, you\u2019ll need:  <p> <ul><li> details of the site where the activity will take place</li>  <li>information about what the activity involves</li> <li>start and end dates for your activity</li></ul></p>  <p> You'll also need a Defra account to send this information. You can sign in with GOV.UK One Login or Government Gateway. If you do not have a Defra account, you’ll be asked to create one after you sign in.",
       "module": "MMO_ADVICE_CONTROL",
       "entryTheme": "new",
+      "overrideCtaButtonText": "Continue",
+      "overrideCtaButtonUrl": "https://get-permission-for-marine-work.defra.gov.uk/guidance/who-is-the-exemption-for/",
       "params": [
         {
           "name": "ADV_TYPE",
@@ -620,9 +636,11 @@
     {
       "id": "WO_EXE_AVAILABLE_ARTICLE_25A",
       "heading": "Fill out an exemption notification",
-      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/25A\"> Article 25A of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption is subject to the requirement that notification of the intention to carry out the activity is given to the MMO prior to the commencement of the activity.",
+      "text": "Based on your answers, your activity is exempt under <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/25A\"> Article 25A of the Marine Licence (Exempted Activities) Order 2011 (opens in new tab)</a> . <p><b><b>Your activity is only exempt on the condition that you provide further information before starting.</b></b>  <p> This is a 'beta' service -  <a target=\"_blank\" href=\"https://www.gov.uk/help/beta\"> find out what this means for you (opens in new tab). </a> <p> To use the service, you\u2019ll need:  <p> <ul><li> details of the site where the activity will take place</li>  <li>information about what the activity involves</li> <li>start and end dates for your activity</li></ul></p>  <p> You'll also need a Defra account to send this information. You can sign in with GOV.UK One Login or Government Gateway. If you do not have a Defra account, you’ll be asked to create one after you sign in.",
       "module": "MMO_ADVICE_CONTROL",
       "entryTheme": "new",
+      "overrideCtaButtonText": "Continue",
+      "overrideCtaButtonUrl": "https://get-permission-for-marine-work.defra.gov.uk/guidance/who-is-the-exemption-for/",
       "params": [
         {
           "name": "ADV_TYPE",
@@ -671,9 +689,11 @@
     {
       "id": "WO_EXE_AVAILABLE_ARTICLE_26A",
       "heading": "Fill out an exemption notification",
-      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/26A\"> Article 26A of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption is subject to the requirement that notification of the intention to carry out the activity is given to the MMO prior to the commencement of the activity.",
+      "text": "Based on your answers, your activity is exempt under <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/26A\"> Article 26A of the Marine Licence (Exempted Activities) Order 2011 (opens in new tab)</a> . <p><b><b>Your activity is only exempt on the condition that you provide further information before starting.</b></b>  <p> This is a 'beta' service -  <a target=\"_blank\" href=\"https://www.gov.uk/help/beta\"> find out what this means for you (opens in new tab). </a> <p> To use the service, you\u2019ll need:  <p> <ul><li> details of the site where the activity will take place</li>  <li>information about what the activity involves</li> <li>start and end dates for your activity</li></ul></p>  <p> You'll also need a Defra account to send this information. You can sign in with GOV.UK One Login or Government Gateway. If you do not have a Defra account, you’ll be asked to create one after you sign in.",
       "module": "MMO_ADVICE_CONTROL",
       "entryTheme": "new",
+      "overrideCtaButtonText": "Continue",
+      "overrideCtaButtonUrl": "https://get-permission-for-marine-work.defra.gov.uk/guidance/who-is-the-exemption-for/",
       "params": [
         {
           "name": "ADV_TYPE",
@@ -724,9 +744,11 @@
     {
       "id": "WO_EXE_AVAILABLE_ARTICLE_34",
       "heading": "Fill out an exemption notification",
-      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/34\"> Article 34 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption is subject to the requirement that notification of the carrying on of the emergency works is given to the MMO within 24 hours of the commencement of the activity. The notification must set out the location of, the circumstances giving rise to and the nature of the emergency works",
+      "text": "Based on your answers, your activity is exempt under <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/34\"> Article 34 of the Marine Licence (Exempted Activities) Order 2011 (opens in new tab)</a> . <p><b><b>Your activity is only exempt on the condition that you provide further information before starting.</b></b>  <p> This is a 'beta' service -  <a target=\"_blank\" href=\"https://www.gov.uk/help/beta\"> find out what this means for you (opens in new tab). </a> <p> To use the service, you\u2019ll need:  <p> <ul><li> details of the site where the activity will take place</li>  <li>information about what the activity involves</li> <li>start and end dates for your activity</li></ul></p>  <p> You'll also need a Defra account to send this information. You can sign in with GOV.UK One Login or Government Gateway. If you do not have a Defra account, you’ll be asked to create one after you sign in.",
       "module": "MMO_ADVICE_CONTROL",
       "entryTheme": "new",
+      "overrideCtaButtonText": "Continue",
+      "overrideCtaButtonUrl": "https://get-permission-for-marine-work.defra.gov.uk/guidance/who-is-the-exemption-for/",
       "params": [
         {
           "name": "ADV_TYPE",
@@ -745,9 +767,11 @@
     {
       "id": "WO_EXE_AVAILABLE_ARTICLE_35",
       "heading": "Fill out an exemption notification",
-      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/35\"> Article 35 of the Marine Licence (Exempted Activities) Order 2011 (as amended) </a> and a marine licence is therefore not required. <p>This exemption is subject to the requirement that notification of the intention to carry out the activity is given to the MMO prior to the commencement of the activity.",
+      "text": "Based on your answers, your activity is exempt under <a target=\"_blank\" href=\"http://www.legislation.gov.uk/uksi/2011/409/article/35\"> Article 35 of the Marine Licence (Exempted Activities) Order 2011 (opens in new tab)</a> . <p><b><b>Your activity is only exempt on the condition that you provide further information before starting.</b></b>  <p> This is a 'beta' service -  <a target=\"_blank\" href=\"https://www.gov.uk/help/beta\"> find out what this means for you (opens in new tab). </a> <p> To use the service, you\u2019ll need:  <p> <ul><li> details of the site where the activity will take place</li>  <li>information about what the activity involves</li> <li>start and end dates for your activity</li></ul></p>  <p> You'll also need a Defra account to send this information. You can sign in with GOV.UK One Login or Government Gateway. If you do not have a Defra account, you’ll be asked to create one after you sign in.",
       "module": "MMO_ADVICE_CONTROL",
       "entryTheme": "new",
+      "overrideCtaButtonText": "Continue",
+      "overrideCtaButtonUrl": "https://get-permission-for-marine-work.defra.gov.uk/guidance/who-is-the-exemption-for/",
       "params": [
         {
           "name": "ADV_TYPE",
@@ -774,7 +798,7 @@
     {
       "id": "WO_EXE_AVAILABLE_SECTION_75_DISPOSAL",
       "heading": "Submit an enquiry",
-      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/ukpga/2009/23/section/75\"> S75 of the Marine and Coastal Access Act 2009 </a> and a marine licence is therefore not required. <p>However, this exemption is subject to the requirement that the activity is carried out in accordance with an <u>approval</u> granted by the MMO. <p>Before granting approval you must satisfy the MMO that the material to be disposed is non-hazardous. Please submit an enquiry setting out the particulars of the project and include evidence to inform the MMO’s assessment. <p>This approval service constitutes a formal permission and is chargeable. An estimate of costs will be provided on receipt of the enquiry form. <p>This exemption does not apply until the MMO grant an approval.",
+      "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/ukpga/2009/23/section/75\"> S75 of the Marine and Coastal Access Act 2009 </a> and a marine licence is therefore not required. <p>However, this exemption is subject to the requirement that the activity is carried out in accordance with an <u>approval</u> granted by the MMO. <p>Before granting approval you must satisfy the MMO that the material to be disposed is non-hazardous. Please submit an enquiry setting out the particulars of the project and include evidence to inform the MMO\u2019s assessment. <p>This approval service constitutes a formal permission and is chargeable. An estimate of costs will be provided on receipt of the enquiry form. <p>This exemption does not apply until the MMO grant an approval.",
       "module": "MMO_ADVICE_CONTROL",
       "entryTheme": "new",
       "params": [
@@ -788,7 +812,7 @@
       "id": "WO_EXE_AVAILABLE_SECTION_77",
       "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/ukpga/2009/23/section/77\"> S77 of the Marine and Coastal Access Act 2009 </a> and a marine licence is therefore not required. <p>This exemption does not require any action from you before it is carried out."
     },
-        {
+    {
       "id": "WO_EXE_AVAILABLE_SECTION_81",
       "text": "Based on the information provided the activity is one that meets the terms of a marine licence exemption set out in <a target=\"_blank\" href=\"http://www.legislation.gov.uk/ukpga/2009/23/section/81\"> S81 of the Marine and Coastal Access Act 2009 </a> and a marine licence is therefore not required. <p>This exemption does not require any action from you before it is carried out."
     },
@@ -855,12 +879,6 @@
       "nextQuestionRoute": "/exemption/construction"
     },
     {
-      "id": "WO_CON_EXEMPTION_JOURNEY_ARTICLE99",
-      "heading": "Check to see if an exemption applies or notify the MMO about an exempt activity",
-      "text": "Based on the information provided the selected activity is a licensable activity and as such may require a marine licence.<p><p>You are advised to select an appropriate option and continue your check.",
-      "nextQuestionRoute": "/exemption/construction/article99"
-    },
-    {
       "id": "WO_CON_SELF_SERVICE_JOURNEY",
       "heading": "Check to see if the activity is suitable for self-service marine licensing",
       "text": "Based on the information provided the selected activity is a licensable activity and as such may require a marine licence.<p><p>You are advised to select an appropriate option and continue your check.",
@@ -869,37 +887,37 @@
     {
       "id": "WO_DEPOSIT_EXEMPTION_JOURNEY",
       "heading": "Check to see if an exemption applies or notify the MMO about an exempt activity",
-          "text": "Based on the information provided the selected activity is a licensable activity and as such may require a marine licence.<p><p>You are advised to select an appropriate option and continue your check.",
+      "text": "Based on the information provided the selected activity is a licensable activity and as such may require a marine licence.<p><p>You are advised to select an appropriate option and continue your check.",
       "nextQuestionRoute": "/exemption/deposit/activity-type"
     },
     {
       "id": "WO_DEPOSIT_SELF_SERVICE_JOURNEY",
       "heading": "Check to see if the activity is suitable for self-service marine licensing",
-          "text": "Based on the information provided the selected activity is a licensable activity and as such may require a marine licence.<p><p>You are advised to select an appropriate option and continue your check.",
+      "text": "Based on the information provided the selected activity is a licensable activity and as such may require a marine licence.<p><p>You are advised to select an appropriate option and continue your check.",
       "nextQuestionRoute": "/deposit/activity"
     },
     {
       "id": "WO_REMOVAL_EXEMPTION_JOURNEY",
       "heading": "Check to see if an exemption applies or notify the MMO about an exempt activity",
-          "text": "Based on the information provided the selected activity is a licensable activity and as such may require a marine licence.<p><p>You are advised to select an appropriate option and continue your check.",
+      "text": "Based on the information provided the selected activity is a licensable activity and as such may require a marine licence.<p><p>You are advised to select an appropriate option and continue your check.",
       "nextQuestionRoute": "/exemption/removal/activity-type"
     },
     {
       "id": "WO_REMOVAL_SELF_SERVICE_JOURNEY",
       "heading": "Check to see if the activity is suitable for self-service marine licensing",
-          "text": "Based on the information provided the selected activity is a licensable activity and as such may require a marine licence.<p><p>You are advised to select an appropriate option and continue your check.",
+      "text": "Based on the information provided the selected activity is a licensable activity and as such may require a marine licence.<p><p>You are advised to select an appropriate option and continue your check.",
       "nextQuestionRoute": "/removal/activity"
     },
     {
       "id": "WO_DREDGING_EXEMPTION_JOURNEY",
       "heading": "Check to see if an exemption applies or notify the MMO about an exempt activity",
-          "text": "Based on the information provided the selected activity is a licensable activity and as such may require a marine licence.<p><p>You are advised to select an appropriate option and continue your check.",
+      "text": "Based on the information provided the selected activity is a licensable activity and as such may require a marine licence.<p><p>You are advised to select an appropriate option and continue your check.",
       "nextQuestionRoute": "/exemption/dredging"
     },
     {
       "id": "WO_DREDGING_SELF_SERVICE_JOURNEY",
       "heading": "Check to see if the activity is suitable for self-service marine licensing",
-          "text": "Based on the information provided the selected activity is a licensable activity and as such may require a marine licence.<p><p>You are advised to select an appropriate option and continue your check.",
+      "text": "Based on the information provided the selected activity is a licensable activity and as such may require a marine licence.<p><p>You are advised to select an appropriate option and continue your check.",
       "nextQuestionRoute": "/dredging/activity"
     }
   ],
@@ -999,7 +1017,9 @@
     {
       "route": "/standard-marine-licence-application/construction",
       "heading": "Construction",
-      "outcomeTypes": ["WO_STANDARD_TRACK_MLA"]
+      "outcomeTypes": [
+        "WO_STANDARD_TRACK_MLA"
+      ]
     },
     {
       "route": "/standard-marine-licence-application/deposit",
@@ -1011,12 +1031,16 @@
     {
       "route": "/standard-marine-licence-application/removal",
       "heading": "Removal",
-      "outcomeTypes": ["WO_STANDARD_TRACK_MLA"]
+      "outcomeTypes": [
+        "WO_STANDARD_TRACK_MLA"
+      ]
     },
     {
       "route": "/standard-marine-licence-application/dredging",
       "heading": "Dredging",
-      "outcomeTypes": ["WO_STANDARD_TRACK_MLA"]
+      "outcomeTypes": [
+        "WO_STANDARD_TRACK_MLA"
+      ]
     },
     {
       "route": "/standard-marine-licence-application/incineration",
@@ -1151,7 +1175,7 @@
         "WO_EXE_NOT_LICENSABLE_DEPOSIT_METHOD"
       ]
     },
-     {
+    {
       "route": "/exemption/licence-not-required/sea",
       "heading": "Marine licence not required",
       "outcomeTypes": [
@@ -1214,14 +1238,13 @@
         "WO_EXE_NOT_LICENSABLE_INCINERATION_METHOD_ELSEWHERE"
       ]
     },
-   {
+    {
       "route": "/exemption/licence-not-required/scuttling-method-elsewhere",
       "heading": "Marine licence not required",
       "outcomeTypes": [
         "WO_EXE_NOT_LICENSABLE_SCUTTLING_METHOD_ELSEWHERE"
       ]
     },
-
     {
       "route": "/exemption/licence-not-required-cables",
       "heading": "Exempt activity",
@@ -1229,7 +1252,7 @@
         "WO_EXE_NOT_LICENSABLE_CABLES"
       ]
     },
-     {
+    {
       "route": "/exemption/licence-not-required-cables/maintenance",
       "heading": "Exempt activity",
       "outcomeTypes": [
@@ -1243,7 +1266,7 @@
         "WO_EXE_NOT_LICENSABLE_PART_CABLES"
       ]
     },
-     {
+    {
       "route": "/exemption/licence-not-required-cables/maintenance/both",
       "heading": "Exempt activity",
       "outcomeTypes": [
@@ -1294,7 +1317,7 @@
     },
     {
       "route": "/exemption/licence-not-required-exemption-available-article-13",
-      "heading": "Exempt activity - Notification required",
+      "heading": "You need to provide more information, but you do not need a marine licence",
       "outcomeTypes": [
         "WO_EXE_AVAILABLE_ARTICLE_13"
       ]
@@ -1322,21 +1345,21 @@
     },
     {
       "route": "/exemption/licence-not-required-exemption-available-article-17",
-      "heading": "Exempt activity - Notification required",
+      "heading": "You need to provide more information, but you do not need a marine licence",
       "outcomeTypes": [
         "WO_EXE_AVAILABLE_ARTICLE_17"
       ]
     },
     {
       "route": "/exemption/licence-not-required-exemption-available-article-17A",
-      "heading": "Exempt activity - Notification required",
+      "heading": "You need to provide more information, but you do not need a marine licence",
       "outcomeTypes": [
         "WO_EXE_AVAILABLE_ARTICLE_17A"
       ]
     },
     {
       "route": "/exemption/licence-not-required-exemption-available-article-17B",
-      "heading": "Exempt activity - Notification required",
+      "heading": "You need to provide more information, but you do not need a marine licence",
       "outcomeTypes": [
         "WO_EXE_AVAILABLE_ARTICLE_17B"
       ]
@@ -1350,7 +1373,7 @@
     },
     {
       "route": "/exemption/licence-not-required-exemption-available-article-18A",
-      "heading": "Exempt activity - Notification required",
+      "heading": "You need to provide more information, but you do not need a marine licence",
       "outcomeTypes": [
         "WO_EXE_AVAILABLE_ARTICLE_18A"
       ]
@@ -1364,14 +1387,14 @@
     },
     {
       "route": "/exemption/licence-not-required-exemption-available-article-20",
-      "heading": "Exempt activity - Notification required",
+      "heading": "You need to provide more information, but you do not need a marine licence",
       "outcomeTypes": [
         "WO_EXE_AVAILABLE_ARTICLE_20"
       ]
     },
     {
       "route": "/exemption/licence-not-required-exemption-available-article-21",
-      "heading": "Exempt activity - Notification required",
+      "heading": "You need to provide more information, but you do not need a marine licence",
       "outcomeTypes": [
         "WO_EXE_AVAILABLE_ARTICLE_21"
       ]
@@ -1427,14 +1450,14 @@
     },
     {
       "route": "/exemption/licence-not-required-exemption-available-article-25-notification",
-      "heading": "Exempt activity - Notification required",
+      "heading": "You need to provide more information, but you do not need a marine licence",
       "outcomeTypes": [
         "WO_EXE_AVAILABLE_ARTICLE_25_NOTIFICATION"
       ]
     },
     {
       "route": "/exemption/licence-not-required-exemption-available-article-25A",
-      "heading": "Exempt activity - Notification required",
+      "heading": "You need to provide more information, but you do not need a marine licence",
       "outcomeTypes": [
         "WO_EXE_AVAILABLE_ARTICLE_25A"
       ]
@@ -1455,7 +1478,7 @@
     },
     {
       "route": "/exemption/licence-not-required-exemption-available-article-26a",
-      "heading": "Exempt activity - Notification required",
+      "heading": "You need to provide more information, but you do not need a marine licence",
       "outcomeTypes": [
         "WO_EXE_AVAILABLE_ARTICLE_26A"
       ]
@@ -1525,14 +1548,14 @@
     },
     {
       "route": "/exemption/licence-not-required-exemption-available-article-34",
-      "heading": "Exempt activity - Notification required",
+      "heading": "You need to provide more information, but you do not need a marine licence",
       "outcomeTypes": [
         "WO_EXE_AVAILABLE_ARTICLE_34"
       ]
     },
     {
       "route": "/exemption/licence-not-required-exemption-available-article-35",
-      "heading": "Exempt activity",
+      "heading": "You need to provide more information, but you do not need a marine licence",
       "outcomeTypes": [
         "WO_EXE_AVAILABLE_ARTICLE_35"
       ]
@@ -1558,7 +1581,7 @@
         "WO_EXE_AVAILABLE_SECTION_75"
       ]
     },
-        {
+    {
       "route": "/exemption/licence-not-required-exemption-available-Section-75-disposal",
       "heading": "Exempt activity - Approval required",
       "outcomeTypes": [
@@ -1683,57 +1706,52 @@
       "route": "/sea",
       "text": "Where will the activity take place?",
       "section": "doINeedAMarineLicence",
-      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/marine-licensing-definitions#mean-high-water-springs\"> mean high water springs (MHWS)</a>, the <a target=\"_blank\" href=\"https://www.gov.uk/guidance/marine-licensing-definitions#normal-tidal-limit\"> normal tidal limit (NTL) </a>, or the MMO’s <a target=\"_blank\" href=\"https://www.gov.uk/guidance/marine-licensing-definitions#jurisdiction\">jurisdiction</a>.",
+      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/marine-licensing-definitions\"> mean high water springs (opens in new tab)</a>.",
       "answers": [
         {
           "id": "inSea",
-          "text": "In the 'Sea'",
+          "text": "In or over the sea",
           "nextQuestionRoute": "/jurisdiction",
-          "hint": "'Sea' includes any area which is <u>submerged</u> at MHWS and the waters of every <u>estuary, river or channel</u> where the tide flows at MHWS tide up to the NTL. Even waters in areas which are closed permanently or intermittently by a lock or other artificial means against the regular action of the tide are included, where seawater flows into or out from the area, either continuously or from time to time."
-        },
-        {
-          "id": "overSea",
-          "text": "Over the 'Sea'",
-          "nextQuestionRoute": "/jurisdiction",
-          "hint": "'Over' the 'Sea' includes a location directly above or overhanging the 'Sea' such as a bridge, open piled structure or cantilever."
+          "hint": "The sea includes any area submerged at mean high water springs"
         },
         {
           "id": "onOrUnderSea",
-          "text": "On or under the 'Seabed'",
-          "nextQuestionRoute": "/jurisdiction",
-          "hint": "'Seabed' means the ground under the 'Sea' and anything resting on it such as a wreck. It includes the intertidal area of the sea or any river at such time as it is exposed temporarily at low tide."
+          "text": "On or under the seabed",
+          "nextQuestionRoute": "/jurisdiction"
+        },
+        {
+          "id": "inRiver",
+          "text": "In a river, estuary, or channel up to the normal tidal limit at mean high water spring tide",
+          "nextQuestionRoute": "/jurisdiction"
+        },
+        {
+          "id": "inClosedArea",
+          "text": "Waters in a closed area, such as a dock, where seawater can flow in or out",
+          "nextQuestionRoute": "/jurisdiction"
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Somewhere else",
           "outcomeRoute": "/exemption/licence-not-required/sea",
-          "hint": "In an area <u>other</u> than those defined above. For example the part of beach <u>above MHWS</u>, the upper extent of a river <u>beyond the NTL</u> and or a land locked body of water such as a lake."
+          "hint": "For example, the part of beach above mean high water springs, or a land locked body of water, such as a lake"
         }
       ]
     },
     {
       "route": "/jurisdiction",
-      "text": "In which waters will the activity take place?",
-      "hint": "See an illustration of these 'waters' or find out more about the MMO’s <a target=\"_blank\" href=\"https://www.gov.uk/guidance/marine-licensing-definitions#jurisdiction\">jurisdiction</a>.",
+      "text": "Which waters will the activity take place in?",
       "section": "doINeedAMarineLicence",
+      "hint": "<p>The Marine Management Organisation (MMO) manages marine licensing in English and Northern Ireland offshore waters. It also licenses certain activities in other parts of the world. <p><p>Find out more about the <a target=\"_blank\" href=\"https://www.gov.uk/guidance/marine-licensing-definitions\">MMO's jurisdiction (opens in new tab)</a>.<p><p><p>",
       "answers": [
         {
           "id": "englishWaters",
-          "text": "In English waters",
-          "nextQuestionRoute": "/activity-type",
-          "hint": "'English waters' is the area of 'Sea' within the limits of territorial waters (12 nautical miles) adjacent to the English coastline (the 'inshore' area). This also includes any area of sea beyond the territorial limit (the 'offshore' area), that is within the exclusive economic zone (EEZ) and the UK sector of the continental shelf (up to 200 nautical miles). This excludes the waters of any devolved administration."
-        },
-        {
-          "id": "northernIrishOffshoreWaters",
-          "text": "In Northern Ireland offshore waters",
-          "nextQuestionRoute": "/activity-type",
-          "hint": "'Northern Ireland offshore waters' is the area of 'Sea', adjacent to Northern Ireland beyond the territorial limit, providing it includes the EEZ and the UK sector of the continental shelf (excluding the waters of any other administration)."
+          "text": "English waters or Northern Ireland offshore waters",
+          "nextQuestionRoute": "/activity-type"
         },
         {
           "id": "otherUkWaters",
-          "text": "In other UK waters",
-          "outcomeRoute": "/licence-not-required-devolved",
-          "hint": "'Other UK waters'means the waters of the devolved administrations of Wales, Scotland or Northern Ireland (excluding Northern Ireland offshore waters)."
+          "text": "Other UK waters – Wales, Scotland or Northern Ireland (excluding Northern Ireland offshore waters)",
+          "outcomeRoute": "/licence-not-required-devolved"
         },
         {
           "id": "elsewhere",
@@ -1790,7 +1808,7 @@
           "id": "britishAircraft",
           "text": "From a British aircraft",
           "outcomeRoute": "/exemption/licence-required-no-exemption-no-self-service",
-          "hint": "British aircraft” means an aircraft registered in the United Kingdom"
+          "hint": "British aircraft\u201d means an aircraft registered in the United Kingdom"
         },
         {
           "id": "floatingContainer",
@@ -1857,7 +1875,7 @@
         }
       ]
     },
-       {
+    {
       "route": "/elsewhere-in-the-world/incineration/where-loaded",
       "text": "Where will the substance or object to be incinerated be loaded? ",
       "section": "elsewhereIncineration",
@@ -1895,7 +1913,7 @@
           "id": "britishAircraft",
           "text": "From a British aircraft",
           "outcomeRoute": "/exemption/licence-required-no-exemption-no-self-service",
-          "hint": "British aircraft” means an aircraft registered in the United Kingdom"
+          "hint": "British aircraft\u201d means an aircraft registered in the United Kingdom"
         },
         {
           "id": "britishMarineStructure",
@@ -1937,50 +1955,45 @@
       "route": "/activity-type",
       "mcmsAppFormMapping": "ACTIVITY_TYPE",
       "text": "What type of activity will be carried out?",
-      "hint": "HINT: Try to think about what you intend to do at a basic level. For example if you plan to take sediment samples for testing or analysis, the type of activity that will take place is a removal activity. If the activity involves the building of something new, or the maintenance, alteration or improvement of something that already exists, then the activity that will take place is a construction activity.<p> </br> Doing more than one thing? If your project involves multiple activities make sure you check each separately starting with the main or most significant activity.",
+      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/do-i-need-a-marine-licence#activities-that-may-need-a-marine-licence\">activities that may need a marine licence (opens in new tab)</a>.",
       "section": "doINeedAMarineLicence",
       "answers": [
         {
           "id": "CON",
           "text": "Construction",
-          "outcomeRoute": "/construction/journey-select",
-          "hint": "Including maintenance, alteration and improvement of works and the laying of cables or pipelines.<br/>Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/construction-alteration-or-improvement-of-works\">construction, maintenance, alteration and improvement</a>"
+          "nextQuestionRoute": "/exemption/construction",
+          "hint": "Including building or making something, maintenance, alteration, and improvement activities</a>"
         },
         {
           "id": "DEPOSIT",
           "text": "Deposit of a substance or object",
-          "nextQuestionRoute": "/deposit/method",
-          "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/deposits#deposit-of-any-substance-or-object\">deposits</a>"
+          "nextQuestionRoute": "/deposit/method"
         },
         {
           "id": "REMOVAL",
           "text": "Removal of a substance or object",
-          "nextQuestionRoute": "/removal/method",
-          "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/removal-of-any-substance-or-object\">removals</a>"
+          "nextQuestionRoute": "/removal/method"
         },
         {
           "id": "DREDGE",
           "text": "Dredging",
-          "outcomeRoute": "/dredging/journey-select",
-          "hint": "Please note: The <u>disposal</u> of dredged material is a different activity to <u>dredging</u>. Disposal activities can be checked by choosing 'Deposit of a substance or object' but in most cases deposit or disposal of dredged material to sea will require a marine licence.<br/>Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/dredging\">dredging</a>"
+          "nextQuestionRoute": "/exemption/dredging",
+          "hint": "The process of removing material from the seabed for navigation, water quality, flood control, or construction"
         },
         {
           "id": "INCINERATION",
           "text": "Incineration of a substance or object",
-          "nextQuestionRoute": "/incineration/method",
-          "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/incineration-of-any-substance-or-object\">incineration</a>"
+          "nextQuestionRoute": "/incineration/method"
         },
         {
           "id": "EXPLOSIVES",
           "text": "Use of an explosive substance",
-          "outcomeRoute": "/exemption/licence-required-no-exemption",
-          "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/deposits#deposit-or-use-of-explosives\">explosives</a>"
+          "outcomeRoute": "/exemption/licence-required-no-exemption"
         },
         {
           "id": "SCUTTLING",
-          "text": "Sinking of a vessel or floating container",
-          "outcomeRoute": "/exemption/licence-required-no-exemption",
-          "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/scuttling-of-any-floating-vessel-or-container\">scuttling</a>"
+          "text": "Sinking of a vessel or floating container (also known as scuttling)",
+          "outcomeRoute": "/exemption/licence-required-no-exemption"
         }
       ]
     },
@@ -1992,33 +2005,33 @@
         {
           "id": "vehicleOrVessel",
           "text": "From a vehicle or vessel",
-          "outcomeRoute": "/deposit/journey-select",
-          "hint": "'vessel' includes hovercraft and any other craft capable of travelling on, in or under water, whether or not self-propelled."
+          "nextQuestionRoute": "/exemption/deposit/activity-type",
+          "hint": "Includes hovercrafts or any other craft capable of travelling on, in or under water"
         },
         {
           "id": "aircraft",
           "text": "From an aircraft",
-          "outcomeRoute": "/deposit/journey-select"
+          "nextQuestionRoute": "/exemption/deposit/activity-type"
         },
         {
           "id": "marineStructure",
           "text": "From a marine structure",
-          "outcomeRoute": "/deposit/journey-select",
-          "hint": "'marine structure' means a platform or other artificial structure at 'Sea', other than a pipeline."
+          "nextQuestionRoute": "/exemption/deposit/activity-type",
+          "hint": "Includes a platform or any other artificial structure at sea, other than a pipeline"
         },
         {
           "id": "floatingContainer",
-          "text": "From a floating container in the 'Sea'",
-          "outcomeRoute": "/deposit/journey-select"
+          "text": "From a floating container in the sea",
+          "nextQuestionRoute": "/exemption/deposit/activity-type"
         },
         {
           "id": "landStructure",
-          "text": "From a structure on land constructed or adapted wholly or mainly for the purposes of depositing solids in the 'Sea'",
-          "outcomeRoute": "/deposit/journey-select"
+          "text": "From a structure on land built or adapted for depositing solids in the sea",
+          "nextQuestionRoute": "/exemption/deposit/activity-type"
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/licence-not-required/deposit-method"
         }
       ]
@@ -2032,7 +2045,7 @@
           "id": "vehicleOrVessel",
           "text": "Using a vehicle or vessel",
           "nextQuestionRoute": "/removal",
-          "hint": "Includes using a winch or other device on the vehicle or vessel. </br>'Vessel' includes hovercraft and any other craft capable of travelling on, in or under water, whether or not self-propelled."
+          "hint": "Includes hovercrafts or any other craft capable of travelling on, in or under water"
         },
         {
           "id": "aircraft",
@@ -2043,36 +2056,34 @@
           "id": "marineStructure",
           "text": "Using a marine structure",
           "nextQuestionRoute": "/removal",
-          "hint": "'marine structure' means a platform or other artificial structure at 'Sea', other than a pipeline."
+          "hint": "Includes a platform or any other artificial structure at sea, other than a pipeline"
         },
         {
           "id": "floatingContainer",
-          "text": "Using a floating container in the 'Sea'",
-          "hint": "'Floating container' includes an 'airbag' or 'lifting bag'",
+          "text": "Using a floating container in the sea",
           "nextQuestionRoute": "/removal"
         },
         {
           "id": "landStructure",
-          "text": "Using a structure on land constructed or adapted wholly or mainly for the purposes of depositing solids in the 'Sea'",
+          "text": "Using a structure on land built or adapted for removing solids from the sea",
           "nextQuestionRoute": "/removal"
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/licence-not-required/removal-method"
         }
       ]
     },
     {
       "route": "/removal",
-      "text": "Will the substance or object to be removed, be removed from the 'Seabed'?",
+      "text": "Will the substance or object be removed from the seabed?",
       "section": "doINeedAMarineLicenceRemoval",
-      "hint": "'Seabed' means the ground under the 'Sea' and anything resting on it such as a wreck. It includes the intertidal area of the sea or any river at such time as it is exposed temporarily at low tide.<p><p>'Sea' includes any area which is submerged at MHWS and the waters of every estuary, river or channel where the tide flows at MHWS tide up to the NTL. Even waters in areas which are closed permanently or intermittently by a lock or other artificial means against the regular action of the tide are included, where seawater flows into or out from the area, either continuously or from time to time.<p><p>Find out more about the MMO’s <a target=\"_blank\" href=\"https://www.gov.uk/guidance/marine-licensing-definitions#what-do-we-mean-by-the-sea\">jurisdiction</a>.",
       "answers": [
         {
           "id": "yes",
           "text": "Yes",
-          "outcomeRoute": "/removal/journey-select"
+          "nextQuestionRoute": "/exemption/removal/activity-type"
         },
         {
           "id": "no",
@@ -2203,7 +2214,7 @@
           "id": "OTHER",
           "text": "Other",
           "outcomeRoute": "/standard-marine-licence-application/other-activity",
-           "hint": "An activity type not listed above"
+          "hint": "An activity type not listed above"
         }
       ]
     },
@@ -2441,8 +2452,9 @@
     {
       "route": "/burial-at-sea/site/needles",
       "text": "Has all relevant documentation relating to the deceased been obtained?",
-      "hint": "'Relevant documentation' means: <p><br/></li><li>a death certificate<br/></li><li>a Certificate of Freedom from Fever and Infection (available from the deceased person’s GP or hospital doctor)<br/> </li><li>a Notice to a Coroner of Intention to Remove a Body out of England (available from the coroner in exchange for a Certificate of Disposal provided by the registrar)<br/> </li><li>a signed DNA sample consent form (required for The Needles site only).<p><p>Additional information about relevant documentation can be found at <a target=\"_blank\" href=\"https://www.gov.uk/guidance/how-to-get-a-licence-for-a-burial-at-sea-in-england\"> GOV.UK</a>.<p>",
-      "answers": [        {
+      "hint": "'Relevant documentation' means: <p><br/></li><li>a death certificate<br/></li><li>a Certificate of Freedom from Fever and Infection (available from the deceased person\u2019s GP or hospital doctor)<br/> </li><li>a Notice to a Coroner of Intention to Remove a Body out of England (available from the coroner in exchange for a Certificate of Disposal provided by the registrar)<br/> </li><li>a signed DNA sample consent form (required for The Needles site only).<p><p>Additional information about relevant documentation can be found at <a target=\"_blank\" href=\"https://www.gov.uk/guidance/how-to-get-a-licence-for-a-burial-at-sea-in-england\"> GOV.UK</a>.<p>",
+      "answers": [
+        {
           "id": "YES",
           "text": "Yes",
           "outcomeRoute": "/fast-track-mla"
@@ -2457,7 +2469,7 @@
     {
       "route": "/burial-at-sea/site/tynemouth",
       "text": "Has all relevant documentation relating to the deceased been obtained?",
-      "hint": "'Relevant documentation' means: <p><br/></li><li>a death certificate<br/></li><li>a Certificate of Freedom from Fever and Infection (available from the deceased person’s GP or hospital doctor)<br/> </li><li>a Notice to a Coroner of Intention to Remove a Body out of England (available from the coroner in exchange for a Certificate of Disposal provided by the registrar)<p><p>Additional information about relevant documentation can be found at <a target=\"_blank\" href=\"https://www.gov.uk/guidance/how-to-get-a-licence-for-a-burial-at-sea-in-england\"> GOV.UK</a>.<p>",
+      "hint": "'Relevant documentation' means: <p><br/></li><li>a death certificate<br/></li><li>a Certificate of Freedom from Fever and Infection (available from the deceased person\u2019s GP or hospital doctor)<br/> </li><li>a Notice to a Coroner of Intention to Remove a Body out of England (available from the coroner in exchange for a Certificate of Disposal provided by the registrar)<p><p>Additional information about relevant documentation can be found at <a target=\"_blank\" href=\"https://www.gov.uk/guidance/how-to-get-a-licence-for-a-burial-at-sea-in-england\"> GOV.UK</a>.<p>",
       "answers": [
         {
           "id": "YES",
@@ -2474,7 +2486,7 @@
     {
       "route": "/burial-at-sea/site/between-hastings-and-newhaven",
       "text": "Has all relevant documentation relating to the deceased been obtained?",
-      "hint": "'Relevant documentation' means: <p><br/></li><li>a death certificate<br/></li><li>a Certificate of Freedom from Fever and Infection (available from the deceased person’s GP or hospital doctor)<br/> </li><li>a Notice to a Coroner of Intention to Remove a Body out of England (available from the coroner in exchange for a Certificate of Disposal provided by the registrar)<p><p>Additional information about relevant documentation can be found at <a target=\"_blank\" href=\"https://www.gov.uk/guidance/how-to-get-a-licence-for-a-burial-at-sea-in-england\"> GOV.UK</a>.<p>",
+      "hint": "'Relevant documentation' means: <p><br/></li><li>a death certificate<br/></li><li>a Certificate of Freedom from Fever and Infection (available from the deceased person\u2019s GP or hospital doctor)<br/> </li><li>a Notice to a Coroner of Intention to Remove a Body out of England (available from the coroner in exchange for a Certificate of Disposal provided by the registrar)<p><p>Additional information about relevant documentation can be found at <a target=\"_blank\" href=\"https://www.gov.uk/guidance/how-to-get-a-licence-for-a-burial-at-sea-in-england\"> GOV.UK</a>.<p>",
       "answers": [
         {
           "id": "YES",
@@ -2918,7 +2930,7 @@
     {
       "route": "/protected-place",
       "text": "Will the activity take place within a 'protected place' or 'controlled site' under the Protection of Military Remains Act (1986)?",
-     "hint": "<p>Activities within sites protected under the Protection of Military Remains Act 1986 are not suitable for self-service marine licensing in any circumstances. All crashed military aircraft are automatically 'protected remains' and sunken military vessels are designated as 'protected places' even where their location is not presently known. <p>The <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\">MMO self-service GIS tool</a> only records known sites and is therefore not exhaustive. <p>Applicants will need to satisfy themselves that they meet the criteria based on their specific circumstances and through their own enquiries where appropriate.",
+      "hint": "<p>Activities within sites protected under the Protection of Military Remains Act 1986 are not suitable for self-service marine licensing in any circumstances. All crashed military aircraft are automatically 'protected remains' and sunken military vessels are designated as 'protected places' even where their location is not presently known. <p>The <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\">MMO self-service GIS tool</a> only records known sites and is therefore not exhaustive. <p>Applicants will need to satisfy themselves that they meet the criteria based on their specific circumstances and through their own enquiries where appropriate.",
       "section": "protectionOfHeritage",
       "answers": [
         {
@@ -2954,7 +2966,7 @@
     {
       "route": "/archaeological-heritage-historic-assets",
       "text": "Does the activity involve the removal of items of archaeological or historic interest or any other activity, the purpose of which is to establish the presence or nature of such items?",
-       "hint": "<p>Activities carried out for the purposes set out will require a valid consent or an agreed method statement from Historic England (or relevant local authority in respect of listed buildings) in order to be considered suitable for self-service marine licensing.<p><p>'Archaeological or historic interest' includes all traces of human existence having a cultural, historical or archaeological character such as:<ol type=\"i\"><li>sites, structures, buildings, artefacts and human remains, together with their archaeological and natural context;</li><li>vessels, aircraft, other vehicles or any part thereof, their cargo or other contents, together with their archaeological and natural context; and</li><li>objects of prehistoric character.</li></ol></p>",
+      "hint": "<p>Activities carried out for the purposes set out will require a valid consent or an agreed method statement from Historic England (or relevant local authority in respect of listed buildings) in order to be considered suitable for self-service marine licensing.<p><p>'Archaeological or historic interest' includes all traces of human existence having a cultural, historical or archaeological character such as:<ol type=\"i\"><li>sites, structures, buildings, artefacts and human remains, together with their archaeological and natural context;</li><li>vessels, aircraft, other vehicles or any part thereof, their cargo or other contents, together with their archaeological and natural context; and</li><li>objects of prehistoric character.</li></ol></p>",
       "section": "archaeologicalHeritageHistoricAssets",
       "answers": [
         {
@@ -3005,9 +3017,9 @@
         }
       ]
     },
-{
+    {
       "route": "/HPMA-Check",
-"text": "Is the area in which you intend to carry out your activity a Highly Protected Marine Area (HPMA)?",
+      "text": "Is the area in which you intend to carry out your activity a Highly Protected Marine Area (HPMA)?",
       "hint": "<p>A HPMA is an area of the sea that has been given the highest level of protection in which almost all licensable activities will be unsuitable for self-service licensing. In limited circumstances it may be possible to agree a methodology with Natural England to undertake the activity.</p><p>You can find out more about HPMAs on <a target=\"_blank\" href=\"https://www.gov.uk/government/collections/highly-protected-marine-areas\">GOV.UK</a>.",
       "section": "marineProtectedArea200",
       "answers": [
@@ -3023,7 +3035,7 @@
         }
       ]
     },
-{
+    {
       "route": "/fast-track-activity-limits",
       "text": "Are the proposed activities limited to any or all of the following?",
       "hint": "<p><ul><li>Deposit of marker buoys</li><li>Removal of marine growth from structures or assets</li><li>Repainting of structures or assets</li><li>Deposit of scaffolding or access towers</li></ul></p>",
@@ -3062,7 +3074,7 @@
     {
       "route": "/natural-england",
       "text": "Has a method been agreed with Natural England?",
-      "hint": "<p>You must have agreed a method statement with Natural England before proceeding to apply for a self-service licence. </p><p>You <u><b>will</b></u> be required to upload the agreed method statement when you apply for a self-service licence.</p>",      
+      "hint": "<p>You must have agreed a method statement with Natural England before proceeding to apply for a self-service licence. </p><p>You <u><b>will</b></u> be required to upload the agreed method statement when you apply for a self-service licence.</p>",
       "section": "naturalEngland",
       "mcmsAppFormMapping": "NATURAL_ENGLAND",
       "answers": [
@@ -3080,27 +3092,25 @@
     },
     {
       "route": "/exemption/construction",
-      "text": "What is the purpose of your construction activity?",
+      "text": "What is the purpose of the construction activity?",
       "section": "construction",
       "mcmsAppFormMapping": "EXE_ACTIVITY_SUBTYPE_CONSTRUCTION",
       "answers": [
         {
-          "id": "maintenance",
-          "text": "Maintenance of existing structures and assets",
-          "nextQuestionRoute": "/exemption/construction/maintenance",
-          "hint": "'Maintenance' means the upkeep or repair of an existing structure or asset wholly <u>within</U> its existing 3 dimensional boundaries"
+          "id": "new",
+          "text": "Build or make something new",
+          "nextQuestionRoute": "/exemption/construction/new"
         },
         {
-          "id": "new",
-          "text": "Construction of something new",
-          "hint": "Includes activities undertaken primarily for maintenance purposes where an element of the works extend beyond the existing boundaries of the structure of asset being maintained.", 
-          "nextQuestionRoute": "/exemption/construction/new"
+          "id": "maintenance",
+          "text": "Maintenance of existing structures and assets",
+          "nextQuestionRoute": "/exemption/construction/maintenance"
         }
       ]
     },
     {
       "route": "/exemption/construction/maintenance",
-      "text": "What does the maintenance activity relate to?",
+      "text": "What is the maintenance activity for?",
       "section": "constructionMaintenance",
       "answers": [
         {
@@ -3111,7 +3121,7 @@
         {
           "id": "pontoons",
           "text": "Pontoons",
-          "nextQuestionRoute": "/exemption/construction/maintenance/pontoons"
+          "nextQuestionRoute": "/exemption/construction/maintenance/pontoons/undertaker"
         },
         {
           "id": "coastalProtectionDrainageOrFloodDefence",
@@ -3121,8 +3131,7 @@
         {
           "id": "harbourWorks",
           "text": "Harbour works",
-          "nextQuestionRoute": "/exemption/construction/maintenance/harbour-works",
-          "hint": "Maintenance carried out by or on behalf of harbour authorities only."
+          "nextQuestionRoute": "/exemption/construction/maintenance/harbour-works"
         },
         {
           "id": "cables",
@@ -3136,7 +3145,7 @@
         },
         {
           "id": "carbonStorage",
-          "text": "Carbon Dioxide Storage",
+          "text": "Carbon dioxide storage",
           "nextQuestionRoute": "/exemption/construction/maintenance/carbon-storage"
         },
         {
@@ -3146,35 +3155,34 @@
         },
         {
           "id": "other",
-          "text": "Other",
-          "outcomeRoute": "/exemption/construction-exe-not-available-continue",
-          "hint": "Maintenance for purposes not set out above"
+          "text": "Something else",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/construction/maintenance/moorings",
-      "text": "What is the purpose of the activity?",
+      "text": "What type of mooring will be maintained?",
       "section": "constructionMaintenance",
       "answers": [
         {
           "id": "pileMooring",
-          "text": "To provide a pile mooring",
+          "text": "Pile mooring",
           "nextQuestionRoute": "/exemption/construction/maintenance/moorings/undertaker"
         },
         {
           "id": "swingingMooring",
-          "text": "To provide a swinging mooring",
+          "text": "Swinging mooring",
           "nextQuestionRoute": "/exemption/construction/maintenance/moorings/undertaker"
         },
         {
           "id": "trotMooring",
-          "text": "To provide a trot mooring",
+          "text": "Trot mooring",
           "nextQuestionRoute": "/exemption/construction/maintenance/moorings/undertaker"
         },
         {
           "id": "aidToNavigation",
-          "text": "To provide a aid to navigation",
+          "text": "Aid to navigation",
           "nextQuestionRoute": "/exemption/construction/maintenance/moorings/undertaker"
         },
         {
@@ -3191,25 +3199,26 @@
       "answers": [
         {
           "id": "harbourAuthority",
-          "text": "A harbour authority or someone on behalf of a harbour authority",
+          "text": "A harbour authority or someone working for them",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-25"
         },
         {
           "id": "lighthouseAuthority",
-          "text": "A lighthouse authority or someone on behalf of a lighthouse authority",
+          "text": "A lighthouse authority or someone working for them",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-25"
         },
         {
           "id": "someoneElse",
           "text": "Someone else",
-          "nextQuestionRoute": "/exemption/construction/maintenance/moorings/undertaker/consent"
+          "nextQuestionRoute": "/exemption/construction/maintenance/moorings/undertaker/consent",
+          "hint": "This could be you or any organisation not listed"
         }
       ]
     },
     {
       "route": "/exemption/construction/maintenance/moorings/undertaker/consent",
-      "text": "does the activity require consent (e.g. a licence) from either a harbour authority or a lighthouse authority under their local legislation?",
-      "hint": "The permission or agreement of the authority does not constitute consent for these purposes.",
+      "text": "Do you need consent from a harbour authority or lighthouse authority under local legislation?",
+      "hint": "Permission or agreement is not the same as formal consent.",
       "section": "constructionMaintenance",
       "answers": [
         {
@@ -3226,7 +3235,7 @@
     },
     {
       "route": "/exemption/construction/maintenance/moorings/undertaker/approval",
-      "text": "Has consent been granted?",
+      "text": "Do you have consent?",
       "section": "constructionMaintenance",
       "answers": [
         {
@@ -3260,25 +3269,25 @@
     },
     {
       "route": "/exemption/construction/maintenance/pontoons/undertaker",
-      "text": "Who will carry out the activity?",
+      "text": "Will a harbour authority or someone working for them carry out the activity?",
       "section": "constructionMaintenance",
       "answers": [
         {
           "id": "harbourAuthority",
-          "text": "A harbour authority or someone on behalf of a harbour authority",
+          "text": "Yes",
           "nextQuestionRoute": "/exemption/construction/maintenance/pontoons/deck"
         },
         {
           "id": "someoneElse",
-          "text": "Someone else",
+          "text": "No",
           "nextQuestionRoute": "/exemption/construction/maintenance/pontoons/consent"
         }
       ]
     },
     {
       "route": "/exemption/construction/maintenance/pontoons/consent",
-      "text": "Does the activity require consent (e.g. a licence) from a harbour authority under local legislation?",
-      "hint": "The permission or agreement of the authority does not constitute consent for these purposes.",
+      "text": "Will the activity take place in a harbour authority area?",
+      "hint": "<p>To find out if the activity falls within a harbour authority area, you can use the <a href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c&showLayers=Navigation\" target=\"_blank\">marine licensing interactive map (opens in new tab)</a>.",
       "section": "constructionMaintenance",
       "answers": [
         {
@@ -3295,7 +3304,7 @@
     },
     {
       "route": "/exemption/construction/maintenance/pontoons/approval",
-      "text": "Has consent been granted?",
+      "text": "Do you have harbour authority consent to maintain a pontoon?",
       "section": "constructionMaintenance",
       "answers": [
         {
@@ -3312,8 +3321,8 @@
     },
     {
       "route": "/exemption/construction/maintenance/pontoons/deck",
-      "text": "When complete will the deck of the pontoon be an area greater than 30m2?",
-      "hint": "NOTE: If the pontoon will be attached to one or more pontoons already in place the question refers to the total deck area of all pontoons combined.",
+      "text": "Will the pontoon deck be larger than 30 square metres when finished?",
+      "hint": "If attached to existing pontoons, this includes their total deck area.\n\n\n",
       "section": "constructionMaintenance",
       "answers": [
         {
@@ -3330,9 +3339,9 @@
     },
     {
       "route": "/exemption/construction/maintenance/pontoons/quantity",
-      "text": "In the 6 months prior to the commencement of this activity will 10 or more pontoons have been constructed or deposited at the location?",
+      "text": "In the 6 months before the activity begins, will the harbour authority have built or approved more than 10 pontoons?\n",
       "section": "constructionMaintenance",
-      "hint": "either by or on behalf of the harbour authority or with the consent required from and granted by the harbour authority",
+      "hint": "Check with the appropriate harbour authority if you're unsure.",
       "answers": [
         {
           "id": "yes",
@@ -3348,7 +3357,7 @@
     },
     {
       "route": "/exemption/construction/maintenance/harbour-works",
-      "text": "Will the activity be carried out wholly within the existing 3 dimensional boundary of the works being maintained?",
+      "text": "Will all the maintenance take place within the structure's existing 3-dimensional boundary?",
       "section": "constructionMaintenance",
       "answers": [
         {
@@ -3365,17 +3374,17 @@
     },
     {
       "route": "/exemption/construction/maintenance/harbour-works/undertaker",
-      "text": "Who will carry out the activity?",
+      "text": "Will a harbour authority or someone working for them carry out the activity?",
       "section": "constructionMaintenance",
       "answers": [
         {
           "id": "harbourAuthority",
-          "text": "A harbour authority or someone on behalf of a harbour authority",
+          "text": "Yes",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-23"
         },
         {
           "id": "someoneElse",
-          "text": "Someone else",
+          "text": "No",
           "outcomeRoute": "/exemption/construction-exe-not-available-continue"
         }
       ]
@@ -3383,32 +3392,27 @@
     {
       "route": "/exemption/construction/maintenance/cables",
       "text": "What is the cable to be maintained used for?",
-      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities--2#cables-pipelines-oil-and-gas-and-carbon-capture-storage\"> cables </a>",
       "section": "constructionMaintenance",
       "answers": [
         {
           "id": "transferOfData",
           "text": "The transfer of data",
-          "nextQuestionRoute": "/exemption/construction/maintenance/cables/location",
-          "hint": "This type of cable transfers data from one place to another."
+          "nextQuestionRoute": "/exemption/construction/maintenance/cables/location"
         },
         {
           "id": "transfer of electricity",
           "text": "The transfer of electricity",
-          "nextQuestionRoute": "/exemption/construction/maintenance/cables/location",
-          "hint": "This type of cable allows the transfers of electricity from one place to another. This includes interconnector cables, which exchange electricity to and from continental Europe and beyond."
+          "nextQuestionRoute": "/exemption/construction/maintenance/cables/location"
         },
         {
           "id": "renewableEnergyExportCable",
-          "text": "Renewable energy export ",
-          "nextQuestionRoute": "/exemption/construction/maintenance/cables/inspection-repair",
-          "hint": "This type of cable exports electricity generated by an offshore wind farm or wave/tidal array to a substation on land."
+          "text": "Renewable energy export",
+          "nextQuestionRoute": "/exemption/construction/maintenance/cables/inspection-repair"
         },
         {
           "id": "other",
-          "text": "Other",
-          "nextQuestionRoute": "/exemption/construction/maintenance/cables/inspection-repair",
-          "hint": "Cables supplying offshore structures, cables utilised in exploration or exploitation of natural resources and or pollution control etc."
+          "text": "Something else",
+          "nextQuestionRoute": "/exemption/construction/maintenance/cables/inspection-repair"
         }
       ]
     },
@@ -3419,24 +3423,24 @@
       "answers": [
         {
           "id": "inside12NM",
-          "text": "Wholly inside 12NM",
+          "text": "Within 12 nautical miles of the UK",
           "nextQuestionRoute": "/exemption/construction/maintenance/cables/inspection-repair"
         },
         {
           "id": "outside12NM",
-          "text": "Wholly outside 12NM",
+          "text": "Beyond 12 nautical miles of the UK",
           "outcomeRoute": "/exemption/licence-not-required-cables/maintenance"
         },
         {
           "id": "bothInsideOutside12NM",
-          "text": "Part inside 12NM part outside 12NM",
+          "text": "Some within and some beyond 12 nautical miles of the UK",
           "outcomeRoute": "/exemption/licence-not-required-cables/maintenance/both"
         }
       ]
     },
     {
       "route": "/exemption/construction/maintenance/cables/inspection-repair",
-      "text": "Does the activity relate to the inspection or repair of an existing cable?",
+      "text": "Does the activity  involve the inspection or repair of an existing cable?",
       "section": "constructionMaintenance",
       "answers": [
         {
@@ -3453,7 +3457,7 @@
     },
     {
       "route": "/exemption/construction/maintenance/cables/emergency",
-      "text": "Are the circumstances serious, unexpected and potentially dangerous requiring immediate action?",
+      "text": "Is immediate action required because the situation is serious, unexpected or dangerous?",
       "section": "constructionMaintenance",
       "answers": [
         {
@@ -3470,8 +3474,8 @@
     },
     {
       "route": "/exemption/construction/maintenance/cables/protection",
-      "text": "Will the activity proposed include the deposit of rock or other materials for the purpose of providing <u>new</U> cable protection?",
-      "hint": "Deposits for these purposes, i.e. those beyond the replenishment or replacement of materials wholly within the three dimensional boundaries of those previously consented and deposited, will require a marine licence. If the maintenance, inspection or repair can be carried out without the need for new protection you are advised to adapt your proposed approach.<p><p>NOTE: If you intend to apply for a marine licence in respect of the addition of new or extended protection, where relevant, please select ‘No’ to continue.",
+      "text": "Does the activity involve depositing rock or other materials to provide new cable protection?",
+      "hint": "Only replacing material within the existing boundary is exempt. New or extended protection needs a marine licence.",
       "section": "constructionMaintenance",
       "answers": [
         {
@@ -3510,34 +3514,35 @@
       "answers": [
         {
           "id": "environmentAgency",
-          "text": "The Environment Agency or someone on behalf of the Environment Agency",
+          "text": "The Environment Agency or someone working for them",
           "nextQuestionRoute": "/exemption/construction/maintenance/coastal-drainage-flood/EA"
         },
         {
           "id": "coastProtectionAuthority",
-          "text": "The Coast Protection Authority or someone on behalf of the Coast Protection Authority",
+          "text": "The Coast Protection Authority or someone working for them",
           "nextQuestionRoute": "/exemption/construction/maintenance/coastal-drainage-flood/CPA"
         },
         {
           "id": "localAuthority",
-          "text": "The Local Authority or someone on behalf of the Local Authority",
+          "text": "The local authority or someone working for them",
           "nextQuestionRoute": "/exemption/construction/maintenance/coastal-drainage-flood/CPA"
         },
         {
           "id": "secretaryStateDefence",
-          "text": "The Secretary of State for Defence or someone on behalf of the Secretary of State for Defence",
+          "text": "The Secretary of State for Defence or someone working for them",
           "nextQuestionRoute": "/exemption/construction/maintenance/coastal-drainage-flood/CPA"
         },
         {
           "id": "other",
-          "text": "Other",
-          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
+          "text": "Someone else",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue",
+          "hint": "This could be you or any organisation not listed"
         }
       ]
     },
     {
       "route": "/exemption/construction/maintenance/coastal-drainage-flood/EA",
-      "text": "Will the activity be carried out wholly within the existing 3 dimensional boundary of the works being maintained?",
+      "text": "Will all the maintenance take place within the existing 3-dimensional boundary?",
       "section": "constructionMaintenance",
       "answers": [
         {
@@ -3555,7 +3560,7 @@
     {
       "route": "/exemption/construction/maintenance/coastal-drainage-flood/EA/beach-replenishment",
       "text": "Does the activity involve beach replenishment?",
-      "hint": "'Beach replenishment' means the addition of material from land-based, off-shore or other coastal sources not connected to the beach or its associated sediment system to replace material permanently lost from the system.",
+      "hint": "Beach replenishment means adding new material from outside sources on land, offshore or along the coast to replace material the beach has permanently lost.",
       "section": "constructionMaintenance",
       "answers": [
         {
@@ -3572,7 +3577,7 @@
     },
     {
       "route": "/exemption/construction/maintenance/coastal-drainage-flood/EA/emergency",
-      "text": "Are the circumstances serious, unexpected and potentially dangerous requiring immediate action in response to flood or imminent risk of flood?",
+      "text": "Is immediate action required due to flooding or an imminent risk of flooding?",
       "section": "construction",
       "answers": [
         {
@@ -3590,7 +3595,7 @@
     {
       "route": "/exemption/construction/maintenance/coastal-drainage-flood/CPA",
       "text": "Is the activity for the purpose of maintaining coast protection works?",
-      "hint": "'Coast protection works' include: </li><li><u>beach re-profiling</U>, which involves the movement of beach material in a cross-shore direction up or down the beach; and </li><li><u>beach recycling</u>, which involves the movement of beach material along the beach from areas of accretion to areas of erosion within the beach or associated sediment system.",
+      "hint": "Coast protection works include beach re-profiling, which involves moving material up or down the beach. They also include beach recycling, which involves moving material along the beach to manage erosion.",
       "section": "constructionMaintenance",
       "answers": [
         {
@@ -3607,7 +3612,7 @@
     },
     {
       "route": "/exemption/construction/maintenance/coastal-drainage-flood/CPA/boundaries",
-      "text": "Will the activity be carried out wholly within the existing 3 dimensional boundary of the works being maintained?",
+      "text": "Will all the maintenance take place within the existing 3-dimensional boundary?",
       "section": "constructionMaintenance",
       "answers": [
         {
@@ -3625,7 +3630,7 @@
     {
       "route": "/exemption/construction/maintenance/coastal-drainage-flood/CPA/beach-replenishment",
       "text": "Does the activity involve beach replenishment?",
-            "hint": "'Beach replenishment' means the addition of material from land-based, off-shore or other coastal sources not connected to the beach or its associated sediment system to replace material permanently lost from the system.",
+      "hint": "Beach replenishment means adding new material from outside sources on land, offshore or along the coast to replace material the beach has permanently lost.",
       "section": "constructionMaintenance",
       "answers": [
         {
@@ -3659,36 +3664,34 @@
     },
     {
       "route": "/exemption/construction/maintenance/pipeline/oil-and-gas/purpose",
-      "text": "What is the purpose of the activity?",
+      "text": "Which of these applies to the construction activity?",
       "section": "constructionMaintenance",
       "answers": [
         {
           "id": "section3PetroleumAct",
-          "text": "something done in the course of carrying on an activity for which a licence under section 3 of the Petroleum Act 1998 or section 2 of the Petroleum (Production) Act 1934 is required",
-          "outcomeRoute": "/exemption/licence-not-required-exemption-available-Section-77",
-          "hint": "Activities are to be regarded as activities for which a licence is required if, by virtue of such a licence, they are activities which may be carried out only with the consent of the Secretary of State or another person."
+          "text": "An  activity that needs a licence under the Petroleum Act 1998 or Petroleum (Production) Act 1934",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-Section-77"
         },
         {
           "id": "part3PetroleumAct",
-          "text": "something done for the purpose of constructing or maintaining a pipeline as respects any part of which an authorisation (within the meaning of Part 3 of the Petroleum Act 1998) is in force;",
+          "text": "Building or maintaining a pipeline that already has authorisation under Part 3 of the Petroleum Act 1998",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-Section-77"
         },
         {
           "id": "part4PetroleumAct",
-          "text": "something done for the purpose of establishing or maintaining an offshore installation (within the meaning of Part 4 of the Petroleum Act 1998;",
-          "outcomeRoute": "/exemption/licence-not-required-exemption-available-Section-77",
-          "hint": "Activities are to be regarded as activities for which a licence is required if, by virtue of such a licence, they are activities which may be carried out only with the consent of the Secretary of State or another person."
+          "text": "Setting up or maintaining an offshore installation that already has authorisation under Part 4 of the Petroleum Act 1998",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-Section-77"
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "nextQuestionRoute": "/exemption/construction/maintenance/pipeline/inspection-repair"
         }
       ]
     },
     {
       "route": "/exemption/construction/maintenance/pipeline/inspection-repair",
-      "text": "Does the activity relate to the inspection or repair of an existing pipeline?",
+      "text": "Does the activity involve the inspection or repair of an existing pipeline?",
       "section": "constructionMaintenance",
       "answers": [
         {
@@ -3705,7 +3708,7 @@
     },
     {
       "route": "/exemption/construction/maintenance/pipeline/emergency",
-      "text": "Are the circumstances serious, unexpected and potentially dangerous requiring immediate action?",
+      "text": "Is immediate action required because the situation is serious, unexpected or dangerous?",
       "section": "construction",
       "answers": [
         {
@@ -3722,8 +3725,8 @@
     },
     {
       "route": "/exemption/construction/maintenance/pipeline/protection",
-      "text": "Will the activity proposed include the deposit of rock or other materials for the purpose of providing <u>new</U> pipeline protection?",
-      "hint": "Deposits for these purposes, i.e. those beyond the replenishment or replacement of materials within the three dimensional boundaries of those previously consented and deposited, will require a marine licence. If the maintenance, inspection or repair can be carried out without the need for new protection you are advised to adapt your proposed approach. <P><P>NOTE: If you intend to apply for a marine licence in respect of the addition of new or extended protection, where relevant, please select ‘No’ to continue.",
+      "text": "Does the activity involve depositing rock or other materials to provide new pipeline protection?",
+      "hint": "Only replacing material within the existing boundary is exempt. New or extended protection needs a marine licence.",
       "section": "constructionMaintenance",
       "answers": [
         {
@@ -3757,7 +3760,7 @@
     },
     {
       "route": "/exemption/construction/maintenance/carbon-storage",
-      "text": "Is the proposed activity something that will be done in the course of carrying on an activity for which a licence under section 4 or 18 of the Energy Act 2008 is required (gas unloading, storage and recovery, and carbon dioxide storage)?",
+      "text": "Does the activity need a licence under sections 4 or 18 of the Energy Act 2008?",
       "section": "constructionMaintenance",
       "answers": [
         {
@@ -3774,7 +3777,7 @@
     },
     {
       "route": "/exemption/construction/maintenance/bored-tunnel",
-      "text": "Will the activity be carried out wholly under the 'Seabed' and relate directly to the construction or operation of a bored tunnel?",
+      "text": "Will all the work take place under the seabed and relate only to building or operating a bored tunnel?",
       "section": "constructionMaintenance",
       "answers": [
         {
@@ -3791,7 +3794,7 @@
     },
     {
       "route": "/exemption/construction/maintenance/bored-tunnel/affect",
-      "text": "Will the activity significantly adversely affect any part of the environment of the UK marine area or the living resources that it supports?",
+      "text": "Will this activity significantly harm the UK marine environment or marine life?",
       "section": "constructionMaintenance",
       "answers": [
         {
@@ -3808,7 +3811,7 @@
     },
     {
       "route": "/exemption/construction/new",
-      "text": "What does the contruction activity relate to?",
+      "text": "What does the construction involve?",
       "section": "construction",
       "answers": [
         {
@@ -3838,35 +3841,34 @@
         },
         {
           "id": "miscellaneous",
-          "text": "Other",
-          "nextQuestionRoute": "/exemption/construction/new/miscellaneous",
-          "hint": "Construction activities for purposes not set out above"
+          "text": "Something else",
+          "nextQuestionRoute": "/exemption/construction/new/miscellaneous"
         }
       ]
     },
     {
       "route": "/exemption/construction/new/moorings",
-      "text": "What is the purpose of the activity?",
+      "text": "What type of mooring will be constructed?",
       "section": "construction",
       "answers": [
         {
           "id": "pileMooring",
-          "text": "To provide a pile mooring",
+          "text": "Pile mooring",
           "nextQuestionRoute": "/exemption/construction/new/moorings/undertaker"
         },
         {
           "id": "swingingMooring",
-          "text": "To provide a swinging mooring",
+          "text": "Swinging mooring",
           "nextQuestionRoute": "/exemption/construction/new/moorings/undertaker"
         },
         {
           "id": "trotMooring",
-          "text": "To provide a trot Mooring",
+          "text": "Trot mooring",
           "nextQuestionRoute": "/exemption/construction/new/moorings/undertaker"
         },
         {
           "id": "aidToNavigation",
-          "text": "To provide a aid to Navigation",
+          "text": "Aid to navigation",
           "nextQuestionRoute": "/exemption/construction/new/moorings/undertaker"
         },
         {
@@ -3883,25 +3885,26 @@
       "answers": [
         {
           "id": "harbourAuthority",
-          "text": "A harbour authority or someone on behalf of a harbour authority",
+          "text": "A harbour authority or someone working for them",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-25"
         },
         {
           "id": "lighthouseAuthority",
-          "text": "A lighthouse authority or someone on behalf of a lighthouse authority",
+          "text": "A lighthouse authority or someone working for them",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-25"
         },
         {
           "id": "someoneElse",
           "text": "Someone else",
-          "nextQuestionRoute": "/exemption/construction/new/moorings/undertaker/consent"
+          "nextQuestionRoute": "/exemption/construction/new/moorings/undertaker/consent",
+          "hint": "This could be you or any organisation not listed"
         }
       ]
     },
     {
       "route": "/exemption/construction/new/moorings/undertaker/consent",
-      "text": "does the activity require consent (e.g. a licence) from a harbour authority under their local legislation?",
-      "hint": "The permission or agreement of the authority does not constitute consent for these purposes.",
+      "text": "Will the activity take place in a harbour authority area?",
+      "hint": "<p>To find out if the activity falls within a harbour authority area, you can use the <a href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c&showLayers=Navigation\" target=\"_blank\">marine licensing interactive map (opens in new tab)</a>.",
       "section": "construction",
       "answers": [
         {
@@ -3918,7 +3921,7 @@
     },
     {
       "route": "/exemption/construction/new/moorings/undertaker/approval",
-      "text": "Has consent been granted?",
+      "text": "Do you have harbour authority consent?",
       "section": "construction",
       "answers": [
         {
@@ -3952,25 +3955,25 @@
     },
     {
       "route": "/exemption/construction/new/pontoons/undertaker",
-      "text": "Who will carry out the activity?",
+      "text": "Will a harbour authority or someone working for them carry out the activity?",
       "section": "construction",
       "answers": [
         {
           "id": "harbourAuthority",
-          "text": "A harbour authority or someone on behalf of a harbour authority",
+          "text": "Yes",
           "nextQuestionRoute": "/exemption/construction/new/pontoons/deck"
         },
         {
           "id": "someoneElse",
-          "text": "Someone else",
+          "text": "No",
           "nextQuestionRoute": "/exemption/construction/new/pontoons/consent"
         }
       ]
     },
     {
       "route": "/exemption/construction/new/pontoons/consent",
-      "text": "Does the activity require consent (e.g. a licence) from a harbour authority under local legislation?",
-      "hint": "The permission or agreement of the authority does not constitute consent for these purposes.",
+      "text": "Will the activity take place in a harbour authority area?",
+      "hint": "<p>To find out if the activity falls within a harbour authority area, you can use the <a href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c&showLayers=Navigation\" target=\"_blank\">marine licensing interactive map (opens in new tab)</a>.",
       "section": "construction",
       "answers": [
         {
@@ -3987,7 +3990,7 @@
     },
     {
       "route": "/exemption/construction/new/pontoons/approval",
-      "text": "Has consent been granted?",
+      "text": "Do you have harbour authority consent to build a pontoon?",
       "section": "construction",
       "answers": [
         {
@@ -4004,8 +4007,8 @@
     },
     {
       "route": "/exemption/construction/new/pontoons/deck",
-      "text": "When complete will the deck of the pontoon be an area greater than 30m2?",
-            "hint": "NOTE: If the pontoon will be attached to one or more pontoons already in place the question refers to the total deck area of all pontoons combined.",
+      "text": "Will the pontoon deck be larger than 30 square metres when finished?",
+      "hint": "If attached to existing pontoons, this includes their total deck area.",
       "section": "construction",
       "answers": [
         {
@@ -4022,9 +4025,9 @@
     },
     {
       "route": "/exemption/construction/new/pontoons/quantity",
-      "text": "In the 6 months prior to the commencement of this activity will 10 or more pontoons have been constructed or deposited at the location?",
+      "text": "In the 6 months before the activity begins, will the harbour authority have built or approved more than 10 pontoons?",
       "section": "construction",
-      "hint": "either by or on behalf of the harbour authority or with the consent required from and granted by the harbour authority",
+      "hint": "Check with the appropriate harbour authority if you're unsure.",
       "answers": [
         {
           "id": "yes",
@@ -4039,368 +4042,8 @@
       ]
     },
     {
-      "route": "/sea/article99",
-      "text": "Where will the activity take place?",
-      "section": "doINeedAMarineLicence",
-      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/marine-licensing-definitions#mean-high-water-springs\"> mean high water springs (MHWS)</a>, the <a target=\"_blank\" href=\"https://www.gov.uk/guidance/marine-licensing-definitions#normal-tidal-limit\"> normal tidal limit (NTL) </a>, or the MMO's <a target=\"_blank\" href=\"https://www.gov.uk/guidance/marine-licensing-definitions#jurisdiction\">jurisdiction</a>.",
-      "answers": [
-        {
-          "id": "inSea",
-          "text": "In the 'Sea'",
-          "nextQuestionRoute": "/jurisdiction/article99",
-          "hint": "'Sea' includes any area which is <u>submerged</u> at MHWS and the waters of every <u>estuary, river or channel</u> where the tide flows at MHWS tide up to the NTL. Even waters in areas which are closed permanently or intermittently by a lock or other artificial means against the regular action of the tide are included, where seawater flows into or out from the area, either continuously or from time to time."
-        },
-        {
-          "id": "overSea",
-          "text": "Over the 'Sea'",
-          "nextQuestionRoute": "/jurisdiction/article99",
-          "hint": "'Over' the 'Sea' includes a location directly above or overhanging the 'Sea' such as a bridge, open piled structure or cantilever."
-        },
-        {
-          "id": "onOrUnderSea",
-          "text": "On or under the 'Seabed'",
-          "nextQuestionRoute": "/jurisdiction/article99",
-          "hint": "'Seabed' means the ground under the 'Sea' and anything resting on it such as a wreck. It includes the intertidal area of the sea or any river at such time as it is exposed temporarily at low tide."
-        },
-        {
-          "id": "other",
-          "text": "Other",
-          "outcomeRoute": "/exemption/licence-not-required/sea",
-          "hint": "In an area <u>other</u> than those defined above. For example the part of beach <u>above MHWS</u>, the upper extent of a river <u>beyond the NTL</u> and or a land locked body of water such as a lake."
-        }
-      ]
-    },
-    {
-      "route": "/jurisdiction/article99",
-      "text": "In which waters will the activity take place?",
-      "hint": "See an illustration of these 'waters' or find out more about the MMO's <a target=\"_blank\" href=\"https://www.gov.uk/guidance/marine-licensing-definitions#jurisdiction\">jurisdiction</a>.",
-      "section": "doINeedAMarineLicence",
-      "answers": [
-        {
-          "id": "englishWaters",
-          "text": "In English waters",
-          "nextQuestionRoute": "/activity-type/article99",
-          "hint": "'English waters' is the area of 'Sea' within the limits of territorial waters (12 nautical miles) adjacent to the English coastline (the 'inshore' area). This also includes any area of sea beyond the territorial limit (the 'offshore' area), that is within the exclusive economic zone (EEZ) and the UK sector of the continental shelf (up to 200 nautical miles). This excludes the waters of any devolved administration."
-        },
-        {
-          "id": "northernIrishOffshoreWaters",
-          "text": "In Northern Ireland offshore waters",
-          "nextQuestionRoute": "/activity-type",
-          "hint": "'Northern Ireland offshore waters' is the area of 'Sea', adjacent to Northern Ireland beyond the territorial limit, providing it includes the EEZ and the UK sector of the continental shelf (excluding the waters of any other administration)."
-        },
-        {
-          "id": "otherUkWaters",
-          "text": "In other UK waters",
-          "outcomeRoute": "/licence-not-required-devolved",
-          "hint": "'Other UK waters'means the waters of the devolved administrations of Wales, Scotland or Northern Ireland (excluding Northern Ireland offshore waters)."
-        },
-        {
-          "id": "elsewhere",
-          "text": "Somewhere else in the world",
-          "nextQuestionRoute": "/elsewhere-in-the-world/activity-type"
-        }
-      ]
-    },
-    {
-      "route": "/activity-type/article99",
-      "mcmsAppFormMapping": "ACTIVITY_TYPE",
-      "text": "What type of activity will be carried out?",
-      "hint": "HINT: Try to think about what you intend to do at a basic level. For example if you plan to take sediment samples for testing or analysis, the type of activity that will take place is a removal activity. If the activity involves the building of something new, or the maintenance, alteration or improvement of something that already exists, then the activity that will take place is a construction activity.<p> </br> Doing more than one thing? If your project involves multiple activities make sure you check each separately starting with the main or most significant activity.",
-      "section": "doINeedAMarineLicence",
-      "answers": [
-        {
-          "id": "CON",
-          "text": "Construction",
-          "outcomeRoute": "/construction/journey-select/article99",
-          "hint": "Including maintenance, alteration and improvement of works and the laying of cables or pipelines.<br/>Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/construction-alteration-or-improvement-of-works\">construction, maintenance, alteration and improvement</a>"
-        },
-        {
-          "id": "DEPO",
-          "text": "Deposit",
-          "outcomeRoute": "/deposit/journey-select",
-          "hint": "Including the deliberate disposal, dumping, placing, tipping or unloading of any substance or object.<br/>Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/deposit-of-substances-and-objects-below-mhws\">deposit activities</a>"
-        },
-        {
-          "id": "REMO",
-          "text": "Removal",
-          "outcomeRoute": "/removal/journey-select",
-          "hint": "Including dredging for the purpose of improving navigation, taking samples for scientific analysis, borrow pits, capital and maintenance dredging, and beach replenishment.<br/>Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/dredging\">dredging and removal activities</a>"
-        },
-        {
-          "id": "SCUTTLE",
-          "text": "Scuttling",
-          "outcomeRoute": "/scuttling/journey-select",
-          "hint": "Deliberately sinking a vessel or floating container.<br/>Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/scuttling-vessels\">scuttling</a>"
-        },
-        {
-          "id": "INCINERATION",
-          "text": "Incineration",
-          "outcomeRoute": "/incineration/journey-select",
-          "hint": "Burning substances or objects.<br/>Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/incineration-of-substances-and-objects\">incineration</a>"
-        }
-      ]
-    },
-    {
-      "route": "/construction/journey-select/article99",
-      "heading": "Marine licence may be required",
-      "text": "<b>Please select the service you require.</b><p><p> Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/guidance/do-i-need-a-marine-licence#exemptions\">exemptions</a>, <a target=\"_blank\" href=\"https://www.gov.uk/guidance/do-i-need-a-marine-licence#self-service\">self-service</a>, or <a target=\"_blank\" href=\"https://www.gov.uk/guidance/do-i-need-a-marine-licence#standard-marine-licence\">standard marine licensing</a>.<p><p>Note: If you select either option 1 or option 2 but it is subsequently determined in the course of the check that the activity does not meet relevant qualifying criteria you will have the opportunity to continue your journey and select a different option once the check is concluded.",
-      "section": "doINeedAMarineLicenceConstruction",
-      "outcomeTypes": [
-        "WO_CON_EXEMPTION_JOURNEY_ARTICLE99",
-        "WO_CON_SELF_SERVICE_JOURNEY",
-        "WO_STANDARD_MLA"
-      ]
-    },
-    {
-      "route": "/exemption/construction/article99",
-      "text": "What is the purpose of your construction activity?",
-      "section": "construction",
-      "mcmsAppFormMapping": "EXE_ACTIVITY_SUBTYPE_CONSTRUCTION",
-      "answers": [
-        {
-          "id": "maintenance",
-          "text": "Maintenance of existing structures and assets",
-          "hint": "'Maintenance' means the upkeep or repair of an existing structure or asset wholly within its existing 3 dimensional boundaries",
-          "nextQuestionRoute": "/exemption/construction/maintenance-alteration"
-        },
-        {
-          "id": "new",
-          "text": "Construction of something new",
-          "hint": "Includes activities undertaken primarily for maintenance purposes where an element of the works extend beyond the existing boundaries of the structure of asset being maintained.", 
-          "nextQuestionRoute": "/exemption/construction/new/article99"
-        }
-      ]
-    },
-    {
-      "route": "/exemption/construction/new/article99",
-      "text": "What does the construction activity relate to?",
-      "section": "construction",
-      "answers": [
-        {
-          "id": "mooringOrNavigation",
-          "text": "Moorings or aids to navigation",
-          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
-        },
-        {
-          "id": "pontoon",
-          "text": "Pontoons",
-          "nextQuestionRoute": "/exemption/construction/new/pontoons/article99"
-        },
-        {
-          "id": "floodEmergency",
-          "text": "Flood or flood risk",
-          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
-        },
-        {
-          "id": "cables",
-          "text": "Cables",
-          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
-        },
-        {
-          "id": "pipelines",
-          "text": "Pipelines",
-          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
-        },
-        {
-          "id": "miscellaneous",
-          "text": "Other",
-          "outcomeRoute": "/exemption/construction-exe-not-available-continue",
-          "hint": "Construction activities for purposes not set out above"
-        }
-      ]
-    },
-    {
-      "route": "/exemption/construction/new/pontoons/article99",
-      "text": "Is the purpose of the activity to provide a pontoon?",
-      "section": "construction",
-      "answers": [
-        {
-          "id": "yes",
-          "text": "Yes",
-          "nextQuestionRoute": "/exemption/construction/new/pontoons/undertaker/article99"
-        },
-        {
-          "id": "no",
-          "text": "No",
-          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
-        }
-      ]
-    },
-    {
-      "route": "/exemption/construction/new/pontoons/undertaker/article99",
-      "text": "Who will carry out the activity?",
-      "section": "construction",
-      "answers": [
-        {
-          "id": "harbourAuthority",
-          "text": "A harbour authority or someone on behalf of a harbour authority",
-          "nextQuestionRoute": "/exemption/construction/new/pontoons/deck/article99"
-        },
-        {
-          "id": "someoneElse",
-          "text": "Someone else",
-          "nextQuestionRoute": "/exemption/construction/new/pontoons/consent/article99"
-        }
-      ]
-    },
-    {
-      "route": "/exemption/construction/new/pontoons/consent/article99",
-      "text": "Does the activity require consent (e.g. a licence) from a harbour authority under local legislation?",
-      "hint": "The permission or agreement of the authority does not constitute consent for these purposes.",
-      "section": "construction",
-      "answers": [
-        {
-          "id": "yes",
-          "text": "Yes",
-          "nextQuestionRoute": "/exemption/construction/new/pontoons/approval/article99"
-        },
-        {
-          "id": "no",
-          "text": "No",
-          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
-        }
-      ]
-    },
-    {
-      "route": "/exemption/construction/new/pontoons/approval/article99",
-      "text": "Has consent been granted?",
-      "section": "construction",
-      "answers": [
-        {
-          "id": "yes",
-          "text": "Yes",
-          "nextQuestionRoute": "/exemption/construction/new/pontoons/deck/article99"
-        },
-        {
-          "id": "no",
-          "text": "No",
-          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
-        }
-      ]
-    },
-    {
-      "route": "/exemption/construction/new/pontoons/deck/article99",
-      "text": "When complete will the deck of the pontoon be an area greater than 30m2?",
-      "hint": "NOTE: If the pontoon will be attached to one or more pontoons already in place the question refers to the total deck area of all pontoons combined.",
-      "section": "construction",
-      "answers": [
-        {
-          "id": "yes",
-          "text": "Yes",
-          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
-        },
-        {
-          "id": "no",
-          "text": "No",
-          "nextQuestionRoute": "/exemption/construction/new/pontoons/quantity/article99"
-        }
-      ]
-    },
-    {
-      "route": "/exemption/construction/new/pontoons/quantity/article99",
-      "text": "In the 6 months prior to the commencement of this activity will 10 or more pontoons have been constructed or deposited at the location?",
-      "section": "construction",
-      "hint": "either by or on behalf of the harbour authority or with the consent required from and granted by the harbour authority",
-      "answers": [
-        {
-          "id": "yes",
-          "text": "Yes",
-          "nextQuestionRoute": "/exemption/removal/scientific-research/samples/obstruction/article99"
-        },
-        {
-          "id": "no",
-          "text": "No",
-          "nextQuestionRoute": "/exemption/removal/scientific-research/samples/obstruction/article99"
-        }
-      ]
-    },
-    {
-      "route": "/exemption/removal/scientific-research/samples/obstruction/article99",
-      "text": "Will the activity cause or be likely to cause an obstruction or danger to navigation?",
-      "section": "removal",
-      "hint": " Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#navigational-risk\"> navigational risk </a> and the steps you can take to ensure your proposal is not one that will cause or be likely to cause and obstruction or danger.",
-      "answers": [
-        {
-          "id": "yes",
-          "text": "Yes",
-          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
-        },
-        {
-          "id": "no",
-          "text": "No",
-          "nextQuestionRoute": "/exemption/removal/scientific-research/samples/mpa/article99"
-        }
-      ]
-    },
-    {
-      "route": "/exemption/removal/scientific-research/samples/mpa/article99",
-      "text": "Will the activity take place in or within 200m of a Marine Protected Area (MPA)?",
-      "section": "removal",
-      "hint": "<p>MPA's are an important part of the marine environment. </p><p>You are responsible for making sure you understand the status of the location where the activity is proposed. </p><p> 'Marine protected areas' mean:<ul><li>Highly Protected Marine Area (HPMA) (designated and candidate)</li><li>Marine Conservation Zones (MCZs) (designated and proposed)</li><li>Special Areas of Conservation (SACs) (designated and candidate)</li><li>Special Protection Areas (SPAs) (designated and potential)</li><li>Ramsar's</li><li>SSSIs</li></ul></p><p> If you are unsure of whether the activity falls within an MPA you should select the appropriate layer in the MMO's <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\"> GIS tool </a> to check.",
-      "answers": [
-        {
-          "id": "yes",
-          "text": "Yes",
-          "nextQuestionRoute": "/exemption/removal/scientific-research/samples/mpa-management/article99"
-        },
-        {
-          "id": "no",
-          "text": "No",
-          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-25A"
-        }
-      ]
-    },
-    {
-      "route": "/exemption/removal/scientific-research/samples/mpa-management/article99",
-      "text": "Is the activity directly connected with or necessary to the management of the Marine Protected Area?",
-      "section": "removal",
-      "answers": [
-        {
-          "id": "yes",
-          "text": "Yes",
-          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-25A"
-        },
-        {
-          "id": "no",
-          "text": "No",
-          "nextQuestionRoute": "/exemption/removal/scientific-research/samples/lse/article99"
-        }
-      ]
-    },
-    {
-      "route": "/exemption/removal/scientific-research/samples/lse/article99",
-      "text": "Is the activity....",
-      "section": "removal",
-      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#marine-protected-areas\"> marine protected areas </a>.",
-      "answers": [
-        {
-          "id": "europeanSiteSamples",
-          "text": "Likely to have a significant effect on a European site?",
-          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
-          "hint": "either alone or in combination with other plans and projects"
-        },
-        {
-          "id": "ramsarSiteSamples",
-          "text": "Likely to have a significant effect on a Ramsar site?",
-          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
-          "hint": "either alone or in combination with other plans and projects"
-        },
-        {
-          "id": "mczSamples",
-          "text": "Capable of affecting (other than insignificantly), the protected features of a Marine Conservation Zone or Highly Protected Marine Area?",
-          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
-          "hint": "including any ecological or geomorphological process on which the conservation of any protected feature of an MCZ or HPMA is (wholly or in Part) dependant"
-        },
-        {
-          "id": "otherSamples",
-          "text": "Unlikely to have any relevant effect on any sites specified above",
-          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-25A"
-        }
-      ]
-    },
-    {
       "route": "/exemption/construction/new/flood-emergency",
-      "text": "Will the activity be carried out by or on behalf on the Environment Agency?",
+      "text": "Will the Environment Agency or someone working for them carry out the activity?",
       "section": "construction",
       "answers": [
         {
@@ -4417,7 +4060,7 @@
     },
     {
       "route": "/exemption/construction/new/flood-emergency/validation",
-      "text": "Are the circumstances serious, unexpected, and potentially dangerous requiring immediate action in response to either flooding or imminent risk of flooding?",
+      "text": "Is immediate action needed due to flooding or an imminent flood risk?",
       "section": "construction",
       "answers": [
         {
@@ -4434,33 +4077,28 @@
     },
     {
       "route": "/exemption/construction/new/cables",
-      "text": "What will the cable to be laid be used for?",
-      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities--2#cables-pipelines-oil-and-gas-and-carbon-capture-storage\"> cables </a>.",
+      "text": "What will the cable be used for?",
       "section": "construction",
       "answers": [
         {
           "id": "transferOfData",
           "text": "The transfer of data",
-          "nextQuestionRoute": "/exemption/construction/new/cables/location",
-          "hint": "This type of cable transfers data from one place to another."
+          "nextQuestionRoute": "/exemption/construction/new/cables/location"
         },
         {
           "id": "transferOfElectricity",
           "text": "The transfer of electricity",
-          "nextQuestionRoute": "/exemption/construction/new/cables/location",
-          "hint": "This type of cable allows the transfers of electricity from one place to another. This includes interconnector cables, which exchange electricity to and from continental Europe and beyond."
+          "nextQuestionRoute": "/exemption/construction/new/cables/location"
         },
         {
           "id": "renewableEnergyExportCable",
           "text": "Renewable energy export ",
-          "outcomeRoute": "/exemption/construction-exe-not-available-continue",
-          "hint": "This type of cable exports electricity generated by an offshore wind farm or wave/tidal array to a substation on land."
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
         },
         {
           "id": "other",
-          "text": "Other",
-          "outcomeRoute": "/exemption/construction-exe-not-available-continue",
-          "hint": "Cables supplying offshore structures, cables utilised in exploration or exploitation of natural resources and or pollution control etc."
+          "text": "Something else",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
         }
       ]
     },
@@ -4471,24 +4109,24 @@
       "answers": [
         {
           "id": "inside12NM",
-          "text": "Wholly inside 12NM",
+          "text": "Within 12 nautical miles of the UK",
           "outcomeRoute": "/exemption/construction-exe-not-available-continue"
         },
         {
           "id": "outside12NM",
-          "text": "Wholly outside 12NM",
+          "text": "Beyond 12 nautical miles of the UK",
           "outcomeRoute": "/exemption/licence-not-required-cables"
         },
         {
           "id": "bothInsideOutside12NM",
-          "text": "Part inside 12NW part outside 12NM",
+          "text": "Some within and some beyond 12 nautical miles of the UK",
           "outcomeRoute": "/exemption/licence-required-no-exemption-part-cables"
         }
       ]
     },
     {
       "route": "/exemption/construction/new/pipelines",
-      "text": "What kind of pipeline does the construction activity relate to?",
+      "text": "What kind of pipeline is the construction activity for?",
       "section": "construction",
       "answers": [
         {
@@ -4510,31 +4148,29 @@
       "answers": [
         {
           "id": "section3PetroleumAct",
-          "text": "something done in the course of carrying on an activity for which a licence under section 3 of the Petroleum Act 1998 or section 2 of the Petroleum (Production) Act 1934 is required",
-          "outcomeRoute": "/exemption/licence-not-required-exemption-available-Section-77",
-          "hint": "Activities are to be regarded as activities for which a licence is required if, by virtue of such a licence, they are activities which may be carried out only with the consent of the Secretary of State or another person."
+          "text": "Activities requiring a licence under the Petroleum Act 1998 or Petroleum (Production) Act 1934",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-Section-77"
         },
         {
           "id": "part3PetroleumAct",
-          "text": "something done for the purpose of constructing or maintaining a pipeline as respects any part of which an authorisation (within the meaning of Part 3 of the Petroleum Act 1998) is in force;",
+          "text": "Constructing or maintaining a pipeline that already has authorisation under Part 3 of the Petroleum Act 1998",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-Section-77"
         },
         {
           "id": "part4PetroleumAct",
-          "text": "something done for the purpose of establishing or maintaining an offshore installation (within the meaning of Part 4 of the Petroleum Act 1998;",
-          "outcomeRoute": "/exemption/licence-not-required-exemption-available-Section-77",
-          "hint": "Activities are to be regarded as activities for which a licence is required if, by virtue of such a licence, they are activities which may be carried out only with the consent of the Secretary of State or another person."
+          "text": "Setting up or maintaining an offshore installation that already has authorisation under Part 4 of the Petroleum Act 1998",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-Section-77"
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/construction-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/construction/new/carbon-storage",
-      "text": "Is the proposed activity something that will be done in the course of carrying on an activity for which a licence under section 4 or 18 of the Energy Act 2008 is required (gas unloading, storage and recovery, and carbon dioxide storage)?",
+      "text": "Is the work part of gas unloading, storage and recovery, or carbon dioxide storage, that needs a licence under sections 4 or 18 of the Energy Act 2008?",
       "section": "construction",
       "answers": [
         {
@@ -4551,7 +4187,7 @@
     },
     {
       "route": "/exemption/construction/new/miscellaneous",
-      "text": "What does the construction activity relate to?",
+      "text": "What is the construction activity for?",
       "section": "construction",
       "answers": [
         {
@@ -4561,54 +4197,53 @@
         },
         {
           "id": "deepseaMining",
-          "text": "Licensed deepsea mining",
+          "text": "Licensed deep sea mining",
           "nextQuestionRoute": "/exemption/construction/new/miscellaneous/deepsea-mining"
         },
         {
           "id": "crossrailAct",
-          "text": "Scheduled works authorised under the Crossrail Act 2008",
+          "text": "Scheduled works under the Crossrail Act 2008",
           "nextQuestionRoute": "/exemption/construction/new/miscellaneous/crossrail-act"
         },
         {
           "id": "carbonStorage",
-          "text": "Carbon Dioxide Storage",
+          "text": "Carbon dioxide storage",
           "nextQuestionRoute": "/exemption/construction/new/carbon-storage"
         },
         {
           "id": "other",
-          "text": "Other",
-          "outcomeRoute": "/exemption/construction-exe-not-available-continue",
-          "hint": "Other construction or alteration activities for purposes not set out above"
+          "text": "Something else",
+          "outcomeRoute": "/exemption/construction-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/construction/new/miscellaneous/deepsea-mining",
-      "text": "Is the activity carried out?",
+      "text": "What is the purpose of the deep sea mining?",
       "section": "construction",
       "answers": [
         {
           "id": "explorationExploitationLicence",
-          "text": "In pursuance of an exploration or exploitation licence issued under the Deep Sea Mining (Temporary Provision) Act 1981",
+          "text": "To get an exploration or exploitation licence under the Deep Sea Mining (Temporary Provision) Act 1981",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-30"
         },
         {
           "id": "reciprocalauthorisation",
-          "text": "In pursuance of a reciprocal authorisation within the meaning given by section 3(3) of the Deep Sea Mining (Temporary Provision) Act 1981",
+          "text": "To get reciprocal authorisation under section 3(3) of the Deep Sea Mining (Temporary Provision) Act 1981",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-30"
         },
         {
           "id": "other",
-          "text": "for another reason",
+          "text": "Something else",
           "outcomeRoute": "/exemption/construction-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/construction/new/miscellaneous/crossrail-act",
-      "text": "Will the activity be carried out within the limits of deviation for scheduled works in exercise of powers conferred by the Crossrail Act 2008 in relation to those works or any work connected with them?",
+      "text": "Will the work take place inside the limits of deviation set by the Crossrail Act 2008?",
       "section": "construction",
-      "hint": "'limits of deviation' means the limits of deviation which are shown on the deposited plans. 'Scheduled works are defined in section 1(1) of the 2008 Act.",
+      "hint": "The limits of deviation are legal boundaries showing how far authorised works can move sideways, up or down on the plans.",
       "answers": [
         {
           "id": "yes",
@@ -4624,7 +4259,7 @@
     },
     {
       "route": "/exemption/construction/new/miscellaneous/bored-tunnel",
-      "text": "Will the activity be carried out wholly under the 'Seabed' and relate directly to the construction or operation of a bored tunnel?",
+      "text": "Will all the work take place under the seabed and relate only to building or operating a bored tunnel?",
       "section": "construction",
       "answers": [
         {
@@ -4641,7 +4276,7 @@
     },
     {
       "route": "/exemption/construction/new/miscellaneous/bored-tunnel/affect",
-      "text": "Will the activity significantly adversely affect any part of the environment of the UK marine area or the living resources that it supports?",
+      "text": "Will this activity significantly harm the UK marine environment or marine life?",
       "section": "construction",
       "answers": [
         {
@@ -4658,18 +4293,18 @@
     },
     {
       "route": "/exemption/deposit/activity-type",
-      "text": "What does the deposit activity relate to?",
+      "text": "What does the deposit activity involve?",
       "section": "deposit",
       "mcmsAppFormMapping": "EXE_ACTIVITY_SUBTYPE_DEPOSIT",
       "answers": [
         {
           "id": "fishing",
-          "text": "Fishing and shellfish propogation and cultivation",
+          "text": "Fishing or shellfish propagation and cultivation",
           "nextQuestionRoute": "/exemption/deposit/fishing"
         },
         {
           "id": "markersMooringsAidsToNavigation",
-          "text": "Markers, moorings and aids to navigation",
+          "text": "Markers, moorings or aids to navigation",
           "nextQuestionRoute": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation"
         },
         {
@@ -4679,9 +4314,8 @@
         },
         {
           "id": "scientificResearch",
-          "text": "Scientific investigation or research",
-          "nextQuestionRoute": "/exemption/deposit/scientific-research",
-          "hint": "Scientific instruments, associated equipment and tracers"
+          "text": "Scientific research",
+          "nextQuestionRoute": "/exemption/deposit/scientific-research"
         },
         {
           "id": "hullCleaning",
@@ -4691,8 +4325,7 @@
         {
           "id": "maintenance",
           "text": "Maintenance of existing structures or assets",
-          "nextQuestionRoute": "/exemption/deposit/maintenance",
-          "hint": "'Maintenance' means the upkeep or repair of an existing structure or asset wholly within its existing 3 dimensional boundaries"
+          "nextQuestionRoute": "/exemption/deposit/maintenance"
         },
         {
           "id": "dredgedMaterial",
@@ -4701,25 +4334,24 @@
         },
         {
           "id": "emergency",
-          "text": "Emergency, safety and training",
+          "text": "Emergency or safety and training",
           "nextQuestionRoute": "/exemption/deposit/emergency-safety-accident-investigation"
         },
         {
           "id": "pollutionResponse",
-          "text": "Pollution prevention and discharge of chemicals",
+          "text": "Pollution prevention or discharge of chemicals",
           "nextQuestionRoute": "/exemption/deposit/pollution"
         },
         {
           "id": "defenceMiningCrossrail",
-          "text": "Miscellaneous",
-          "nextQuestionRoute": "/exemption/deposit/miscellaneous",
-          "hint": "Other deposit activities for purposes not set out above"
+          "text": "Something else",
+          "nextQuestionRoute": "/exemption/deposit/miscellaneous"
         }
       ]
     },
     {
       "route": "/exemption/deposit/maintenance",
-      "text": "What does the maintenance activity relate to?",
+      "text": "What will be maintained?",
       "section": "deposit",
       "answers": [
         {
@@ -4730,51 +4362,51 @@
         {
           "id": "harbourWorkMaintenance",
           "text": "Harbour works",
-          "nextQuestionRoute": "/exemption/deposit/maintenance/harbour-works",
-          "hint": "Maintenance carried out by or on behalf of harbour authorities only."
+          "nextQuestionRoute": "/exemption/deposit/maintenance/harbour-works"
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/deposit/maintenance/coastal-drainage-flood",
-      "text": "Who will carry out the activity?",
+      "text": "Who will carry out the deposit?",
       "section": "deposit",
       "answers": [
         {
           "id": "environmentAgency",
-          "text": "The Environment Agency or someone on behalf of the Environment Agency",
+          "text": "The Environment Agency or someone working for them",
           "nextQuestionRoute": "/exemption/deposit/maintenance/coastal-drainage-flood/EA"
         },
         {
           "id": "coastProtectionAuthority",
-          "text": "The Coast Protection Authority or someone on behalf of the Coast Protection Authority",
+          "text": "The Coast Protection Authority or someone working for them",
           "nextQuestionRoute": "/exemption/deposit/maintenance/coastal-drainage-flood/CPA"
         },
         {
           "id": "localAuthority",
-          "text": "The Local Authority or someone on behalf of the Local Authority",
+          "text": "The local authority or someone working for them",
           "nextQuestionRoute": "/exemption/deposit/maintenance/coastal-drainage-flood/CPA"
         },
         {
           "id": "secretaryStateDefence",
-          "text": "The Secretary of State for Defence or someone on behalf of the Secretary of State for Defence",
+          "text": "The Secretary of State for Defence or someone working for them",
           "nextQuestionRoute": "/exemption/deposit/maintenance/coastal-drainage-flood/CPA"
         },
         {
           "id": "other",
-          "text": "Other",
-          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+          "text": "Someone else",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue",
+          "hint": "This could be you or any organisation not listed"
         }
       ]
     },
     {
       "route": "/exemption/deposit/maintenance/coastal-drainage-flood/EA",
-      "text": "Will the activity be carried out wholly within the existing 3 dimensional boundary of the works being maintained?",
+      "text": "Will all the maintenance take place within the existing 3-dimensional boundary?",
       "section": "deposit",
       "answers": [
         {
@@ -4792,7 +4424,7 @@
     {
       "route": "/exemption/deposit/maintenance/coastal-drainage-flood/EA/beach-replenishment",
       "text": "Does the activity involve beach replenishment?",
-            "hint": "'Beach replenishment' means the addition of material from land-based, off-shore or other coastal sources not connected to the beach or its associated sediment system to replace material permanently lost from the system.",
+      "hint": "Beach replenishment means adding new material from outside sources on land, offshore or along the coast to replace material the beach has permanently lost.",
       "section": "deposit",
       "answers": [
         {
@@ -4810,7 +4442,7 @@
     {
       "route": "/exemption/deposit/maintenance/coastal-drainage-flood/CPA",
       "text": "Is the activity for the purpose of maintaining coast protection works?",
-            "hint": "'Coast protection works' include: </li><li><u>beach re-profiling</U>, which involves the movement of beach material in a cross-shore direction up or down the beach; and </li><li><u>beach recycling</u>, which involves the movement of beach material along the beach from areas of accretion to areas of erosion within the beach or associated sediment system.",
+      "hint": "Coast protection works include beach re-profiling, which involves moving material up or down the beach. They also include beach recycling, which involves moving material along the beach to manage erosion.",
       "section": "deposit",
       "answers": [
         {
@@ -4828,7 +4460,7 @@
     {
       "route": "/exemption/deposit/maintenance/coastal-drainage-flood/CPA/beach-replenishment",
       "text": "Does the activity involve beach replenishment?",
-            "hint": "'Beach replenishment' means the addition of material from land-based, off-shore or other coastal sources not connected to the beach or its associated sediment system to replace material permanently lost from the system.",
+      "hint": "Beach replenishment means adding new material from outside sources on land, offshore or along the coast to replace material the beach has permanently lost.",
       "section": "deposit",
       "answers": [
         {
@@ -4845,7 +4477,7 @@
     },
     {
       "route": "/exemption/deposit/maintenance/coastal-drainage-flood/EA/emergency-flood",
-      "text": "Are the circumstances serious, unexpected, and potentially dangerous requiring immediate action in response to either flooding or imminent risk of flooding?",
+      "text": "Is immediate action needed due to flooding or an imminent flood risk?",
       "section": "deposit",
       "answers": [
         {
@@ -4879,7 +4511,7 @@
     },
     {
       "route": "/exemption/deposit/maintenance/harbour-works/boundaries",
-      "text": "Will the activity be carried out within the 3 dimensional boundaries of the existing works?",
+      "text": "Will the activity be carried out within the 3-dimensional boundaries of the existing works?",
       "section": "deposit",
       "answers": [
         {
@@ -4896,7 +4528,7 @@
     },
     {
       "route": "/exemption/deposit/maintenance/harbour-works/undertaker",
-      "text": "Will the activity be carried out by or on behalf of the harbour authority?",
+      "text": "Will a harbour authority or someone working for them carry out the activity?",
       "section": "deposit",
       "answers": [
         {
@@ -4913,12 +4545,12 @@
     },
     {
       "route": "/exemption/deposit/fishing",
-      "text": "What does the deposit activity relate to?",
+      "text": "What is the purpose of the deposit activity?",
       "section": "deposit",
       "answers": [
         {
           "id": "shellfishPropogationCultivation",
-          "text": "Shellfish propogation and cultivation",
+          "text": "Shellfish propagation or cultivation",
           "nextQuestionRoute": "/exemption/deposit/fishing/shellfish-propagation-cultivation"
         },
         {
@@ -4928,14 +4560,14 @@
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/deposit/fishing/shellfish-propagation-cultivation",
-      "text": "Will the activity involve the deposit of a shellfish, trestle, raft, cage, pole, rope, marker or line in the course of propagation or cultivation of shellfish?",
+      "text": "Will the activity involve depositing equipment for shellfish propagation or cultivation?",
       "section": "deposit",
       "answers": [
         {
@@ -4952,9 +4584,9 @@
     },
     {
       "route": "/exemption/deposit/fishing/shellfish-propagation-cultivation/obstruction",
-      "text": "Will the deposit cause or be likely to cause an obstruction or danger to navigation?",
+      "text": "Is the activity likely to cause an obstruction or danger to navigation?\n",
       "section": "deposit",
-      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#navigational-risk\"> navigational risk </a> and the steps you can take to ensure your proposal is not one that will cause or be likely to cause and obstruction or danger.",
+      "hint": "<p>If you're unsure, you can check with the relevant harbour authority. If outside their jurisdiction, check with the <a target=\"_blank\" href=\"https://www.gov.uk/government/organisations/maritime-and-coastguard-agency\">Maritime and Coastguard Agency (opens in new tab)</a> or <a target=\"_blank\" href=\"https://www.trinityhouse.co.uk/\">Trinity House (opens in new tab)</a>.",
       "answers": [
         {
           "id": "yes",
@@ -4970,7 +4602,7 @@
     },
     {
       "route": "/exemption/deposit/fishing/shellfish-propagation-cultivation/disposal-artificial-reef",
-      "text": "Is the deposit for the purpose of",
+      "text": "Is the deposit for any of the following?",
       "section": "deposit",
       "answers": [
         {
@@ -4985,38 +4617,37 @@
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-13"
         }
       ]
     },
     {
       "route": "/exemption/deposit/fishing/fishing-operations",
-      "text": "What will be deposited",
+      "text": "What will be deposited?",
       "section": "deposit",
       "answers": [
         {
           "id": "depositFishingGear",
           "text": "Fishing Gear",
           "nextQuestionRoute": "/exemption/deposit/fishing/fishing-operations/fishing-gear",
-          "hint": "'Fishing gear' includes gear used to fish for or take shellfish, but does not include anything used in connection with propagation or cultivation of shellfish."
+          "hint": "Does not include anything used for propagation or cultivation of shellfish"
         },
         {
           "id": "depositReturns",
-          "text": "Fish or other objects caught and returned in the course of a fishing operation",
-          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-12",
-          "hint": "'Fish' includes any part of a fish and also shellfish."
+          "text": "Fish or other objects caught and returned  during a fishing operation",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-12"
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/deposit/fishing/fishing-operations/fishing-gear",
-      "text": "Is the purpose of the deposit to dispose of the gear?",
+      "text": "Is the purpose of the deposit to dispose of the fishing gear?",
       "section": "deposit",
       "answers": [
         {
@@ -5033,7 +4664,7 @@
     },
     {
       "route": "/exemption/deposit/dredged-material",
-      "text": "Will the activity be carried out by or on behalf of the harbour authority?",
+      "text": "Will a harbour authority or someone working for them carry out the activity?",
       "section": "deposit",
       "answers": [
         {
@@ -5050,39 +4681,39 @@
     },
     {
       "route": "/exemption/deposit/dredged-material/authorisation",
-      "text": "Is the activity authorised by",
+      "text": "Is the deposit authorised by any of the following?",
       "section": "deposit",
       "answers": [
         {
           "id": "localAct",
-          "text": "A local Act",
+          "text": "A local act",
           "nextQuestionRoute": "/exemption/deposit/dredged-material/method"
         },
         {
           "id": "harboursAct",
-          "text": "An order under Section 14 or 16 of the Harbours Act 1964",
+          "text": "An order under section 14 or 16 of the Harbours Act 1964",
           "nextQuestionRoute": "/exemption/deposit/dredged-material/method"
         },
         {
           "id": "section1HaNorthernIreland",
-          "text": "An order under Section 1 of the Harbours Act (Northern ireland) 1970",
+          "text": "An order under section 1 of the Harbours Act (Northern ireland) 1970",
           "nextQuestionRoute": "/exemption/deposit/dredged-material/method"
         },
         {
           "id": "section10HaNorthernIreland",
-          "text": "An order under Section 10(3) of the Harbours Act (Northern ireland) 1970",
+          "text": "An order under section 10(3) of the Harbours Act (Northern Ireland) 1970",
           "nextQuestionRoute": "/exemption/deposit/dredged-material/method"
         },
         {
           "id": "other",
-          "text": "None of the above",
-           "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
+          "text": "Not authorised by any of these",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/deposit/dredged-material/method",
-      "text": "Will the activity be carried out in accordance with the relevant authorisation?",
+      "text": "Will the activity be carried out in line with the conditions of the relevant authorisation?",
       "section": "deposit",
       "answers": [
         {
@@ -5099,9 +4730,9 @@
     },
     {
       "route": "/exemption/deposit/dredged-material/location",
-      "text": "Will the material be disposed of inside surface waters?",
+      "text": "Will the material be deposited or disposed of inside surface waters?",
       "section": "deposit",
-      "hint": "'Surface waters' is defined in Article 2 of the <a target=\"_blank\" href=\"https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32000L0060\">EU Waste Framework Directive (2000/60/EC)</a>.",
+      "hint": "This includes rivers, lakes, estuaries and coastal waters.",
       "answers": [
         {
           "id": "yes",
@@ -5117,7 +4748,7 @@
     },
     {
       "route": "/exemption/deposit/dredged-material/purpose",
-      "text": "What is the purpose of the project the disposal relates to?",
+      "text": "What is the purpose of the deposit or disposal?",
       "section": "deposit",
       "answers": [
         {
@@ -5142,15 +4773,15 @@
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/deposit/dredged-material/non-hazardous",
-      "text": "Can you demonstrate that the material to be deposited or disposed is non-hazardous?",
-      "hint": "The properties that determine if waste is 'hazardous' are set out in annex III <a target=\"_blank\" href=\"https://ec.europa.eu/environment/waste/framework/list.htm\">EU Waste Framework Directive (2008/98/EC)</a>.",
+      "text": "Can you demonstrate that the material to be deposited or disposed of is non-hazardous?",
+      "hint": "Hazardous waste includes material that is explosive, flammable, toxic or harmful to the environment or human health.",
       "section": "deposit",
       "answers": [
         {
@@ -5167,7 +4798,7 @@
     },
     {
       "route": "/exemption/deposit/emergency-safety-accident-investigation",
-      "text": "What does the deposit activity relate to?",
+      "text": "What does the emergency, safety or training activity involve?",
       "section": "deposit",
       "answers": [
         {
@@ -5182,17 +4813,17 @@
         },
         {
           "id": "coastguardActivities",
-          "text": "Coastguard activities - safety purposes and training",
+          "text": "Coastguard activities",
           "nextQuestionRoute": "/exemption/deposit/emergency-safety-accident-investigation/coastguard"
         },
         {
           "id": "flares",
-          "text": "Flares - Safety purposes and training",
+          "text": "Flares ",
           "nextQuestionRoute": "/exemption/deposit/emergency-safety-accident-investigation/flares"
         },
         {
           "id": "salvageOperation",
-          "text": "Salvage Operation",
+          "text": "Salvage operation",
           "nextQuestionRoute": "/exemption/deposit/emergency-safety-accident-investigation/salvage"
         },
         {
@@ -5207,15 +4838,14 @@
         },
         {
           "id": "other",
-          "text": "Other",
-          "outcomeRoute": "/exemption/deposit-exe-not-available-continue",
-          "hint": "Other deposit activities for purposes not set out above"
+          "text": "Something else",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/deposit/emergency-safety-accident-investigation/flood",
-      "text": "Will the activity be carried out by or on behalf of the Environment Agency?",
+      "text": "Will the Environment Agency carry out the activity?",
       "section": "deposit",
       "answers": [
         {
@@ -5232,7 +4862,7 @@
     },
     {
       "route": "/exemption/deposit/emergency-safety-accident-investigation/flood/emergency",
-      "text": "Are the circumstances serious, unexpected and potentially dangerous requiring immediate action in response to flood or imminent risk of flood?",
+      "text": "Is immediate action required due to flooding or an imminent risk of flooding?",
       "section": "deposit",
       "answers": [
         {
@@ -5249,8 +4879,7 @@
     },
     {
       "route": "/exemption/deposit/emergency-safety-accident-investigation/cables-pipelines",
-      "text": "Does the deposit activity relate to the inspection or repair of an existing cable or pipeline",
-      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities--2#cables-pipelines-oil-and-gas-and-carbon-capture-storage\"> cables and pipelines </a>.",
+      "text": "Does the activity involve the inspection or repair of an existing cable or pipeline?",
       "section": "deposit",
       "answers": [
         {
@@ -5267,7 +4896,7 @@
     },
     {
       "route": "/exemption/deposit/emergency-safety-accident-investigation/cables-pipelines/emergency",
-      "text": "Are the circumstances serious, unexpected and potentially dangerous requiring immediate action?",
+      "text": "Is immediate action required because the situation is serious, unexpected or dangerous?",
       "section": "deposit",
       "answers": [
         {
@@ -5284,8 +4913,8 @@
     },
     {
       "route": "/exemption/deposit/emergency-safety-accident-investigation/cables-pipelines/protection",
-      "text": "Will the activity proposed include the deposit of rock or other materials for the purpose of providing <u>new</U> pipeline protection?",
-      "hint": "Deposits for these purposes, i.e. those beyond the replenishment or replacement of materials within the three dimensional boundaries of those previously consented and deposited, will require a marine licence. If the maintenance, inspection or repair can be carried out without the need for new protection you are advised to adapt your proposed approach. <P><P>NOTE: If you intend to apply for a marine licence in respect of the addition of new or extended protection, where relevant, please select ‘No’ to continue.",
+      "text": "Does the activity involve depositing rock or other materials to provide new pipeline protection?",
+      "hint": "Only replacing material within the existing boundary is exempt. New or extended protection needs a marine licence.",
       "section": "deposit",
       "answers": [
         {
@@ -5319,7 +4948,7 @@
     },
     {
       "route": "/exemption/deposit/emergency-safety-accident-investigation/coastguard",
-      "text": "Will the activity be carried out by or on behalf the Secretary of State for Transport, acting through the Maritime and Coastguard Agency?",
+      "text": "Will the Maritime and Coastguard Agency or someone working for them carry out the activity?",
       "section": "deposit",
       "answers": [
         {
@@ -5341,30 +4970,29 @@
       "answers": [
         {
           "id": "securingVesselAircraftMarineStructureSafety",
-          "text": "Securing the safety of a vessel, aircraft or marine structure ",
-          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-32",
-          "hint": "'marine structure' means a platform or other artificial structure at 'Sea', other than a pipeline."
+          "text": "To secure the safety of a vessel, aircraft or marine structure",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-32"
         },
         {
           "id": "savingLife",
-          "text": "Saving life",
+          "text": "To save life",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-32"
         },
         {
           "id": "training",
-          "text": "Training for either of the above two purposes",
+          "text": "Training for safety or life saving",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-32"
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/deposit/emergency-safety-accident-investigation/flares",
-      "text": "Will the activity involve the deposit or use of a distress flare, smoke float or similar pyrotechnic substance or object",
+      "text": "Will the activity involve depositing or using distress flares, smoke floats or similar pyrotechnics?",
       "section": "deposit",
       "answers": [
         {
@@ -5386,30 +5014,29 @@
       "answers": [
         {
           "id": "securingVesselAircraftMarineStructureSafety",
-          "text": "Securing the safety of a vessel, aircraft or marine structure ",
-          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-33",
-          "hint": "'marine structure' means a platform or other artificial structure at 'Sea', other than a pipeline."
+          "text": "To secure the safety of a vessel, aircraft or marine structure",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-33"
         },
         {
           "id": "savingLife",
-          "text": "Saving life",
+          "text": "To save life",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-33"
         },
         {
           "id": "training",
-          "text": "Training for either of the above two purposes",
+          "text": "Training for safety or life saving",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-33"
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/deposit/emergency-safety-accident-investigation/salvage",
-      "text": "Will the deposit be made in the course of an official salvage operation for the purpose of ensuring the safety of a vessel or preventing pollution?",
+      "text": "Is the activity part of an official salvage operation to protect a vessel or prevent pollution?",
       "section": "deposit",
       "answers": [
         {
@@ -5426,27 +5053,27 @@
     },
     {
       "route": "/exemption/deposit/emergency-safety-accident-investigation/safety-directions",
-      "text": "What is the purpose of the deposit",
+      "text": "What is the purpose of the activity?",
       "section": "deposit",
       "answers": [
         {
           "id": "secretaryOfStateSchedule3A",
-          "text": "In exercise of a power under Schedule 3A to the Merchant Shipping Act 1995 (safety directions) by or on behalf of the Secretary of State",
+          "text": "Exercising a power under Schedule 3A of the Merchant Shipping Act (safety directions)",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-8"
         },
         {
           "id": "schedule3ACompliance",
-          "text": "Compliance with a direction under Schedule 3A to the Merchant Shipping Act 1995 (safety directions)",
+          "text": "Complying with a direction under Schedule 3A of the Merchant Shipping Act (safety directions)",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-8"
         },
         {
           "id": "avoidingInterference",
-          "text": "Avoiding interference with action taken under Schedule 3A to the Merchant Shipping Act 1995 (safety directions)",
+          "text": "Avoiding interference with a safety direction under Schedule 3A of the Merchant Shipping Act (safety directions)",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-8"
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
         }
       ]
@@ -5470,7 +5097,7 @@
     },
     {
       "route": "/exemption/deposit/emergency-safety-accident-investigation/air-accident-investigation",
-      "text": "Will the activity be carried out for the purpose of recovering a substance or object as part of an official investigation into an accident involving aircraft?",
+      "text": "Is the activity to recover a substance or object as part of an official aircraft accident investigation?",
       "section": "deposit",
       "answers": [
         {
@@ -5487,7 +5114,7 @@
     },
     {
       "route": "/exemption/deposit/pollution",
-      "text": "What does the deposit activity relate to?",
+      "text": "Is the deposit for pollution prevention or discharge of chemicals?",
       "section": "deposit",
       "answers": [
         {
@@ -5498,46 +5125,45 @@
         {
           "id": "dischargeOffshoreChemicalsOil",
           "text": "Discharge of offshore chemicals and oil",
-          "hint": "Activities authorised under the Offshore Chemical Regulations 2002 or the Offshore Petroleum Activities (Oil and Pollution Prevention and Control) Regulations 2005.",
           "nextQuestionRoute": "/exemption/deposit/pollution/offshore-chemical-oil"
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/deposit/pollution/pollution-prevention-treatment",
-      "text": "What does the deposit activity relate to?",
+      "text": "What does the pollution prevention or treatment involve?",
       "section": "deposit",
       "answers": [
         {
           "id": "equipmentContainControlRecoverOilsEtc",
-          "text": "Equipment to contain, control or recover oils etc",
+          "text": "Equipment to contain, control or recover oils ",
           "nextQuestionRoute": "/exemption/deposit/pollution/pollution-response-equipment"
         },
         {
           "id": "marineChemicalMarineOilTreatment",
-          "text": "Marine chemical and marine oil treatment substances",
+          "text": "Marine chemical and oil treatment substances",
           "nextQuestionRoute": "/exemption/deposit/pollution/chemical-oil-treatment"
         },
         {
           "id": "pollutionPreventionPart6MerchantShippingAct1995",
-          "text": "Activities within Part 6 of the Merchant Shipping Act 1995",
-          "nextQuestionRoute": "/exemption/deposit/pollution/pollution-prevention"
+          "text": "Activities within Part 6 of the Merchant Shipping Act 1995 (Prevention of Pollution)",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-7"
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/deposit/pollution/pollution-response-equipment",
-      "text": "Is the equipment to be deposited for the purpose of controlling, containing or recovering oil, a mixture containing oil, chemicals, flotsam or algae blooms?",
+      "text": "Is the equipment being deposited to control, contain or recover oil, chemicals, flotsam or algae blooms?",
       "section": "deposit",
       "answers": [
         {
@@ -5571,34 +5197,34 @@
     },
     {
       "route": "/exemption/deposit/pollution/chemical-oil-treatment",
-      "text": "What is the purpose of the deposit",
+      "text": "What is the purpose of the activity?",
       "section": "deposit",
       "answers": [
         {
           "id": "oilSpills",
-          "text": "Dispersing or treating oil spills",
+          "text": "\tTo disperse or treat an oil spill\n",
           "nextQuestionRoute": "/exemption/deposit/pollution/chemical-oil-treatment/approved"
         },
         {
           "id": "chemicalPollution",
-          "text": "Treat chemical pollution",
+          "text": "To treat chemical pollution",
           "nextQuestionRoute": "/exemption/deposit/pollution/chemical-oil-treatment/approved"
         },
         {
           "id": "seabedFouling",
-          "text": "Remove fouling matter from the surface of the 'Sea' or 'Seabed'",
+          "text": "To remove fouling matter from the surface of the sea or seabed",
           "nextQuestionRoute": "/exemption/deposit/pollution/chemical-oil-treatment/approved"
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/deposit/pollution/chemical-oil-treatment/approved",
-      "text": "Is the substance to be deposited one which is approved for the purposes by the MMO?",
+      "text": "Is the substance being deposited approved by the Marine Management Organisation (MMO)?",
       "section": "deposit",
       "answers": [
         {
@@ -5615,7 +5241,7 @@
     },
     {
       "route": "/exemption/deposit/pollution/chemical-oil-treatment/conditions",
-      "text": "Will the substance be used in accordance with conditions to which the approval is subject?",
+      "text": "Will the substance be used in line with the conditions of its approval?",
       "section": "deposit",
       "answers": [
         {
@@ -5666,8 +5292,7 @@
     },
     {
       "route": "/exemption/deposit/pollution/pollution-prevention",
-      "text": "Does the activity proposed to be carried out fall within the subject matter of Part 6 of the Merchant Shipping Act 1995 (prevention of pollution)?",
-      "hint": "Find out more about <a target=\"_blank\" href=\" http://www.legislation.gov.uk/ukpga/1995/21/part/VI\"> Part 6 of the Merchant Shipping Act 1995</a>",
+      "text": "Does the activity proposed to be carried out fall within the subject matter of Part 6 of the Merchant Shipping Act 1995 (Prevention of Pollution)?",
       "section": "deposit",
       "answers": [
         {
@@ -5684,7 +5309,7 @@
     },
     {
       "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation",
-      "text": "What does the deposit activity relate to?",
+      "text": "What will be deposited?",
       "section": "deposit",
       "answers": [
         {
@@ -5695,8 +5320,7 @@
         {
           "id": "mooringsAidsToNavigation",
           "text": "Moorings or aids to navigation",
-          "nextQuestionRoute": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/moorings",
-          "hint": "Activities carried out by or on behalf of Lighthouse and Harbour authorities only"
+          "nextQuestionRoute": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/moorings"
         },
         {
           "id": "marineSiteMarkers",
@@ -5710,7 +5334,7 @@
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
         }
       ]
@@ -5739,9 +5363,9 @@
     },
     {
       "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/temporary-markers24/obstruction",
-      "text": "Will the activity cause or be likely to cause an obstruction or danger to navigation?",
+      "text": "Is the activity likely to cause an obstruction or danger to navigation?",
       "section": "deposit",
-      "hint": " Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#navigational-risk\"> navigational risk </a> and the steps you can take to ensure your proposal is not one that will cause or be likely to cause and obstruction or danger.",
+      "hint": "<p>If you're unsure, you can check with the relevant harbour authority. If outside their jurisdiction, check with the <a target=\"_blank\" href=\"https://www.gov.uk/government/organisations/maritime-and-coastguard-agency\">Maritime and Coastguard Agency (opens in new tab)</a> or <a target=\"_blank\" href=\"https://www.trinityhouse.co.uk/\">Trinity House (opens in new tab)</a>.",
       "answers": [
         {
           "id": "yes",
@@ -5757,9 +5381,9 @@
     },
     {
       "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/temporary-markers24/mpa",
-      "text": "Will the activity take place in or within 200m of a Marine Protected Area (MPA)?",
+      "text": "Will any activity take place within 200m of a Marine Protected Area (MPA)?",
       "section": "deposit",
-   "hint": "<p>MPA's are an important part of the marine environment. </p><p>You are responsible for making sure you understand the status of the location where the activity is proposed. </p><p> ‘Marine protected areas’ mean:<ul><li>Highly Protected Marine Area (HPMA) (designated and candidate)</li><li>Marine Conservation Zones (MCZs) (designated and proposed)</li><li>Special Areas of Conservation (SACs) (designated and candidate)</li><li>Special Protection Areas (SPAs) (designated and potential)</li><li>Ramsar's</li><li>SSSIs</li></ul></p><p> If you are unsure of whether the activity falls within an MPA you should select the appropriate layer in the MMO’s <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\"> GIS tool </a> to check.",
+      "hint": "<p>MPAs are designated areas of the sea protected from harmful human activity. You are responsible for making sure you understand the status of the location where the activity is proposed.</p><p>Marine Protected Areas include:</p><ul class=\"govuk-list govuk-list--bullet\"><li>Highly Protected Marine Areas (HPMA)</li><li>Marine Conservation Zones (MCZs)</li><li>Special Areas of Conservation (SACs)</li><li>Special Protection Areas (SPAs)</li><li>Ramsar sites</li><li>Sites of Special Scientific Interest (SSSIs)</li></ul><p>If you're unsure of whether the activity is within 200m of an MPA, <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\">check the MMO self-service GIS tool (opens in new tab)</a>.</p>",
       "answers": [
         {
           "id": "yes",
@@ -5775,7 +5399,7 @@
     },
     {
       "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/temporary-markers24/mpa-management",
-      "text": "Is the activity directly connected with or necessary to the management of the Marine Protected Area?",
+      "text": "Is the activity necessary for managing the marine protected area?",
       "section": "deposit",
       "answers": [
         {
@@ -5792,40 +5416,36 @@
     },
     {
       "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/temporary-markers24/lse",
-      "text": "Is the activity....",
+      "text": "Is the activity likely to affect any of the following?",
       "section": "deposit",
-      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#marine-protected-areas\"> marine protected areas </a>.",
       "answers": [
         {
           "id": "europeanSiteTemporaryMarkers",
-          "text": "Likely to have a significant effect on a European site?",
-          "outcomeRoute": "/exemption/deposit-exe-not-available-continue",
-          "hint": "either alone or in combination with other plans and projects"
+          "text": "A European site",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
         },
         {
           "id": "ramsarSiteTemporaryMarkers",
-          "text": "Likely to have a significant effect on a Ramsar site?",
-          "outcomeRoute": "/exemption/deposit-exe-not-available-continue",
-          "hint": "either alone or in combination with other plans and projects"
+          "text": "A Ramsar site",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
         },
         {
           "id": "mczTemporaryMarkers",
-          "text": "Capable of affecting (other than insignificantly), the protected features of a Marine Conservation Zone or Highly Protected Marine Area?",
-          "outcomeRoute": "/exemption/deposit-exe-not-available-continue",
-          "hint": "including any ecological or geomorphological process on which the conservation of any protected feature of an MCZ or HPMA is (wholly or in Part) dependant"
+          "text": "The protected features of a marine conservation zone or highly protected marine area",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
         },
         {
           "id": "otherTemporaryMarkers",
-          "text": "Unlikely to have any relevant effect on any sites specified above?",
+          "text": "Unlikely to affect any of the listed sites",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-26a-no-notification"
         }
       ]
     },
     {
       "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/temporary-markers/obstruction",
-      "text": "Will the activity cause or be likely to cause an obstruction or danger to navigation?",
+      "text": "Is the activity likely to cause an obstruction or danger to navigation?",
       "section": "deposit",
-      "hint": " Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#navigational-risk\"> navigational risk </a> and the steps you can take to ensure your proposal is not one that will cause or be likely to cause and obstruction or danger.",
+      "hint": "<p>If you're unsure, you can check with the relevant harbour authority. If outside their jurisdiction, check with the <a target=\"_blank\" href=\"https://www.gov.uk/government/organisations/maritime-and-coastguard-agency\">Maritime and Coastguard Agency (opens in new tab)</a> or <a target=\"_blank\" href=\"https://www.trinityhouse.co.uk/\">Trinity House (opens in new tab)</a>.",
       "answers": [
         {
           "id": "yes",
@@ -5841,9 +5461,9 @@
     },
     {
       "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/temporary-markers/mpa",
-      "text": "Will the activity take place in or within 200m of a Marine Protected Area (MPA)?",
+      "text": "Will any activity take place within 200m of a Marine Protected Area (MPA)?",
       "section": "deposit",
-  "hint": "<p>MPA's are an important part of the marine environment. </p><p>You are responsible for making sure you understand the status of the location where the activity is proposed. </p><p> ‘Marine protected areas’ mean:<ul><li>Highly Protected Marine Area (HPMA) (designated and candidate)</li><li>Marine Conservation Zones (MCZs) (designated and proposed)</li><li>Special Areas of Conservation (SACs) (designated and candidate)</li><li>Special Protection Areas (SPAs) (designated and potential)</li><li>Ramsar's</li><li>SSSIs</li></ul></p><p> If you are unsure of whether the activity falls within an MPA you should select the appropriate layer in the MMO’s <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\"> GIS tool </a> to check.",
+      "hint": "<p>MPAs are designated areas of the sea protected from harmful human activity. You are responsible for making sure you understand the status of the location where the activity is proposed.</p><p>Marine Protected Areas include:</p><ul class=\"govuk-list govuk-list--bullet\"><li>Highly Protected Marine Areas (HPMA)</li><li>Marine Conservation Zones (MCZs)</li><li>Special Areas of Conservation (SACs)</li><li>Special Protection Areas (SPAs)</li><li>Ramsar sites</li><li>Sites of Special Scientific Interest (SSSIs)</li></ul><p>If you're unsure of whether the activity is within 200m of an MPA, <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\">check the MMO self-service GIS tool (opens in new tab)</a>.</p>",
       "answers": [
         {
           "id": "yes",
@@ -5859,7 +5479,7 @@
     },
     {
       "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/temporary-markers/mpa-management",
-      "text": "Is the activity directly connected with or necessary to the management of the Marine Protected Area?",
+      "text": "Is the activity necessary for managing the marine protected area?",
       "section": "deposit",
       "answers": [
         {
@@ -5876,31 +5496,27 @@
     },
     {
       "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/temporary-markers/lse",
-      "text": "Is the activity....",
+      "text": "Is the activity likely to affect any of the following?",
       "section": "deposit",
-      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#marine-protected-areas\"> marine protected areas </a>.",
       "answers": [
         {
           "id": "europeanSiteTemporaryMarkers",
-          "text": "Likely to have a significant effect on a European site?",
-          "outcomeRoute": "/exemption/deposit-exe-not-available-continue",
-          "hint": "either alone or in combination with other plans and projects"
+          "text": "A European site",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
         },
         {
           "id": "ramsarSiteTemporaryMarkers",
-          "text": "Likely to have a significant effect on a Ramsar site?",
-          "outcomeRoute": "/exemption/deposit-exe-not-available-continue",
-          "hint": "either alone or in combination with other plans and projects"
+          "text": "A Ramsar site",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
         },
         {
           "id": "mczTemporaryMarkers",
-          "text": "Capable of affecting (other than insignificantly), the protected features of a Marine Conservation Zone or Highly Protected Marine Area?",
-          "outcomeRoute": "/exemption/deposit-exe-not-available-continue",
-          "hint": "including any ecological or geomorphological process on which the conservation of any protected feature of an MCZ or HPMA is (wholly or in Part) dependant"
+          "text": "The protected features of a marine conservation zone or highly protected marine area",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
         },
         {
           "id": "otherTemporaryMarkers",
-          "text": "Unlikely to have any relevant effect on any sites specified above?",
+          "text": "Unlikely to affect any of the listed sites",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-26a"
         }
       ]
@@ -5934,12 +5550,12 @@
       "answers": [
         {
           "id": "marineSiteExistence",
-          "text": "Installing a marker to indicate the existence and extent of a European Marine Site",
+          "text": "Installing a marker to show the extent of a European marine site",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-26"
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
         }
       ]
@@ -5951,12 +5567,12 @@
       "answers": [
         {
           "id": "marineSiteExistence",
-          "text": "Installing a marker to indicate the existence and extent of a Marine Conservation Zone",
+          "text": "Installing a marker to show the extent of a marine conservation zone",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-26"
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
         }
       ]
@@ -6011,14 +5627,15 @@
         {
           "id": "someoneElse",
           "text": "Someone else",
-          "nextQuestionRoute": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/moorings/consent"
+          "nextQuestionRoute": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/moorings/consent",
+          "hint": "This could be you or any organisation not listed"
         }
       ]
     },
     {
       "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/moorings/consent",
-      "text": "Does the activity require consent (e.g. a licence) from a harbour authority under local legislation?",
-      "hint": "The permission or agreement of the authority does not constitute consent for these purposes.",
+      "text": "Will the activity take place in a harbour authority area?",
+      "hint": "<p>To find out if the activity falls within a harbour authority area, you can use the <a href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c&showLayers=Navigation\" target=\"_blank\">marine licensing interactive map (opens in new tab)</a>.",
       "section": "deposit",
       "answers": [
         {
@@ -6035,7 +5652,7 @@
     },
     {
       "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/moorings/approval",
-      "text": "Has consent been granted?",
+      "text": "Do you have harbour authority consent?",
       "section": "deposit",
       "answers": [
         {
@@ -6052,7 +5669,7 @@
     },
     {
       "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/pontoons",
-      "text": "Is the purpose of the activity to provide a pontoon?",
+      "text": "Is the purpose of the activity to deposit a pontoon?",
       "section": "deposit",
       "answers": [
         {
@@ -6069,25 +5686,25 @@
     },
     {
       "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/pontoons/undertaker",
-      "text": "Who will carry out the activity?",
+      "text": "Will a harbour authority or someone working for them carry out the activity?",
       "section": "deposit",
       "answers": [
         {
           "id": "harbourAuthority",
-          "text": "A harbour authority or someone on behalf of a harbour authority",
+          "text": "Yes",
           "nextQuestionRoute": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/pontoon/deck"
         },
         {
           "id": "someoneElse",
-          "text": "Someone else",
+          "text": "No",
           "nextQuestionRoute": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/pontoon/consent"
         }
       ]
     },
     {
       "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/pontoon/consent",
-      "text": "Does the activity require consent (e.g. a licence) from a harbour authority under local legislation?",
-      "hint": "The permission or agreement of the authority does not constitute consent for these purposes.",
+      "text": "Will the activity take place in a harbour authority area?",
+      "hint": "<p>To find out if the activity falls within a harbour authority area, you can use the <a href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c&showLayers=Navigation\" target=\"_blank\">marine licensing interactive map (opens in new tab)</a>.",
       "section": "deposit",
       "answers": [
         {
@@ -6104,7 +5721,7 @@
     },
     {
       "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/pontoon/approval",
-      "text": "Has consent been granted?",
+      "text": "Do you have harbour authority consent?",
       "section": "deposit",
       "answers": [
         {
@@ -6121,8 +5738,8 @@
     },
     {
       "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/pontoon/deck",
-      "text": "When complete will the deck of the pontoon be an area greater than 30m2?",
-            "hint": "NOTE: If the pontoon will be attached to one or more pontoons already in place the question refers to the total deck area of all pontoons combined.",
+      "text": "Will the pontoon deck be larger than 30 square metres when finished?",
+      "hint": "If attached to existing pontoons, this includes their total deck area.",
       "section": "deposit",
       "answers": [
         {
@@ -6139,9 +5756,9 @@
     },
     {
       "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/pontoon/quantity",
-      "text": "In the 6 months prior to the commencement of this activity will 10 or more pontoons have been constructed or deposited at the location?",
+      "text": "In the 6 months before the activity begins, will the harbour authority have built or approved more than 10 pontoons?",
       "section": "deposit",
-      "hint": "either by or on behalf of the harbour authority or with the consent required from and granted by the harbour authority",
+      "hint": "Check with the appropriate harbour authority if your're unsure.",
       "answers": [
         {
           "id": "yes",
@@ -6157,34 +5774,34 @@
     },
     {
       "route": "/exemption/deposit/markers-moorings-pontoons-aids-to-navigation/dive-trails",
-      "text": "Is the purpose of the activity to place or secure signage or other identifying markers relating to:",
+      "text": "Is the purpose of the activity to place or secure signs or other identifying markers for any of the following?",
       "section": "deposit",
       "answers": [
         {
           "id": "protectionWrecksAct",
-          "text": "a wreck within an area designated as a restricted area within the meaning of section 1 of the Protection of Wrecks Act 1973",
+          "text": "A wreck in a restricted area under the Protection of Wrecks Act 1973",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-31"
         },
         {
           "id": "monumentsArchaeologicalAreasAct",
-          "text": "a monument designated as a scheduled monument under section 1 of the Ancient Monuments and Archaeological Areas Act 1979",
+          "text": "A scheduled monument under the Ancient Monuments and Archaeological Areas Act 1979",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-31"
         },
         {
           "id": "protectionMilitaryRemainsAct",
-          "text": "an area designated as a controlled site under section 1(2)(b) of the Protection of Military Remains Act 1986",
+          "text": "A controlled site under the Protection of Military Remains Act 1986",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-31"
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/deposit/scientific-research",
-      "text": "What does the depsoit activity relate to?",
+      "text": "What will be deposited?",
       "section": "deposit",
       "answers": [
         {
@@ -6199,15 +5816,14 @@
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/deposit/scientific-research/scientific-equipment",
-      "text": "Is the object to be deposited a scientific instrument or equipment associated with such an instrument?",
-      "hint": "'Scientific instrument' means a specialist device or tool, designed to measure, record or analyse data for scientific purposes. ‘Associated equipment’ means equipment fundamental to the functioning or operation of the instrument itself.",
+      "text": "Is the object to be deposited a scientific instrument or associated equipment?",
       "section": "deposit",
       "answers": [
         {
@@ -6224,7 +5840,7 @@
     },
     {
       "route": "/exemption/deposit/scientific-research/scientific-equipment/survey",
-      "text": "Is the instrument or equipment to be deposited as part of a scientific experiment or survey?",
+      "text": "Will the scientific instrument or equipment be deposited for scientific research?",
       "section": "deposit",
       "answers": [
         {
@@ -6241,8 +5857,7 @@
     },
     {
       "route": "/exemption/deposit/scientific-research/scientific-equipment/tethered",
-      "text": "Will the scientific instrument or associated equipment to be deposited be tethered to the 'Seabed'?",
-      "hint": "'Tethered' means to fasten, fix or attach by any means to limit the instruments range of movement.<p><p>'Seabed' means the ground under the 'Sea' and anything resting on it such as a wreck. It includes the intertidal area of the sea or any river at such time as it is exposed temporarily at low tide.<p><p>'Sea' includes any area which is submerged at MHWS and the waters of every estuary, river or channel where the tide flows at MHWS tide up to the NTL. Even waters in areas which are closed permanently or intermittently by a lock or other artificial means against the regular action of the tide are included, where seawater flows into or out from the area, either continuously or from time to time.<p><p>Find out more about the MMO’s <a target=\"_blank\" href=\"https://www.gov.uk/guidance/marine-licensing-definitions#what-do-we-mean-by-the-sea\">jurisdiction</a>.",
+      "text": "Will the scientific instrument or equipment be tethered to the seabed?",
       "section": "deposit",
       "answers": [
         {
@@ -6259,9 +5874,9 @@
     },
     {
       "route": "/exemption/deposit/scientific-research/scientific-equipment/navigational-clearance",
-      "text": "Will the scientific instrument or associated equipment to be deposited reduce navigational clearance by more than 5% by reference to 'chart datum'?",
+      "text": "Will the scientific instrument or  equipment reduce navigational clearance by more than 5% based on chart datum?",
       "section": "deposit",
-      "hint": "'Chart Datum' is the plane below which all depths are published on a navigational chart. It is also the plane to which all tidal heights are referred, so by adding the tidal height to the charted depth, the true depth of water is determined. By international agreement Chart Datum is defined as a level so low that the tide will not frequently fall below it. In the United Kingdom, this level is normally approximately the level of Lowest Astronomical Tide.",
+      "hint": "Chart datum is the reference level used on navigational charts for measuring depths and tidal heights. It's usually set at the level of the lowest astronomical tide.",
       "answers": [
         {
           "id": "yes",
@@ -6277,9 +5892,9 @@
     },
     {
       "route": "/exemption/deposit/scientific-research/scientific-equipment/obstruction",
-      "text": "Will the activity cause or be likely to cause an obstruction or danger to navigation?",
+      "text": "Is the activity likely to cause an obstruction or danger to navigation?",
       "section": "deposit",
-      "hint": " Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#navigational-risk\"> navigational risk </a> and the steps you can take to ensure your proposal is not one that will cause or be likely to cause and obstruction or danger.",
+      "hint": "<p>If you're unsure, you can check with the relevant harbour authority. If outside their jurisdiction, check with the <a target=\"_blank\" href=\"https://www.gov.uk/government/organisations/maritime-and-coastguard-agency\">Maritime and Coastguard Agency (opens in new tab)</a> or <a target=\"_blank\" href=\"https://www.trinityhouse.co.uk/\">Trinity House (opens in new tab)</a>.",
       "answers": [
         {
           "id": "yes",
@@ -6295,9 +5910,9 @@
     },
     {
       "route": "/exemption/deposit/scientific-research/scientific-equipment/mpa",
-      "text": "Will the activity take place in or within 200m of a Marine Protected Area (MPA)?",
+      "text": "Will any activity take place within 200m of a Marine Protected Area (MPA)?",
       "section": "deposit",
-  "hint": "<p>MPA's are an important part of the marine environment. </p><p>You are responsible for making sure you understand the status of the location where the activity is proposed. </p><p> ‘Marine protected areas’ mean:<ul><li>Highly Protected Marine Area (HPMA) (designated and candidate)</li><li>Marine Conservation Zones (MCZs) (designated and proposed)</li><li>Special Areas of Conservation (SACs) (designated and candidate)</li><li>Special Protection Areas (SPAs) (designated and potential)</li><li>Ramsar's</li><li>SSSIs</li></ul></p><p> If you are unsure of whether the activity falls within an MPA you should select the appropriate layer in the MMO’s <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\"> GIS tool </a> to check.",
+      "hint": "<p>MPAs are designated areas of the sea protected from harmful human activity. You are responsible for making sure you understand the status of the location where the activity is proposed.</p><p>Marine Protected Areas include:</p><ul class=\"govuk-list govuk-list--bullet\"><li>Highly Protected Marine Areas (HPMA)</li><li>Marine Conservation Zones (MCZs)</li><li>Special Areas of Conservation (SACs)</li><li>Special Protection Areas (SPAs)</li><li>Ramsar sites</li><li>Sites of Special Scientific Interest (SSSIs)</li></ul><p>If you're unsure of whether the activity is within 200m of an MPA, <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\">check the MMO self-service GIS tool (opens in new tab)</a>.</p>",
       "answers": [
         {
           "id": "yes",
@@ -6313,7 +5928,7 @@
     },
     {
       "route": "/exemption/deposit/scientific-research/scientific-equipment/mpa-management",
-      "text": "Is the activity directly connected with or necessary to the management of the Marine Protected Area?",
+      "text": "Is the activity necessary for managing the marine protected area?",
       "section": "deposit",
       "answers": [
         {
@@ -6330,31 +5945,27 @@
     },
     {
       "route": "/exemption/deposit/scientific-research/scientific-equipment/lse",
-      "text": "Is the activity....",
+      "text": "Is the activity likely to affect any of the following?",
       "section": "deposit",
-      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#marine-protected-areas\"> marine protected areas </a>.",
       "answers": [
         {
           "id": "europeanSiteScientificEquipment",
-          "text": "Likely to have a significant effect on a European site?",
-          "outcomeRoute": "/exemption/deposit-exe-not-available-continue",
-          "hint": "either alone or in combination with other plans and projects"
+          "text": "A European site",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
         },
         {
           "id": "ramsarSiteScientificEquipment",
-          "text": "Likely to have a significant effect on a Ramsar site?",
-          "outcomeRoute": "/exemption/deposit-exe-not-available-continue",
-          "hint": "either alone or in combination with other plans and projects"
+          "text": "A Ramsar site",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
         },
         {
           "id": "mczScientificEquipment",
-          "text": "Capable of affecting (other than insignificantly), the protected features of a Marine Conservation Zone or Highly Protected Marine Area?",
-          "outcomeRoute": "/exemption/deposit-exe-not-available-continue",
-          "hint": "including any ecological or geomorphological process on which the conservation of any protected feature of an MCZ or HPMA is (wholly or in Part) dependant"
+          "text": "The protected features of a marine conservation zone or highly protected marine area",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
         },
         {
           "id": "otherScientificEquipment",
-          "text": "Unlikely to have any relevant effect on any sites specified above",
+          "text": "Unlikely to affect any of the listed sites",
           "nextQuestionRoute": "/exemption/deposit/scientific-research/scientific-equipment/disposal"
         }
       ]
@@ -6378,7 +5989,7 @@
     },
     {
       "route": "/exemption/deposit/scientific-research/tracers-reagents",
-      "text": "Is the reagent or tracer approved for use by the MMO?",
+      "text": "Is the reagent or tracer approved for use by the Marine Management Organisation (MMO)?",
       "section": "deposit",
       "answers": [
         {
@@ -6395,9 +6006,9 @@
     },
     {
       "route": "/exemption/deposit/scientific-research/tracers-reagents/obstruction",
-      "text": "Will the activity cause or be likely to cause an obstruction or danger to navigation?",
+      "text": "Is the activity likely to cause an obstruction or danger to navigation?",
       "section": "deposit",
-      "hint": " Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#navigational-risk\"> navigational risk </a> and the steps you can take to ensure your proposal is not one that will cause or be likely to cause and obstruction or danger.",
+      "hint": "<p>If you're unsure, you can check with the relevant harbour authority. If outside their jurisdiction, check with the <a target=\"_blank\" href=\"https://www.gov.uk/government/organisations/maritime-and-coastguard-agency\">Maritime and Coastguard Agency (opens in new tab)</a> or <a target=\"_blank\" href=\"https://www.trinityhouse.co.uk/\">Trinity House (opens in new tab)</a>.",
       "answers": [
         {
           "id": "yes",
@@ -6413,9 +6024,9 @@
     },
     {
       "route": "/exemption/deposit/scientific-research/tracers-reagents/mpa",
-      "text": "Will the activity take place in or within 200m of a Marine Protected Area (MPA)?",
+      "text": "Will any activity take place within 200m of a Marine Protected Area (MPA)?",
       "section": "deposit",
-   "hint": "<p>MPA's are an important part of the marine environment. </p><p>You are responsible for making sure you understand the status of the location where the activity is proposed. </p><p> ‘Marine protected areas’ mean:<ul><li>Highly Protected Marine Area (HPMA) (designated and candidate)</li><li>Marine Conservation Zones (MCZs) (designated and proposed)</li><li>Special Areas of Conservation (SACs) (designated and candidate)</li><li>Special Protection Areas (SPAs) (designated and potential)</li><li>Ramsar's</li><li>SSSIs</li></ul></p><p> If you are unsure of whether the activity falls within an MPA you should select the appropriate layer in the MMO’s <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\"> GIS tool </a> to check.",
+      "hint": "<p>MPAs are designated areas of the sea protected from harmful human activity. You are responsible for making sure you understand the status of the location where the activity is proposed.</p><p>Marine Protected Areas include:</p><ul class=\"govuk-list govuk-list--bullet\"><li>Highly Protected Marine Areas (HPMA)</li><li>Marine Conservation Zones (MCZs)</li><li>Special Areas of Conservation (SACs)</li><li>Special Protection Areas (SPAs)</li><li>Ramsar sites</li><li>Sites of Special Scientific Interest (SSSIs)</li></ul><p>If you're unsure of whether the activity is within 200m of an MPA, <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\">check the MMO self-service GIS tool (opens in new tab)</a>.</p>",
       "answers": [
         {
           "id": "yes",
@@ -6431,7 +6042,7 @@
     },
     {
       "route": "/exemption/deposit/scientific-research/tracers-reagents/mpa-management",
-      "text": "Is the activity directly connected with or necessary to the management of the Marine Protected Area?",
+      "text": "Is the activity necessary for managing the marine protected area?",
       "section": "deposit",
       "answers": [
         {
@@ -6448,31 +6059,27 @@
     },
     {
       "route": "/exemption/deposit/scientific-research/tracers-reagents/lse",
-      "text": "Is the activity....",
+      "text": "Is the activity likely to affect any of the following?",
       "section": "deposit",
-      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#marine-protected-areas\"> marine protected areas </a>.",
       "answers": [
         {
           "id": "europeanSiteTracers",
-          "text": "Likely to have a significant effect on a European site",
-          "outcomeRoute": "/exemption/deposit-exe-not-available-continue",
-          "hint": "either alone or in combination with other plans and projects"
+          "text": "A European site",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
         },
         {
           "id": "ramsarSiteTracers",
-          "text": "Likely to have a significant effect on a Ramsar site?",
-          "outcomeRoute": "/exemption/deposit-exe-not-available-continue",
-          "hint": "either alone or in combination with other plans and projects"
+          "text": "A Ramsar site",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
         },
         {
           "id": "mczTracers",
-          "text": "Capable of affecting (other than insignificantly), the protected features of a Marine Conservation Zone or Highly Protected Marine Area?",
-          "outcomeRoute": "/exemption/deposit-exe-not-available-continue",
-          "hint": "including any ecological or geomorphological process on which the conservation of any protected feature of an MCZ or HPMA is (wholly or in Part) dependant"
+          "text": "The protected features of a marine conservation zone or highly protected marine area",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
         },
         {
           "id": "otherTracers",
-          "text": "Unlikely to have any relevant effect on any sites specified above",
+          "text": "Unlikely to affect any of the listed sites",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-17"
         }
       ]
@@ -6484,7 +6091,7 @@
       "answers": [
         {
           "id": "launchingVessels",
-          "text": "Launching of vessels etc",
+          "text": "Launching of vessels",
           "nextQuestionRoute": "/exemption/deposit/vessels/launch"
         },
         {
@@ -6509,16 +6116,15 @@
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/deposit/vessels/launch",
-      "text": "Is the purpose of the deposit to facilitate the launching of a vehicle, vessel, aircraft, marine structure or floating container?",
+      "text": "Is the purpose of the deposit to launch a vehicle, vessel, aircraft, marine structure or floating container?",
       "section": "deposit",
-      "hint": "'marine structure' means a platform or other artificial structure at 'Sea', other than a pipeline.",
       "answers": [
         {
           "id": "yes",
@@ -6568,40 +6174,39 @@
     },
     {
       "route": "/exemption/deposit/vessels/hull-cleaning/method",
-      "text": "What method will be used to clean the hull?",
+      "text": "How will the hull be cleaned?",
       "section": "deposit",
       "answers": [
         {
           "id": "cloth",
-          "text": "By hand using a soft cloth",
+          "text": "By hand with a soft cloth",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-27A"
         },
         {
           "id": "sponge",
-          "text": "By hand using a sponge",
+          "text": "By hand with a sponge",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-27A"
         },
         {
           "id": "softBrush",
-          "text": "By hand using the bristles of a soft brush",
+          "text": "By hand with a soft-bristled brush",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-27A"
         },
         {
           "id": "sandpaper",
-          "text": "By hand using sandpaper with a grit size of at least P2000",
+          "text": "By hand using sandpaper of at least P2000 grit size",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-27A"
         },
         {
           "id": "other",
-          "text": "Other",
-          "outcomeRoute": "/exemption/deposit-exe-not-available-continue",
-          "hint": "ISO 6344-3:2013 sets standards for the determination of grain size distribution in relation to coated abrasives."
+          "text": "Another way",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/deposit/vessels/navigation",
-      "text": "Will the deposit be made from a vehicle, vessel, aircraft or marine structure in the normal course of its maintenance or navigation?",
+      "text": "Will the deposit be made from a vehicle, vessel, aircraft or marine structure as part of its normal maintenance or navigation?",
       "section": "deposit",
       "answers": [
         {
@@ -6652,7 +6257,7 @@
     },
     {
       "route": "/exemption/deposit/vessels/aggregate-dredging",
-      "text": "Was the substance or object to be deposited taken from the 'Sea' in the course of dredging for aggregates?",
+      "text": "Was the substance or object to be deposited taken from the sea in the course of dredging for aggregates?",
       "section": "deposit",
       "answers": [
         {
@@ -6691,7 +6296,7 @@
     },
     {
       "route": "/exemption/deposit/vessels/aggregate-dredging/water-location",
-      "text": "Will the water be deposited by overflow or pumped discharge from the hold of the vessel at the site of dredging, either during or following its completion, and or on the return journey of the vessel?",
+      "text": "Will water from the vessel's hold be discharged during or after dredging, or on the return journey?",
       "section": "deposit",
       "answers": [
         {
@@ -6723,11 +6328,11 @@
         }
       ]
     },
- {
+    {
       "route": "/exemption/deposit/vessels/dismantling-ships",
       "text": "Will the deposit be made as part of the dismantling of a ship that is waste?",
       "section": "deposit",
-      "hint": "'Ship' is intended to refer to large commercial or flag bearing vessels, the dismantling of which is regulated under alternative relevant legislation. It does <u>not</u> include ‘houseboats’. <p><p>'Waste' is defined in Article 3 of the EU Waste Framework Directive (2008/98/EC) as 'any substance or object which the holder discards or intends or is required to discard'.<p><p> Please refer to the <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/waste-classification-technical-guidance\">Technical guidance WM3</a> on Waste classification. <p><p>If there is any doubt about whether the vessel you intend to dismantle is a ship you should seek advice from the marine licensing team.",
+      "hint": "<p>A ship means a large commercial or flag-bearing vessel. It does not include houseboats. Dismantling these types of ships is covered by separate legislation.\n\n<p>Waste means any substance or object that the holder discards, intends to discard or is required to discard, as defined in the EU Waste Framework Directive (2008/98/EC).\n\n<p>For more information read the <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/waste-classification-technical-guidance\">technical guidance on waste classification (opens in new tab)</a>.\n",
       "answers": [
         {
           "id": "yes",
@@ -6754,7 +6359,7 @@
         {
           "id": "no",
           "text": "No",
-         "nextQuestionRoute": "/exemption/deposit/vessels/dismantling-ships/explosives"
+          "nextQuestionRoute": "/exemption/deposit/vessels/dismantling-ships/explosives"
         }
       ]
     },
@@ -6794,23 +6399,23 @@
     },
     {
       "route": "/exemption/deposit/vessels/foreign-vessels/undertaker",
-      "text": "Will the activity be carried out by or in relation to",
+      "text": "Is the activity being carried out by or connected to any of the following?",
       "section": "deposit",
       "answers": [
         {
           "id": "thirdCountry",
           "text": "A third country vessel",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-37",
-          "hint": "Third country vessel” means a vessel which is flying the flag of, or is registered in, any State or territory (other than Gibraltar) which is not a member State and is not registered in a member State."
+          "hint": "A third country vessel is one registered in or flying the flag of a country outside the UK"
         },
         {
           "id": "warship",
-          "text": "A warship, naval auxiliary, other vessel or aircraft owned or operated by a state and used, for the time being, only on government non-commercial service (whether or not the warship, naval auxiliary, other vessel is a third country vessel)",
+          "text": "A warship, naval auxiliary, or other state-owned vessel or aircraft used only for non-commercial government service",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-37"
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
         }
       ]
@@ -6820,11 +6425,10 @@
       "text": "What does the deposit activity relate to?",
       "section": "deposit",
       "answers": [
-          {
+        {
           "id": "vessels",
           "text": "Vessels",
-          "nextQuestionRoute": "/exemption/deposit/vessels",
-          "hint": "Launching of a vessel, exercising rights of foreign vessels, normal navigation, aggregate or mineral dredging and dismantling of ships"
+          "nextQuestionRoute": "/exemption/deposit/vessels"
         },
         {
           "id": "defenceActivities",
@@ -6848,15 +6452,14 @@
         },
         {
           "id": "other",
-          "text": "Other",
-          "outcomeRoute": "/exemption/deposit-exe-not-available-continue",
-          "hint": "Other deposit activities for purposes not set out above"
+          "text": "Something else",
+          "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/deposit/miscellaneous/defence-activities",
-      "text": "Who will carry out the activity?",
+      "text": "Who will carry out the deposit?",
       "section": "deposit",
       "answers": [
         {
@@ -6905,36 +6508,36 @@
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/deposit/miscellaneous/deepsea-mining",
-      "text": "Is the activity carried out?",
+      "text": "What is the purpose of the deep sea mining?",
       "section": "deposit",
       "answers": [
         {
           "id": "explorationExploitationLicence",
-          "text": "In pursuance of an exploration or exploitation licence issued under the Deep Sea Mining (Temporary Provision) Act 1981",
+          "text": "To get an exploration or exploitation licence under the Deep Sea Mining (Temporary Provision) Act 1981",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-30"
         },
         {
           "id": "reciprocalauthorisation",
-          "text": "In pursuance of a reciprocal authorisation within the meaning given by section 3(3) of the Deep Sea Mining (Temporary Provision) Act 1981",
+          "text": "To get reciprocal authorisation under section 3(3) of the Deep Sea Mining (Temporary Provision) Act 1981",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-30"
         },
         {
           "id": "other",
-          "text": "for another reason",
+          "text": "Something else",
           "outcomeRoute": "/exemption/deposit-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/deposit/miscellaneous/crossrail-act",
-      "text": "Will the activity be carried out within the limits of deviation for scheduled works in exercise of powers conferred by the Crossrail Act 2008 in relation to those works or any work connected with them?",
+      "text": "Will the activity take place within the limits of deviation for scheduled Crossrail works or any connected works under the Crossrail Act 2008?",
       "section": "deposit",
       "answers": [
         {
@@ -6951,18 +6554,18 @@
     },
     {
       "route": "/exemption/removal/activity-type",
-      "text": "What does the removal activity relate to?",
+      "text": "What does the removal activity involve?",
       "section": "removal",
       "mcmsAppFormMapping": "EXE_ACTIVITY_SUBTYPE_REMOVAL",
       "answers": [
         {
           "id": "fishing",
-          "text": "Fishing and shellfish propogation and cultivation",
+          "text": "Fishing or shellfish propagation and cultivation",
           "nextQuestionRoute": "/exemption/removal/fishing"
         },
         {
           "id": "markersMooringsAndAidToNavigation",
-          "text": "Markers, moorings and aids to navigation",
+          "text": "Markers, moorings or aids to navigation",
           "nextQuestionRoute": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation"
         },
         {
@@ -6972,42 +6575,39 @@
         },
         {
           "id": "scientificResearch",
-          "text": "Scientific investigation or research",
-          "nextQuestionRoute": "/exemption/removal/scientific-research",
-          "hint": "Scientific instruments and associated equipment, samples for testing and analysis"
+          "text": "Scientific research",
+          "nextQuestionRoute": "/exemption/removal/scientific-research"
         },
         {
           "id": "maintenance",
-          "text": "Maintenance of existing strucutres or assets",
-          "nextQuestionRoute": "/exemption/removal/maintenance",
-          "hint":"'Maintenance' means the upkeep or repair of an existing structure or asset wholly within its existing 3 dimensional boundaries"
+          "text": "Maintenance of existing structures or assets",
+          "nextQuestionRoute": "/exemption/removal/maintenance"
         },
         {
           "id": "waste",
-          "text": "Litter and Dead animals",
+          "text": "Litter or dead animals",
           "nextQuestionRoute": "/exemption/removal/waste"
         },
         {
           "id": "ObstructionsDanger",
-          "text": "Obstructions, danger to navigation and accidental deposits",
+          "text": "Obstructions, danger to navigation, or accidental deposits",
           "nextQuestionRoute": "/exemption/removal/obstruction"
         },
         {
           "id": "emergency",
-          "text": "Emergency, safety and training",
+          "text": "Emergency or safety and training",
           "nextQuestionRoute": "/exemption/removal/emergency-safety-pollution-response-accident-investigation"
         },
         {
           "id": "miscellaneous",
-          "text": "Other",
-          "nextQuestionRoute": "/exemption/removal/miscellaneous",
-          "hint": "Removal activities for purposes not set out above"
+          "text": "Something else",
+          "nextQuestionRoute": "/exemption/removal/miscellaneous"
         }
       ]
     },
     {
       "route": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation",
-      "text": "What does the removal activity relate to?",
+      "text": "What will be removed?",
       "section": "removal",
       "answers": [
         {
@@ -7017,9 +6617,8 @@
         },
         {
           "id": "mooringsAidsToNavigation",
-          "text": "Moorings and aids to navigation",
-          "nextQuestionRoute": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/moorings",
-          "hint": "Activities carried out by or on behalf of Lighthouse and Harbour authorities only"
+          "text": "Moorings or aids to navigation",
+          "nextQuestionRoute": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/moorings"
         },
         {
           "id": "marineSiteMarkers",
@@ -7033,7 +6632,7 @@
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         }
       ]
@@ -7045,17 +6644,17 @@
       "answers": [
         {
           "id": "markerLess24Hours",
-          "text": "The removal of a marker and its appurtenances that has been in place for less than 24 hours",
+          "text": "Removal of a marker that has been in place for less than 24 hours",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-26a-no-notification"
         },
         {
           "id": "markerLess28Days",
-          "text": "The removal of a marker and its appurtenances that has been in place for longer than 24 hours but less than 28 days and for which notification of the intention to carry out the activity under article 26A has previously been given to the MMO",
+          "text": "Removal of a marker that has been in place for 24 hours to 28 days where the Marine Management Organisation was already notified",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-26a"
         },
         {
           "id": "markerGreater28Days",
-          "text": "The removal of a marker and its appurtenances that has been in place for longer than than 28 days",
+          "text": "Removal of a marker that has been in place for more than 28 days",
           "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         }
       ]
@@ -7089,12 +6688,12 @@
       "answers": [
         {
           "id": "marineSiteExistence",
-          "text": "Removal of a marker installed to indicate the existence and extent of a European Marine Site",
+          "text": "Removal of a marker showing the extent of a European marine site",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-26"
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         }
       ]
@@ -7106,12 +6705,12 @@
       "answers": [
         {
           "id": "marineSiteExistence",
-          "text": "Removal of a marker installed to indicate the existence and extent of a Marine Conservation Zone",
+          "text": "Removal of a marker showing the extent of a marine conservation zone",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-26"
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         }
       ]
@@ -7133,12 +6732,12 @@
         },
         {
           "id": "trotMooring",
-          "text": "Trot Mooring",
+          "text": "Trot mooring",
           "nextQuestionRoute": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/moorings/undertaker"
         },
         {
           "id": "aidToNavigation",
-          "text": "Aid to Navigation",
+          "text": "Aid to navigation",
           "nextQuestionRoute": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/moorings/undertaker"
         },
         {
@@ -7155,12 +6754,12 @@
       "answers": [
         {
           "id": "harbourAuthority",
-          "text": "A harbour authority or someone on behalf of a harbour authority",
+          "text": "A harbour authority or someone working for them",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-25"
         },
         {
           "id": "lighthouseAuthority",
-          "text": "A lighthouse authority or someone on behalf of a lighthouse authority",
+          "text": "A lighthouse authority or someone working for them",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-25"
         },
         {
@@ -7172,8 +6771,8 @@
     },
     {
       "route": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/moorings/consent",
-      "text": "Does the activity require consent (e.g. a licence) from a harbour authority under local legislation?",
-      "hint": "The permission or agreement of the authority does not constitute consent for these purposes.",
+      "text": "Will the activity take place in a harbour authority area?",
+      "hint": "<p>To find out if the activity falls within a harbour authority area, you can use the <a href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c&showLayers=Navigation\" target=\"_blank\">marine licensing interactive map (opens in new tab)</a>.",
       "section": "removal",
       "answers": [
         {
@@ -7190,7 +6789,7 @@
     },
     {
       "route": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/moorings/approval",
-      "text": "Has consent been granted?",
+      "text": "Do you have harbour authority consent?",
       "section": "removal",
       "answers": [
         {
@@ -7229,7 +6828,7 @@
       "answers": [
         {
           "id": "harbourAuthority",
-          "text": "A harbour authority or someone on behalf of a harbour authority",
+          "text": "A harbour authority or someone working for them",
           "nextQuestionRoute": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/pontoon/deck"
         },
         {
@@ -7241,8 +6840,8 @@
     },
     {
       "route": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/pontoon/consent",
-      "text": "Does the activity require consent (e.g. a licence) from a harbour authority under local legislation?",
-      "hint": "The permission or agreement of the authority does not constitute consent for these purposes.",
+      "text": "Will the activity take place in a harbour authority area?",
+      "hint": "<p>To find out if the activity falls within a harbour authority area, you can use the <a href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c&showLayers=Navigation\" target=\"_blank\">marine licensing interactive map (opens in new tab)</a>.",
       "section": "removal",
       "answers": [
         {
@@ -7259,7 +6858,7 @@
     },
     {
       "route": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/pontoon/approval",
-      "text": "Has consent been granted?",
+      "text": "Do you have harbour authority consent to remove a pontoon?",
       "section": "removal",
       "answers": [
         {
@@ -7276,8 +6875,8 @@
     },
     {
       "route": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/pontoon/deck",
-      "text": "When complete will the deck of the pontoon be an area greater than 30m2?",
-            "hint": "NOTE: If the pontoon will be attached to one or more pontoons already in place the question refers to the total deck area of all pontoons combined.",
+      "text": "Will the pontoon deck be larger than 30 square metres when finished?",
+      "hint": "If attached to existing pontoons, this includes their total deck area.",
       "section": "removal",
       "answers": [
         {
@@ -7294,34 +6893,34 @@
     },
     {
       "route": "/exemption/removal/markers-moorings-pontoons-aids-to-navigation/dive-trails",
-      "text": "Is the purpose of the activity to remove signage or other identifying markers relating:",
+      "text": "Is the activity to remove signage or markers from any of the following?",
       "section": "removal",
       "answers": [
         {
           "id": "protectionWrecksAct",
-          "text": "a wreck within an area designated as a restricted area within the meaning of section 1 of the Protection of Wrecks Act 1973",
+          "text": "A wreck in a restricted area under the Protection of Wrecks Act 1973",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-31"
         },
         {
           "id": "monumentsArchaeologicalAreasAct",
-          "text": "a monument designated as a scheduled monument under section 1 of the Ancient Monuments and Archaeological Areas Act 1979",
+          "text": "A scheduled monument under the Ancient Monuments and Archaeological Areas Act 1979",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-31"
         },
         {
           "id": "protectionMilitaryRemainsAct",
-          "text": "an area designated as a controlled site under section 1(2)(b) of the Protection of Military Remains Act 1986",
+          "text": "A controlled site under the Protection of Military Remains Act 1986",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-31"
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/removal/scientific-research",
-      "text": "What does the removal activity relate to?",
+      "text": "What will be removed?",
       "section": "removal",
       "answers": [
         {
@@ -7336,15 +6935,14 @@
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/removal/scientific-research/scientific-equipment",
-      "text": "Is the object to be removed a scientific instrument or equipment associated with such an instrument?",
-      "hint": "'Scientific instrument' means a specialist device or tool, designed to measure, record or analyse data for scientific purposes. ‘Associated equipment’ means equipment fundamental to the functioning or operation of the instrument itself.",
+      "text": "Is the object a scientific instrument or associated equipment?",
       "section": "removal",
       "answers": [
         {
@@ -7361,7 +6959,7 @@
     },
     {
       "route": "/exemption/removal/scientific-research/scientific-equipment/survey",
-      "text": "Was the instrument or associated equipment originally deposited as part of a scientific experiment or survey?",
+      "text": "Was the instrument or equipment originally deposited for scientific research?",
       "section": "removal",
       "answers": [
         {
@@ -7378,9 +6976,9 @@
     },
     {
       "route": "/exemption/removal/scientific-research/scientific-equipment/mpa",
-      "text": "Will the activity take place in or within 200m of a Marine Protected Area (MPA)?",
+      "text": "Will the activity take place within 200 metres of a marine protected area (MPA)?",
       "section": "removal",
-  "hint": "<p>MPA's are an important part of the marine environment. </p><p>You are responsible for making sure you understand the status of the location where the activity is proposed. </p><p> ‘Marine protected areas’ mean:<ul><li>Highly Protected Marine Area (HPMA) (designated and candidate)</li><li>Marine Conservation Zones (MCZs) (designated and proposed)</li><li>Special Areas of Conservation (SACs) (designated and candidate)</li><li>Special Protection Areas (SPAs) (designated and potential)</li><li>Ramsar's</li><li>SSSIs</li></ul></p><p> If you are unsure of whether the activity falls within an MPA you should select the appropriate layer in the MMO’s <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\"> GIS tool </a> to check.",
+      "hint": "<p>MPAs are designated areas of the sea protected from harmful human activity. Any activity within 200 metres of an MPA may need a marine licence.\n\n<p>To find out if the activity falls within 200 metres of an MPA, you can use the <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c&showLayers=Marine%20Protected%20Areas\">marine licensing interactive map (opens in new tab)</a>.",
       "answers": [
         {
           "id": "yes",
@@ -7396,7 +6994,7 @@
     },
     {
       "route": "/exemption/removal/scientific-research/scientific-equipment/mpa-management",
-      "text": "Is the activity directly connected with or necessary to the management of the Marine Protected Area?",
+      "text": "Is the activity necessary for managing the marine protected area?",
       "section": "removal",
       "answers": [
         {
@@ -7413,38 +7011,34 @@
     },
     {
       "route": "/exemption/removal/scientific-research/scientific-equipment/lse",
-      "text": "Is the activity....",
+      "text": "Is the activity likely to affect any of the following?",
       "section": "removal",
-      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#marine-protected-areas\"> marine protected areas </a>.",
       "answers": [
         {
           "id": "europeanSiteScientificEquipment",
-          "text": "Likely to have a significant effect on a European site?",
-          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
-          "hint": "either alone or in combination with other plans and projects"
+          "text": "A European site",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         },
         {
           "id": "ramsarSiteScientificEquipment",
-          "text": "Likely to have a significant effect on a Ramsar site?",
-          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
-          "hint": "either alone or in combination with other plans and projects"
+          "text": "A Ramsar site",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         },
         {
           "id": "mczScientificEquipment",
-          "text": "Capable of affecting (other than insignificantly), the protected features of a Marine Conservation Zone or Highly Protected Marine Area?",
-          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
-          "hint": "including any ecological or geomorphological process on which the conservation of any protected feature of an MCZ or HPMA is (wholly or in Part) dependant"
+          "text": "The protected features of a marine conservation zone or highly protected marine area",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         },
         {
           "id": "otherScientificEquipment",
-          "text": "Unlikely to have any relevant effect on any sites specified above",
+          "text": "Unlikely to affect any of the listed sites",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-17"
         }
       ]
     },
     {
       "route": "/exemption/removal/scientific-research/samples",
-      "text": "Is the purpose of the activity to take a sample of material for testing or analysis?",
+      "text": "Is the purpose to take a sample for testing or analysis?",
       "section": "removal",
       "answers": [
         {
@@ -7461,7 +7055,7 @@
     },
     {
       "route": "/exemption/removal/scientific-research/samples/volume",
-      "text": "Will the sample to be collected be of a volume of 1m3 or less?",
+      "text": "Will each sample have a volume of 1 cubic metre or less?",
       "section": "removal",
       "answers": [
         {
@@ -7478,9 +7072,9 @@
     },
     {
       "route": "/exemption/removal/scientific-research/samples/obstruction",
-      "text": "Will the activity cause or be likely to cause an obstruction or danger to navigation?",
+      "text": "Is the activity likely to cause an obstruction or danger to navigation?",
       "section": "removal",
-      "hint": " Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#navigational-risk\"> navigational risk </a> and the steps you can take to ensure your proposal is not one that will cause or be likely to cause and obstruction or danger.",
+      "hint": "<p>If you're unsure, you can check with the relevant harbour authority. If outside their jurisdiction, check with the <a target=\"_blank\" href=\"https://www.gov.uk/government/organisations/maritime-and-coastguard-agency\">Maritime and Coastguard Agency (opens in new tab)</a> or <a target=\"_blank\" href=\"https://www.trinityhouse.co.uk/\">Trinity House (opens in new tab)</a>.",
       "answers": [
         {
           "id": "yes",
@@ -7496,9 +7090,9 @@
     },
     {
       "route": "/exemption/removal/scientific-research/samples/mpa",
-      "text": "Will the activity take place in or within 200m of a Marine Protected Area (MPA)?",
+      "text": "Will any activity take place within 200m of a Marine Protected Area (MPA)?",
       "section": "removal",
-  "hint": "<p>MPA's are an important part of the marine environment. </p><p>You are responsible for making sure you understand the status of the location where the activity is proposed. </p><p> ‘Marine protected areas’ mean:<ul><li>Highly Protected Marine Area (HPMA) (designated and candidate)</li><li>Marine Conservation Zones (MCZs) (designated and proposed)</li><li>Special Areas of Conservation (SACs) (designated and candidate)</li><li>Special Protection Areas (SPAs) (designated and potential)</li><li>Ramsar's</li><li>SSSIs</li></ul></p><p> If you are unsure of whether the activity falls within an MPA you should select the appropriate layer in the MMO’s <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\"> GIS tool </a> to check.",
+      "hint": "<p>MPAs are designated areas of the sea protected from harmful human activity. You are responsible for making sure you understand the status of the location where the activity is proposed.</p><p>Marine Protected Areas include:</p><ul class=\"govuk-list govuk-list--bullet\"><li>Highly Protected Marine Areas (HPMA)</li><li>Marine Conservation Zones (MCZs)</li><li>Special Areas of Conservation (SACs)</li><li>Special Protection Areas (SPAs)</li><li>Ramsar sites</li><li>Sites of Special Scientific Interest (SSSIs)</li></ul><p>If you're unsure of whether the activity is within 200m of an MPA, <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\">check the MMO self-service GIS tool (opens in new tab)</a>.</p>",
       "answers": [
         {
           "id": "yes",
@@ -7514,7 +7108,7 @@
     },
     {
       "route": "/exemption/removal/scientific-research/samples/mpa-management",
-      "text": "Is the activity directly connected with or necessary to the management of the Marine Protected Area?",
+      "text": "Is the activity necessary for managing the marine protected area?",
       "section": "removal",
       "answers": [
         {
@@ -7525,56 +7119,51 @@
         {
           "id": "no",
           "text": "No",
-          "nextQuestionRoute": "/exemption/removal/scientific-research/scientific-equipment/lse"
+          "nextQuestionRoute": "/exemption/removal/scientific-research/samples/lse"
         }
       ]
     },
     {
       "route": "/exemption/removal/scientific-research/samples/lse",
-      "text": "Is the activity....",
+      "text": "Is the activity likely to affect any of the following?",
       "section": "removal",
-      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#marine-protected-areas\"> marine protected areas </a>.",
       "answers": [
         {
           "id": "europeanSiteSamples",
-          "text": "Likely to have a significant effect on a European site?",
-          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
-          "hint": "either alone or in combination with other plans and projects"
+          "text": "A European site",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         },
         {
           "id": "ramsarSiteSamples",
-          "text": "Likely to have a significant effect on a Ramsar site?",
-          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
-          "hint": "either alone or in combination with other plans and projects"
+          "text": "A Ramsar site",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         },
         {
           "id": "mczSamples",
-          "text": "Capable of affecting (other than insignificantly), the protected features of a Marine Conservation Zone or Highly Protected Marine Area?",
-          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
-          "hint": "including any ecological or geomorphological process on which the conservation of any protected feature of an MCZ or HPMA is (wholly or in Part) dependant"
+          "text": "The protected features of a marine conservation zone or highly protected marine area",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         },
         {
           "id": "otherSamples",
-          "text": "Unlikely to have any relevant effect on any sites specified above",
+          "text": "Unlikely to affect any of the listed sites",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-17A"
         }
       ]
     },
     {
       "route": "/exemption/removal/maintenance",
-      "text": "What does the removal activity relate to?",
+      "text": "What will be maintained?",
       "section": "removal",
       "answers": [
         {
           "id": "coastalProtectionDrainageFloodDefence",
-          "text": "Maintenance of coast protection, drainage or flood defence works",
+          "text": "Coast protection, drainage or flood defence works",
           "nextQuestionRoute": "/exemption/removal/maintenance/coastal-drainage-flood"
         },
         {
           "id": "harbourWorkMaintenance",
-          "text": "Maintenance of harbour works",
-          "nextQuestionRoute": "/exemption/removal/maintenance/harbour-works",
-          "hint": "Maintenance carried out by or on behalf of harbour authorities only."
+          "text": "Harbour works",
+          "nextQuestionRoute": "/exemption/removal/maintenance/harbour-works"
         },
         {
           "id": "cablesPipelines",
@@ -7583,7 +7172,7 @@
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         }
       ]
@@ -7595,34 +7184,34 @@
       "answers": [
         {
           "id": "environmentAgency",
-          "text": "The Environment Agency or someone on behalf of the Environment Agency",
+          "text": "The Environment Agency or someone working for them",
           "nextQuestionRoute": "/exemption/removal/maintenance/coastal-drainage-flood/EA"
         },
         {
           "id": "coastProtectionAuthority",
-          "text": "The Coast Protection Authority or someone on behalf of the Coast Protection Authority",
+          "text": "The Coast Protection Authority or someone working for them",
           "nextQuestionRoute": "/exemption/removal/maintenance/coastal-drainage-flood/CPA"
         },
         {
           "id": "localAuthority",
-          "text": "The Local Authority or someone on behalf of the Local Authority",
+          "text": "The local authority or someone working for them",
           "nextQuestionRoute": "/exemption/removal/maintenance/coastal-drainage-flood/CPA"
         },
         {
           "id": "secretaryStateDefence",
-          "text": "The Secretary of State for Defence or someone on behalf of the Secretary of State for Defence",
+          "text": "The Secretary of State for Defence or someone working for them",
           "nextQuestionRoute": "/exemption/removal/maintenance/coastal-drainage-flood/CPA"
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Someone else",
           "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/removal/maintenance/coastal-drainage-flood/EA",
-      "text": "Will the activity be carried out wholly within the existing 3 dimensional boundary of the works being maintained?",
+      "text": "Will all the maintenance take place within the existing 3-dimensional boundary?",
       "section": "removal",
       "answers": [
         {
@@ -7639,7 +7228,7 @@
     },
     {
       "route": "/exemption/removal/maintenance/coastal-drainage-flood/EA/emergency-flood",
-      "text": "Are the circumstances serious, unexpected, and potentially dangerous requiring immediate action in response to either flooding or imminent risk of flooding?",
+      "text": "Is immediate action required because the situation is serious, unexpected or dangerous?",
       "section": "removal",
       "answers": [
         {
@@ -7656,8 +7245,8 @@
     },
     {
       "route": "/exemption/removal/maintenance/coastal-drainage-flood/CPA",
-      "text": "Is the activity for the purpose of maintaining coast protection works?",
-            "hint": "'Coast protection works' include: </li><li><u>beach re-profiling</U>, which involves the movement of beach material in a cross-shore direction up or down the beach; and </li><li><u>beach recycling</u>, which involves the movement of beach material along the beach from areas of accretion to areas of erosion within the beach or associated sediment system.",
+      "text": "Is the purpose of the activity to maintain coast protection works?",
+      "hint": "Coast protection works include beach re-profiling, which involves moving material up or down the beach. They also include beach recycling, which involves moving material along the beach to manage erosion.",
       "section": "removal",
       "answers": [
         {
@@ -7674,7 +7263,7 @@
     },
     {
       "route": "/exemption/removal/maintenance/harbour-works",
-      "text": "Is the activity for the purpose of maintaining harbour works?",
+      "text": "Is the purpose of the activity to maintain harbour works?",
       "section": "removal",
       "answers": [
         {
@@ -7691,7 +7280,7 @@
     },
     {
       "route": "/exemption/removal/maintenance/harbour-works/boundaries",
-      "text": "Will the activity be carried out within the 3 dimensional boundaries of the existing works?",
+      "text": "Will the activity be carried out within the 3-dimensional boundaries of the existing works?",
       "section": "removal",
       "answers": [
         {
@@ -7708,7 +7297,7 @@
     },
     {
       "route": "/exemption/removal/maintenance/harbour-works/undertaker",
-      "text": "Will the activity be carried out by or on behalf of the harbour authority?",
+      "text": "Will a harbour authority or someone working for them carry out the activity?",
       "section": "removal",
       "answers": [
         {
@@ -7726,7 +7315,6 @@
     {
       "route": "/exemption/removal/maintenance/cables-pipelines",
       "text": "Does the removal activity relate to the inspection or repair of an existing cable or pipeline?",
-      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities--2#cables-pipelines-oil-and-gas-and-carbon-capture-storage\"> cables and pipelines </a>.",
       "section": "removal",
       "answers": [
         {
@@ -7743,7 +7331,7 @@
     },
     {
       "route": "/exemption/removal/maintenance/cables-pipelines/emergency",
-      "text": "Are the circumstances serious, unexpected, and potentially dangerous requiring immediate action?",
+      "text": "Is immediate action required because the situation is serious, unexpected or dangerous?",
       "section": "removal",
       "answers": [
         {
@@ -7760,7 +7348,7 @@
     },
     {
       "route": "/exemption/removal/waste",
-      "text": "What does the removal activity relate to?",
+      "text": "What will be removed?",
       "section": "removal",
       "answers": [
         {
@@ -7770,32 +7358,31 @@
         },
         {
           "id": "marineLitter",
-          "text": "Marine litter (by divers)",
+          "text": "Marine litter left by divers",
           "nextQuestionRoute": "/exemption/removal/waste/marine-litter",
-          "hint": "'marine litter' means any persistent, manufactured or processed solid material discarded, disposed of or abandoned in the marine and coastal environment"
+          "hint": "Any persistent, manufactured or processed solid material discarded, disposed of or abandoned in the marine and coastal environment"
         },
         {
           "id": "litterSeaweed",
-          "text": "Litter and seaweed",
-          "nextQuestionRoute": "/exemption/removal/waste/litter-seaweed",
-          "hint": "by or on behalf of local authorities only"
+          "text": "Litter or seaweed",
+          "nextQuestionRoute": "/exemption/removal/waste/litter-seaweed"
         },
         {
           "id": "litterDebris",
           "text": "Marine litter and debris",
           "nextQuestionRoute": "/exemption/removal/waste/litter-debris",
-          "hint": "by or on behalf of a harbour authority only"
+          "hint": "Debris includes remains of something destroyed or unwanted material left scattered around"
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         }
       ]
     },
-        {
+    {
       "route": "/exemption/removal/obstruction",
-      "text": "What does the removal activity relate to?",
+      "text": "What will be removed?",
       "section": "removal",
       "answers": [
         {
@@ -7810,16 +7397,16 @@
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/removal/waste/dead-animals",
-      "text": "Will the activity involve the removal of a dead animal from a beach or intertidal area?",
+      "text": "Will the activity involve removing a dead animal from a beach or intertidal area?",
       "section": "removal",
-"hint": "’Beach’ means an area of sand or small stones near the sea.</br>'Intertidal area' means the area between the level of mean high water springs and the level of mean low water springs.",
+      "hint": "Intertidal area means the area between the level of mean high water springs and the level of mean low water springs.",
       "answers": [
         {
           "id": "yes",
@@ -7835,7 +7422,7 @@
     },
     {
       "route": "/exemption/removal/waste/dead-animals/undertaker",
-      "text": "Will the activity be carried out by or on behalf of a local authority?",
+      "text": "Will a local authority carry out the removal?",
       "section": "removal",
       "answers": [
         {
@@ -7852,9 +7439,9 @@
     },
     {
       "route": "/exemption/removal/waste/dead-animals/undertaker/mpa",
-      "text": "Will the activity take place in or within 200m of a Marine Protected Area (MPA)?",
+      "text": "Will the activity take place within 200 metres of a marine protected area (MPA)?",
       "section": "removal",
-  "hint": "<p>MPA's are an important part of the marine environment. </p><p>You are responsible for making sure you understand the status of the location where the activity is proposed. </p><p> ‘Marine protected areas’ mean:<ul><li>Highly Protected Marine Area (HPMA) (designated and candidate)</li><li>Marine Conservation Zones (MCZs) (designated and proposed)</li><li>Special Areas of Conservation (SACs) (designated and candidate)</li><li>Special Protection Areas (SPAs) (designated and potential)</li><li>Ramsar's</li><li>SSSIs</li></ul></p><p> If you are unsure of whether the activity falls within an MPA you should select the appropriate layer in the MMO’s <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\"> GIS tool </a> to check.",
+      "hint": "<p>MPAs are designated areas of the sea protected from harmful human activity. Any activity within 200 metres of an MPA may need a marine licence.\n\n<p>To find out if the activity falls within 200 metres of an MPA, you can use the <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c&showLayers=Marine%20Protected%20Areas\">marine licensing interactive map (opens in new tab)</a>.",
       "answers": [
         {
           "id": "yes",
@@ -7870,7 +7457,7 @@
     },
     {
       "route": "/exemption/removal/waste/dead-animals/undertaker/mpa-management",
-      "text": "Is the activity directly connected with or necessary to the management of the Marine Protected Area?",
+      "text": "Is the activity necessary for managing the marine protected area?",
       "section": "removal",
       "answers": [
         {
@@ -7887,40 +7474,35 @@
     },
     {
       "route": "/exemption/removal/waste/dead-animals/undertaker/lse",
-      "text": "Is the activity....",
+      "text": "Is the activity likely to affect any of the following?",
       "section": "removal",
-      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#marine-protected-areas\"> marine protected areas </a>.",
       "answers": [
         {
           "id": "europeanDeadAnimals",
-          "text": "Likely to have a significant effect on a European site?",
-          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
-          "hint": "either alone or in combination with other plans and projects"
+          "text": "A European site",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         },
         {
           "id": "ramsarDeadAnimals",
-          "text": "Likely to have a significant effect on a Ramsar site?",
-          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
-          "hint": "either alone or in combination with other plans and projects"
+          "text": "A Ramsar site",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         },
         {
           "id": "mczDeadAnimals",
-          "text": "Capable of affecting (other than insignificantly), the protected features of a Marine Conservation Zone or Highly Protected Marine Area?",
-          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
-          "hint": "including any ecological or geomorphological process on which the conservation of any protected feature of an MCZ or HPMA is (wholly or in Part) dependant"
+          "text": "The protected features of a marine conservation zone or highly protected marine area",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         },
         {
           "id": "otherDeadAnimals",
-          "text": "Unlikely to have any relevant effect on any sites specified above",
+          "text": "Unlikely to affect any of the listed sites",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-21"
         }
       ]
     },
     {
       "route": "/exemption/removal/waste/marine-litter",
-      "text": "Will the activity involve the removal of marine litter or abandoned, discarded or lost fishing gear in the course of a diving activity?",
+      "text": "Will the activity involve removing marine litter or fishing gear that was discarded or lost during a dive?",
       "section": "removal",
-      "hint": "'marine litter' means any persistent, manufactured or processed solid material discarded, disposed of or abandoned in the marine and coastal environment",
       "answers": [
         {
           "id": "yes",
@@ -7936,9 +7518,9 @@
     },
     {
       "route": "/exemption/removal/waste/marine-litter/historic-interest",
-      "text": "Is the activity likely to cause damage to features of archaeological or historic interest in an area where the diving activities in question occur?",
+      "text": "Is the activity likely to damage archaeological or historic features where the dive took place?",
       "section": "removal",
-      "hint": "'Archaeological or historic interest' includes all traces of human existence having a cultural, historical or archaeological character such as:<ol type=\"i\"><li>sites, structures, buildings, artefacts and human remains, together with their archaeological and natural context;</li><li>vessels, aircraft, other vehicles or any part thereof, their cargo or other contents, together with their archaeological and natural context; and</li><li>objects of prehistoric character.</li></ol></p>",
+      "hint": "This includes wrecks, monuments, artefacts, and other traces of human activity with cultural, historical or archaeological value.",
       "answers": [
         {
           "id": "yes",
@@ -7954,9 +7536,9 @@
     },
     {
       "route": "/exemption/removal/waste/marine-litter/mpa",
-      "text": "Will the activity take place in or within 200m of a Marine Protected Area (MPA)?",
+      "text": "Will the activity take place within 200 metres of a marine protected area (MPA)?",
       "section": "removal",
-  "hint": "<p>MPA's are an important part of the marine environment. </p><p>You are responsible for making sure you understand the status of the location where the activity is proposed. </p><p> ‘Marine protected areas’ mean:<ul><li>Highly Protected Marine Area (HPMA) (designated and candidate)</li><li>Marine Conservation Zones (MCZs) (designated and proposed)</li><li>Special Areas of Conservation (SACs) (designated and candidate)</li><li>Special Protection Areas (SPAs) (designated and potential)</li><li>Ramsar's</li><li>SSSIs</li></ul></p><p> If you are unsure of whether the activity falls within an MPA you should select the appropriate layer in the MMO’s <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\"> GIS tool </a> to check.",
+      "hint": "<p>MPAs are designated areas of the sea protected from harmful human activity. Any activity within 200 metres of an MPA may need a marine licence.\n\n<p>To find out if the activity falls within 200 metres of an MPA, you can use the <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c&showLayers=Marine%20Protected%20Areas\">marine licensing interactive map (opens in new tab)</a>.",
       "answers": [
         {
           "id": "yes",
@@ -7972,7 +7554,7 @@
     },
     {
       "route": "/exemption/removal/waste/marine-litter/mpa-management",
-      "text": "Is the activity directly connected with or necessary to the management of the Marine Protected Area?",
+      "text": "Is the activity necessary for managing the marine protected area?",
       "section": "removal",
       "answers": [
         {
@@ -7989,40 +7571,36 @@
     },
     {
       "route": "/exemption/removal/waste/marine-litter/lse",
-      "text": "Is the activity....",
+      "text": "Is the activity likely to affect any of the following?",
       "section": "removal",
-      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#marine-protected-areas\"> marine protected areas </a>.",
       "answers": [
         {
           "id": "europeanSiteMarineLitter",
-          "text": "Likely to have a significant effect on a European site?",
-          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
-          "hint": "either alone or in combination with other plans and projects"
+          "text": "A European site",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         },
         {
           "id": "ramsarSiteMarineLitter",
-          "text": "Likely to have a significant effect on a Ramsar site?",
-          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
-          "hint": "either alone or in combination with other plans and projects"
+          "text": "A Ramsar site",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         },
         {
           "id": "mczMarineLitter",
-          "text": "Capable of affecting (other than insignificantly), the protected features of a Marine Conservation Zone or Highly Protected Marine Area?",
-          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
-          "hint": "including any ecological or geomorphological process on which the conservation of any protected feature of an MCZ or HPMA is (wholly or in Part) dependant"
+          "text": "The protected features of a marine conservation zone or highly protected marine area",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         },
         {
           "id": "otherMarineLitter",
-          "text": "Unlikely to have any relevant effect on any sites specified above",
+          "text": "Unlikely to affect any of the listed sites",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-21A"
         }
       ]
     },
     {
       "route": "/exemption/removal/waste/litter-seaweed",
-      "text": "Will the activity involve the removal of litter or seaweed from a beach or intertidal area?",
+      "text": "Will you remove litter or seaweed from a beach or intertidal area?",
       "section": "removal",
-"hint": "’Beach’ means an area of sand or small stones near the sea.</br>'Intertidal area' means the area between the level of mean high water springs and the level of mean low water springs.",
+      "hint": "Intertidal area means the area between the level of mean high water springs and the level of mean low water springs.",
       "answers": [
         {
           "id": "yes",
@@ -8038,7 +7616,7 @@
     },
     {
       "route": "/exemption/removal/waste/litter-seaweed/undertaker",
-      "text": "Will the activity be carried out by or on behalf of a local authority?",
+      "text": "Will a local authority carry out the removal?",
       "section": "removal",
       "answers": [
         {
@@ -8055,8 +7633,8 @@
     },
     {
       "route": "/exemption/removal/waste/litter-seaweed/mpa",
-      "text": "Will the activity take place in or within 200m of a Marine Protected Area (MPA)?",
-        "hint": "<p>MPA's are an important part of the marine environment. </p><p>You are responsible for making sure you understand the status of the location where the activity is proposed. </p><p> ‘Marine protected areas’ mean:<ul><li>Highly Protected Marine Area (HPMA) (designated and candidate)</li><li>Marine Conservation Zones (MCZs) (designated and proposed)</li><li>Special Areas of Conservation (SACs) (designated and candidate)</li><li>Special Protection Areas (SPAs) (designated and potential)</li><li>Ramsar's</li><li>SSSIs</li></ul></p><p> If you are unsure of whether the activity falls within an MPA you should select the appropriate layer in the MMO’s <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\"> GIS tool </a> to check.",
+      "text": "Will the activity take place within 200 metres of a marine protected area (MPA)?",
+      "hint": "<p>MPAs are designated areas of the sea protected from harmful human activity. Any activity within 200 metres of an MPA may need a marine licence.\n\n<p>To find out if the activity falls within 200 metres of an MPA, you can use the <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c&showLayers=Marine%20Protected%20Areas\">marine licensing interactive map (opens in new tab)</a>.",
       "section": "removal",
       "answers": [
         {
@@ -8073,7 +7651,7 @@
     },
     {
       "route": "/exemption/removal/waste/litter-seaweed/mpa-management",
-      "text": "Is the activity directly connected with or necessary to the management of the Marine Protected Area?",
+      "text": "Is the activity necessary for managing the marine protected area?",
       "section": "removal",
       "answers": [
         {
@@ -8090,39 +7668,35 @@
     },
     {
       "route": "/exemption/removal/waste/litter-seaweed/lse",
-      "text": "Is the activity....",
+      "text": "Is the activity likely to affect any of the following?",
       "section": "removal",
       "answers": [
         {
           "id": "europeanSiteScientificEquipment",
-          "text": "Likely to have a significant effect on a European site?",
-          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
-          "hint": "either alone or in combination with other plans and projects"
+          "text": "A European site",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         },
         {
           "id": "ramsarSiteScientificEquipment",
-          "text": "Likely to have a significant effect on a Ramsar site?",
-          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
-          "hint": "either alone or in combination with other plans and projects"
+          "text": "A Ramsar site",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         },
         {
           "id": "mczScientificEquipment",
-          "text": "Capable of affecting (other than insignificantly), the protected features of a Marine Conservation Zone or Highly Protected Marine Area?",
-          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
-          "hint": "including any ecological or geomorphological process on which the conservation of any protected feature of an MCZ or HPMA is (wholly or in Part) dependant"
+          "text": "The protected features of a marine conservation zone or highly protected marine area",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         },
         {
           "id": "otherScientificEquipment",
-          "text": "Unlikely to have any relevant effect on any sites specified above",
+          "text": "Unlikely to affect any of the listed sites",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-21-no-notification"
         }
       ]
     },
     {
       "route": "/exemption/removal/waste/litter-debris",
-      "text": " Will the activity involve the removal of marine litter or debris from within the jurisdiction of a harbour authority?",
+      "text": "Will you remove marine litter or debris from within a harbour authority area?",
       "section": "removal",
-      "hint": "'marine litter' means any persistent, manufactured or processed solid material discarded, disposed of or abandoned in the marine and coastal environment.</br>'Debris' includes remnants from something that has been destroyed or pieces of unwanted or discarded material that are spread around.",
       "answers": [
         {
           "id": "yes",
@@ -8138,26 +7712,26 @@
     },
     {
       "route": "/exemption/removal/waste/litter-debris/undertaker",
-      "text": "Who will carry out the activity?",
+      "text": "Will a harbour authority or someone working for them carry out the activity?",
       "section": "removal",
       "answers": [
         {
           "id": "harbourAuthority",
-          "text": "A harbour authority or someone on behalf of a harbour authority",
+          "text": "Yes",
           "nextQuestionRoute": "/exemption/removal/waste/litter-debris/historic-interest"
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "No",
           "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/removal/waste/litter-debris/historic-interest",
-      "text": "Is the activity likely to cause damage to features of archaeological or historic interest in an area where the diving activities in question occur?",
+      "text": "Is the activity likely to damage archaeological or historic features where the dive took place?",
       "section": "removal",
-      "hint": "'Archaeological or historic interest' includes all traces of human existence having a cultural, historical or archaeological character such as:<ol type=\"i\"><li>sites, structures, buildings, artefacts and human remains, together with their archaeological and natural context;</li><li>vessels, aircraft, other vehicles or any part thereof, their cargo or other contents, together with their archaeological and natural context; and</li><li>objects of prehistoric character.</li></ol></p>",
+      "hint": "This includes wrecks, monuments, artefacts, and other traces of human activity with cultural, historical or archaeological value.",
       "answers": [
         {
           "id": "yes",
@@ -8173,10 +7747,10 @@
     },
     {
       "route": "/exemption/removal/waste/litter-debris/mpa",
-      "text": "Will the activity take place in or within 200m of a Marine Protected Area (MPA)?",
+      "text": "Will the activity take place within 200 metres of a marine protected area (MPA)?",
       "section": "removal",
-      "hint": "<p>MPA's are an important part of the marine environment. </p><p>You are responsible for making sure you understand the status of the location where the activity is proposed. </p><p> ‘Marine protected areas’ mean:<ul><li>Highly Protected Marine Area (HPMA) (designated and candidate)</li><li>Marine Conservation Zones (MCZs) (designated and proposed)</li><li>Special Areas of Conservation (SACs) (designated and candidate)</li><li>Special Protection Areas (SPAs) (designated and potential)</li><li>Ramsar's</li><li>SSSIs</li></ul></p><p> If you are unsure of whether the activity falls within an MPA you should select the appropriate layer in the MMO’s <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\"> GIS tool </a> to check.",
-      "answers": [ 
+      "hint": "<p>MPAs are designated areas of the sea protected from harmful human activity. Any activity within 200 metres of an MPA may need a marine licence.\n\n<p>To find out if the activity falls within 200 metres of an MPA, you can use the <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c&showLayers=Marine%20Protected%20Areas\">marine licensing interactive map (opens in new tab)</a>.",
+      "answers": [
         {
           "id": "yes",
           "text": "Yes",
@@ -8191,7 +7765,7 @@
     },
     {
       "route": "/exemption/removal/waste/litter-debris/mpa-management",
-      "text": "Is the activity directly connected with or necessary to the management of the Marine Protected Area?",
+      "text": "Is the activity necessary for managing the marine protected area?",
       "section": "removal",
       "answers": [
         {
@@ -8208,38 +7782,34 @@
     },
     {
       "route": "/exemption/removal/waste/litter-debris/lse",
-      "text": "Is the activity....",
+      "text": "Is the activity likely to affect any of the following?",
       "section": "removal",
-      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#marine-protected-areas\"> marine protected areas </a>.",
       "answers": [
         {
           "id": "europeanSiteMarineLitter",
-          "text": "Likely to have a significant effect on a European site?",
-          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
-          "hint": "either alone or in combination with other plans and projects"
+          "text": "A European site",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         },
         {
           "id": "ramsarSiteMarineLitter",
-          "text": "Likely to have a significant effect on a Ramsar site?",
-          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
-          "hint": "either alone or in combination with other plans and projects"
+          "text": "A Ramsar site",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         },
         {
           "id": "mczMarineLitter",
-          "text": "Capable of affecting (other than insignificantly), the protected features of a Marine Conservation Zone or Highly Protected Marine Area?",
-          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
-          "hint": "including any ecological or geomorphological process on which the conservation of any protected feature of an MCZ or HPMA is (wholly or in Part) dependant"
+          "text": "The protected features of a marine conservation zone or highly protected marine area",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         },
         {
           "id": "otherMarineLitter",
-          "text": "Unlikely to have any relevant effect on any sites specified above",
+          "text": "Unlikely to affect any of the listed sites",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-24A"
         }
       ]
     },
     {
       "route": "/exemption/removal/waste/accidental-deposits",
-      "text": "Was the object to be removed deposited accidentally?",
+      "text": "Was the object deposited accidentally?",
       "section": "removal",
       "answers": [
         {
@@ -8256,7 +7826,7 @@
     },
     {
       "route": "/exemption/removal/waste/accidental-deposits/within-12-months",
-      "text": "Will the removal take place within 12 months of the date the object was accidentally deposited?",
+      "text": "Will the removal take place within 12 months of the accidental deposit?",
       "section": "removal",
       "answers": [
         {
@@ -8273,9 +7843,9 @@
     },
     {
       "route": "/exemption/removal/waste/accidental-deposits/obstruction",
-      "text": "Will the activity cause or be likely to cause an obstruction or danger to navigation?",
+      "text": "Is the activity likely to cause an obstruction or danger to navigation?",
       "section": "removal",
-      "hint": " Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#navigational-risk\"> navigational risk </a> and the steps you can take to ensure your proposal is not one that will cause or be likely to cause and obstruction or danger.",
+      "hint": "<p>If you're unsure, you can check with the relevant harbour authority. If outside their jurisdiction, check with the <a target=\"_blank\" href=\"https://www.gov.uk/government/organisations/maritime-and-coastguard-agency\">Maritime and Coastguard Agency (opens in new tab)</a> or <a target=\"_blank\" href=\"https://www.trinityhouse.co.uk/\">Trinity House (opens in new tab)</a>.",
       "answers": [
         {
           "id": "yes",
@@ -8291,9 +7861,9 @@
     },
     {
       "route": "/exemption/removal/waste/accidental-deposits/mpa",
-      "text": "Will the activity take place in or within 200m of a Marine Protected Area (MPA)?",
+      "text": "Will the activity take place within 200 metres of a marine protected area (MPA)?",
       "section": "removal",
-  "hint": "<p>MPA's are an important part of the marine environment. </p><p>You are responsible for making sure you understand the status of the location where the activity is proposed. </p><p> ‘Marine protected areas’ mean:<ul><li>Highly Protected Marine Area (HPMA) (designated and candidate)</li><li>Marine Conservation Zones (MCZs) (designated and proposed)</li><li>Special Areas of Conservation (SACs) (designated and candidate)</li><li>Special Protection Areas (SPAs) (designated and potential)</li><li>Ramsar's</li><li>SSSIs</li></ul></p><p> If you are unsure of whether the activity falls within an MPA you should select the appropriate layer in the MMO’s <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\"> GIS tool </a> to check.",
+      "hint": "<p>MPAs are designated areas of the sea protected from harmful human activity. Any activity within 200 metres of an MPA may need a marine licence.\n\n<p>To find out if the activity falls within 200 metres of an MPA, you can use the <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c&showLayers=Marine%20Protected%20Areas\">marine licensing interactive map (opens in new tab)</a>.",
       "answers": [
         {
           "id": "yes",
@@ -8309,7 +7879,7 @@
     },
     {
       "route": "/exemption/removal/waste/accidental-deposits/mpa-management",
-      "text": "Is the activity directly connected with or necessary to the management of the Marine Protected Area?",
+      "text": "Is the activity necessary for managing the marine protected area?",
       "section": "removal",
       "answers": [
         {
@@ -8326,31 +7896,27 @@
     },
     {
       "route": "/exemption/removal/waste/accidental-deposits/lse",
-      "text": "Is the activity....",
+      "text": "Is the activity likely to affect any of the following?",
       "section": "removal",
-      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#marine-protected-areas\"> marine protected areas </a>.",
       "answers": [
         {
           "id": "europeanAccidentalDeposits",
-          "text": "Likely to have a significant effect on a European site?",
-          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
-          "hint": "either alone or in combination with other plans and projects"
+          "text": "A European site",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         },
         {
           "id": "ramsarAccidentalDeposits",
-          "text": "Likely to have a significant effect on a Ramsar site?",
-          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
-          "hint": "either alone or in combination with other plans and projects"
+          "text": "A Ramsar site",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         },
         {
           "id": "mczAccidentalDeposits",
-          "text": "Capable of affecting (other than insignificantly), the protected features of a Marine Conservation Zone or Highly Protected Marine Area?",
-          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
-          "hint": "including any ecological or geomorphological process on which the conservation of any protected feature of an MCZ or HPMA is (wholly or in Part) dependant"
+          "text": "The protected features of a marine conservation zone or highly protected marine area",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         },
         {
           "id": "otherAccidentalDeposits",
-          "text": "Unlikely to have any relevant effect on any sites specified above",
+          "text": "Unlikely to affect any of the listed sites",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-17B"
         }
       ]
@@ -8369,7 +7935,7 @@
           "id": "conservancyAuthority",
           "text": "A conservancy authority",
           "nextQuestionRoute": "/exemption/removal/waste/obstruction-danger-navigation/purpose",
-          "hint": "within the meaning given by section 313(1) of the Merchant Shipping Act 1995."
+          "hint": "As defined in section 313(1) of the Merchant Shipping Act 1995"
         },
         {
           "id": "lighthouseAuthority",
@@ -8378,19 +7944,20 @@
         },
         {
           "id": "inlandNavigationAuthority",
-          "text": "A person with powers under any enactment or statutory order to work on or maintain a canal or other inland navigation including navigation in tidal water.",
+          "text": "A person authorised to work on or maintain a canal or other inland navigation, including tidal water",
           "nextQuestionRoute": "/exemption/removal/waste/obstruction-danger-navigation/purpose"
         },
         {
           "id": "other",
-          "text": "Other",
-          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
+          "text": "Someone else",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
+          "hint": "This could be you or any organisation not listed"
         }
       ]
     },
     {
       "route": "/exemption/removal/waste/obstruction-danger-navigation/purpose",
-      "text": "Is the purpose of the activity to remove an object causing or likely to cause an obstruction or danger to navigation?",
+      "text": "Is the purpose to remove an object that's causing or likely to cause an obstruction or danger to navigation?",
       "section": "removal",
       "answers": [
         {
@@ -8407,7 +7974,7 @@
     },
     {
       "route": "/exemption/removal/emergency-safety-pollution-response-accident-investigation",
-      "text": "What does the removal activity relate to?",
+      "text": "What does the emergency, safety or training involve?",
       "section": "removal",
       "answers": [
         {
@@ -8422,12 +7989,12 @@
         },
         {
           "id": "coastguardActivities",
-          "text": "Coastguard activities - safety purposes and training",
+          "text": "Coastguard activities ",
           "nextQuestionRoute": "/exemption/removal/emergency-safety-pollution-response-accident-investigation/coastguard"
         },
         {
           "id": "salvageOperation",
-          "text": "Salvage Operation",
+          "text": "Salvage operation",
           "nextQuestionRoute": "/exemption/removal/emergency-safety-pollution-response-accident-investigation/salvage"
         },
         {
@@ -8437,24 +8004,24 @@
         },
         {
           "id": "pollutionPreventionPart6MerchantShippingAct1995",
-          "text": "Pollution prevention - activities within Part 6 of the Merchant Shipping Act 1995",
+          "text": "Pollution prevention",
           "nextQuestionRoute": "/exemption/removal/emergency-safety-pollution-response-accident-investigation/pollution-prevention"
         },
         {
           "id": "firefighting",
-          "text": "Fire Fighting",
+          "text": "Fire fighting",
           "nextQuestionRoute": "/exemption/removal/emergency-safety-pollution-response-accident-investigation/fire-fighting"
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/removal/emergency-safety-pollution-response-accident-investigation/flood",
-      "text": "Will the activity be carried out by or on behalf of the Environment Agency?",
+      "text": "Will the Environment Agency carry out the removal?",
       "section": "removal",
       "answers": [
         {
@@ -8471,7 +8038,7 @@
     },
     {
       "route": "/exemption/removal/emergency-safety-pollution-response-accident-investigation/flood/emergency",
-      "text": "Are the circumstances serious, unexpected and potentially dangerous requiring immediate action in response to flood or imminent risk of flood?",
+      "text": "Is immediate action required because the situation is serious, unexpected or dangerous?",
       "section": "removal",
       "answers": [
         {
@@ -8488,8 +8055,7 @@
     },
     {
       "route": "/exemption/removal/emergency-safety-pollution-response-accident-investigation/cables-pipelines",
-      "text": "Does the removal activity relate to the inspection or repair of an existing cable or pipeline",
-      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities--2#cables-pipelines-oil-and-gas-and-carbon-capture-storage\"> cables and pipelines </a>.",
+      "text": "Does the removal activity involve the inspection or repair of an existing cable or pipeline?",
       "section": "removal",
       "answers": [
         {
@@ -8506,7 +8072,7 @@
     },
     {
       "route": "/exemption/removal/emergency-safety-pollution-response-accident-investigation/cables-pipelines/emergency",
-      "text": "Are the circumstances serious, unexpected and potentially dangerous requiring immediate action?",
+      "text": "Is immediate action required because the situation is serious, unexpected or dangerous?",
       "section": "removal",
       "answers": [
         {
@@ -8523,7 +8089,7 @@
     },
     {
       "route": "/exemption/removal/emergency-safety-pollution-response-accident-investigation/coastguard",
-      "text": "Will the activity be carried out by or on behalf the Secretary of State for Transport, acting through the Maritime and Coastguard Agency?",
+      "text": "Will the Maritime and Coastguard Agency or someone working for them carry out the activity?",
       "section": "removal",
       "answers": [
         {
@@ -8545,30 +8111,29 @@
       "answers": [
         {
           "id": "securingVesselAircraftMarineStructureSafety",
-          "text": "Securing the safety of a vessel, aircraft or marine structure ",
-          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-32",
-          "hint": "'marine structure' means a platform or other artificial structure at 'Sea', other than a pipeline."
+          "text": "To secure the safety of a vessel, aircraft or marine structure",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-32"
         },
         {
           "id": "savingLife",
-          "text": "Saving life",
+          "text": "To save life",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-32"
         },
         {
           "id": "training",
-          "text": "Training for either of the above two purposes",
+          "text": "Training for safety or life saving",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-32"
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/removal/emergency-safety-pollution-response-accident-investigation/salvage",
-      "text": "Will the activity be carried out in the course of an official salvage operation for the purpose of ensuring the safety of a vessel or preventing pollution?",
+      "text": "Is the activity part of an official salvage operation to protect a vessel or prevent pollution?",
       "section": "removal",
       "answers": [
         {
@@ -8590,30 +8155,29 @@
       "answers": [
         {
           "id": "secretaryOfStateSchedule3A",
-          "text": "In exercise of a power under Schedule 3A to the Merchant Shipping Act 1995 (safety directions) by or on behalf of the Secretary of State",
+          "text": "Exercising a power under Schedule 3A of the Merchant Shipping Act (safety directions)",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-8"
         },
         {
           "id": "schedule3ACompliance",
-          "text": "Compliance with a direction under Schedule 3A to the Merchant Shipping Act 1995 (safety directions)",
+          "text": "Complying with a direction under Schedule 3A of the Merchant Shipping Act (safety directions)",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-8"
         },
         {
           "id": "avoidingInterference",
-          "text": "Avoiding interference with action taken under Schedule 3A to the Merchant Shipping Act 1995 (safety directions)",
+          "text": "Avoiding interference with a safety direction under Schedule 3A of the Merchant Shipping Act (safety directions)",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-8"
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/removal/emergency-safety-pollution-response-accident-investigation/pollution-prevention",
-      "text": "Does the activity proposed to be carried out fall within the subject matter of Part 6 of the Merchant Shipping Act 1995 (prevention of pollution)?",
-        "hint": "Find out more about <a target=\"_blank\" href=\" http://www.legislation.gov.uk/ukpga/1995/21/part/VI\"> Part 6 of the Merchant Shipping Act 1995</a>",
+      "text": "Does the activity fall within Part 6 of the Merchant Shipping Act 1995 (Prevention of Pollution)?",
       "section": "removal",
       "answers": [
         {
@@ -8630,7 +8194,7 @@
     },
     {
       "route": "/exemption/removal/emergency-safety-pollution-response-accident-investigation/fire-fighting",
-      "text": "Will the activity be carried out for the purpose of fighting or preventing the spread of fire?",
+      "text": "Is the activity to fight or prevent the spread of fire?",
       "section": "removal",
       "answers": [
         {
@@ -8647,7 +8211,7 @@
     },
     {
       "route": "/exemption/removal/emergency-safety-pollution-response-accident-investigation/air-accident-investigation",
-      "text": "Will the activity be carried out for the purpose of recovering a substance or object as part of an official investigation into an accident involving aircraft?",
+      "text": "Is the activity to recover items as part of an official aircraft accident investigation?",
       "section": "removal",
       "answers": [
         {
@@ -8664,12 +8228,12 @@
     },
     {
       "route": "/exemption/removal/fishing",
-      "text": "What does the removal activity relate to?",
+      "text": "What does the activity relate to?",
       "section": "removal",
       "answers": [
         {
           "id": "shellfishPropogationCultivation",
-          "text": "Shellfish propogation and cultivation",
+          "text": "Shellfish propagation or cultivation",
           "nextQuestionRoute": "/exemption/removal/fishing/shellfish-propagation-cultivation"
         },
         {
@@ -8679,16 +8243,16 @@
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/removal/fishing/shellfish-propagation-cultivation",
-      "text": "Will the activity be carried out for the purpose of moving shellfish within the 'Sea' in the course of its propagation or cultivation?",
+      "text": "Will the activity be for moving shellfish within the sea for propagation or cultivation?",
       "section": "removal",
-      "hint": "'shellfish' includes crustaceans and molluscs of any kind and any part of a shellfish.",
+      "hint": "Includes crustaceans, molluscs of any kind, and any part of a shellfish.",
       "answers": [
         {
           "id": "yes",
@@ -8704,9 +8268,9 @@
     },
     {
       "route": "/exemption/removal/fishing/shellfish-propagation-cultivation/obstruction",
-      "text": "Will the deposit cause or be likely to cause an obstruction or danger to navigation?",
+      "text": "Is the activity likely to cause an obstruction or danger to navigation?\n",
       "section": "removal",
-      "hint": " Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#navigational-risk\"> navigational risk </a> and the steps you can take to ensure your proposal is not one that will cause or be likely to cause and obstruction or danger.",
+      "hint": "<p>If you're unsure, you can check with the relevant harbour authority. If outside their jurisdiction, check with the <a target=\"_blank\" href=\"https://www.gov.uk/government/organisations/maritime-and-coastguard-agency\">Maritime and Coastguard Agency (opens in new tab)</a> or <a target=\"_blank\" href=\"https://www.trinityhouse.co.uk/\">Trinity House (opens in new tab)</a>.",
       "answers": [
         {
           "id": "yes",
@@ -8737,14 +8301,14 @@
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/removal/miscellaneous",
-      "text": "What does the removal activity relate to?",
+      "text": "What does the activity relate to?",
       "section": "removal",
       "answers": [
         {
@@ -8754,17 +8318,17 @@
         },
         {
           "id": "deepseaMining",
-          "text": "Licensed deepsea mining",
+          "text": "Licensed deep sea mining",
           "nextQuestionRoute": "/exemption/removal/miscellaneous/deepsea-mining"
         },
         {
           "id": "crossrailAct",
-          "text": "Scheduled works authorised under the Crossrail Act 2008",
+          "text": "Scheduled works under the Crossrail Act 2008",
           "nextQuestionRoute": "/exemption/removal/miscellaneous/crossrail-act"
         },
         {
           "id": "dismantlingShips",
-          "text": "Dismantling Ships",
+          "text": "Dismantling ships",
           "nextQuestionRoute": "/exemption/removal/miscellaneous/dismantling-ships"
         },
         {
@@ -8779,9 +8343,8 @@
         },
         {
           "id": "other",
-          "text": "Other",
-          "outcomeRoute": "/exemption/removal-exe-not-available-continue",
-          "hint": "Other removal activities for purposes not set out above"
+          "text": "Something else",
+          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         }
       ]
     },
@@ -8792,12 +8355,12 @@
       "answers": [
         {
           "id": "ukForces",
-          "text": "The naval, military or air forces of the crown (including reserve forces and the Royal Fleet Auxiliary)",
+          "text": "UK armed forces, including reserve forces and the Royal Fleet Auxiliary",
           "nextQuestionRoute": "/exemption/removal/miscellaneous/defence-activities/restriction"
         },
         {
           "id": "visiting forces",
-          "text": "A visiting force within the meaning given by Section 12 of the Visiting Forces Act 1952",
+          "text": "A visiting force under the Visiting Forces Act 1952",
           "nextQuestionRoute": "/exemption/removal/miscellaneous/defence-activities/restriction"
         },
         {
@@ -8836,36 +8399,37 @@
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/removal/miscellaneous/deepsea-mining",
-      "text": "Is the activity carried out?",
+      "text": "What is the purpose of the deep sea mining?",
       "section": "removal",
       "answers": [
         {
           "id": "explorationExploitationLicence",
-          "text": "In pursuance of an exploration or exploitation licence issued under the Deep Sea Mining (Temporary Provision) Act 1981",
+          "text": "To get an exploration or exploitation licence under the Deep Sea Mining (Temporary Provision) Act 1981",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-30"
         },
         {
           "id": "reciprocalauthorisation",
-          "text": "In pursuance of a reciprocal authorisation within the meaning given by section 3(3) of the Deep Sea Mining (Temporary Provision) Act 1981",
+          "text": "To get reciprocal authorisation under section 3(3) of the Deep Sea Mining (Temporary Provision) Act 1981",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-30"
         },
         {
           "id": "other",
-          "text": "for another reason",
+          "text": "Something else",
           "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/removal/miscellaneous/crossrail-act",
-      "text": "Will the activity be carried out within the limits of deviation for scheduled works in exercise of powers conferred by the Crossrail Act 2008 in relation to those works or any work connected with them?",
+      "text": "Will the work take place inside the limits of deviation set by the Crossrail Act 2008?",
+      "hint": "The limits of deviation are legal boundaries showing how far authorised works can move sideways, up or down on the plans.",
       "section": "removal",
       "answers": [
         {
@@ -8882,9 +8446,9 @@
     },
     {
       "route": "/exemption/removal/miscellaneous/dismantling-ships",
-      "text": "Will the activity be carried out as part of the dismantling of a ship that is waste?",
+      "text": "Will the activity involve dismantling a ship that is waste?",
       "section": "removal",
-      "hint": "'Ship' is intended to refer to large commercial or flag bearing vessels, the dismantling of which is regulated under alternative relevant legislation. It does <u>not</u> include ‘houseboats’. <p><p>'Waste' is defined in Article 3 of the EU Waste Framework Directive (2008/98/EC) as 'any substance or object which the holder discards or intends or is required to discard'.<p><p> Please refer to the <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/waste-classification-technical-guidance\">Technical guidance WM3</a> on Waste classification. <p><p>If there is any doubt about whether the vessel you intend to dismantle is a ship you should seek advice from the marine licensing team.",
+      "hint": "A ship means large commercial or flag-bearing vessels. It does not include houseboats.<p><p>Waste means anything the holder discards, intends to discard or must discard under the EU Waste Framework Directive 2008/98/EC. For more information read the <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/waste-classification-technical-guidance\">technical guidance on waste classification (opens in new tab)</a>.",
       "answers": [
         {
           "id": "yes",
@@ -8900,7 +8464,7 @@
     },
     {
       "route": "/exemption/removal/miscellaneous/foreign-vessels",
-      "text": "Will the activity be carried out in exercise of a right under rules of international law?",
+      "text": "Will the activity be carried out under international law rights?",
       "section": "removal",
       "answers": [
         {
@@ -8917,37 +8481,37 @@
     },
     {
       "route": "/exemption/removal/miscellaneous/foreign-vessels/undertaker",
-      "text": "Will the activity be carried out by or in relation to",
+      "text": "Will the activity involve any of the following?",
       "section": "removal",
       "answers": [
         {
           "id": "thirdCountry",
           "text": "A third country vessel",
-          "hint": "Third country vessel” means a vessel which is flying the flag of, or is registered in, any State or territory (other than Gibraltar) which is not a member State and is not registered in a member State.",
+          "hint": "A third country vessel is one registered in or flying the flag of a country outside the UK",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-37"
         },
         {
           "id": "warship",
-          "text": "A warship, naval auxiliary, other vessel or aircraft owned or operated by a state and used, for the time being, only on government non-commercial service (whether or not the warship, naval auxiliary, other vessel is a third country vessel)",
+          "text": "A warship, naval auxiliary, or other state-owned vessel or aircraft used only for non-commercial government service",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-37"
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/dredging",
-      "text": "What does the dredging activity relate to?",
+      "text": "What does the dredging activity involve?",
       "section": "dredging",
       "mcmsAppFormMapping": "EXE_ACTIVITY_SUBTYPE_DREDGING",
       "answers": [
         {
           "id": "navigationalDredging",
           "text": "Navigational dredging",
-          "hint": "Dredging to deepen berths or channels etc for the purpose of providing access to vessels and or otherwise facilite navigation.",
+          "hint": "Dredging to deepen berths, channels or other areas to improve access and navigation for vessels",
           "nextQuestionRoute": "/exemption/dredging/navigational-dredging"
         },
         {
@@ -8957,35 +8521,34 @@
         },
         {
           "id": "coastalProtectionDrainageOrFloodDefence",
-          "text": "Coastal Protection, drainage or flood defence",
+          "text": "Coastal protection, drainage or flood defence",
           "nextQuestionRoute": "/exemption/dredging/coastal-drainage-flood"
         },
         {
           "id": "emergency",
-          "text": "Emergency, safety and training",
+          "text": "Emergency or safety and training",
           "nextQuestionRoute": "/exemption/dredging/emergency"
         },
-                {
+        {
           "id": "deepseaMining",
-          "text": "Licensed deepsea mining",
+          "text": "Licensed deep sea mining",
           "nextQuestionRoute": "/exemption/dredging/miscellaneous/deepsea-mining"
         },
         {
           "id": "crossrailAct",
-          "text": "Scheduled works authorised under the Crossrail Act 2008",
+          "text": "Scheduled works under the Crossrail Act 2008",
           "nextQuestionRoute": "/exemption/dredging/miscellaneous/crossrail-act"
         },
         {
           "id": "miscellaneous",
-          "text": "Other",
-          "outcomeRoute": "/exemption/dredging-exe-not-available-continue",
-          "hint": "Dredging activities for purposes not set out above"
+          "text": "Something else",
+          "outcomeRoute": "/exemption/dredging-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/dredging/navigational-dredging",
-      "text": "Will the activity be carried out by or on behalf of the harbour authority?",
+      "text": "Will the harbour authority or someone working for them carry out the activity?",
       "section": "dredging",
       "answers": [
         {
@@ -9002,12 +8565,12 @@
     },
     {
       "route": "/exemption/dredging/navigational-dredging/authorisation",
-      "text": "Is the activity authorised by",
+      "text": "Is the dredging authorised by any of the following?",
       "section": "dredging",
       "answers": [
         {
           "id": "localAct",
-          "text": "A local Act",
+          "text": "A local act",
           "nextQuestionRoute": "/exemption/dredging/navigational-dredging/method"
         },
         {
@@ -9017,24 +8580,24 @@
         },
         {
           "id": "section1HaNorthernIreland",
-          "text": "An order under Section 1 of the Harbours Act (Northern ireland) 1970",
+          "text": "An order under Section 14 or 16 of the Harbours Act 1964",
           "nextQuestionRoute": "/exemption/dredging/navigational-dredging/method"
         },
         {
           "id": "section10HaNorthernIreland",
-          "text": "An order under Section 10(3) of the Harbours Act (Northern ireland) 1970",
+          "text": "An order under Section 14 or 16 of the Harbours Act 1964",
           "nextQuestionRoute": "/exemption/dredging/navigational-dredging/method"
         },
         {
           "id": "other",
-          "text": "None of the above",
+          "text": "Not authorised by any of these",
           "nextQuestionRoute": "/exemption/dredging/navigational-dredging/purpose"
         }
       ]
     },
     {
       "route": "/exemption/dredging/navigational-dredging/method",
-      "text": "Will the activity be carried out in accordance with the relevant authorisation?",
+      "text": "Will the dredging be carried out in line with the relevant authorisation?",
       "section": "dredging",
       "answers": [
         {
@@ -9051,9 +8614,8 @@
     },
     {
       "route": "/exemption/dredging/navigational-dredging/purpose",
-      "text": "Is the purpose of the activity to enable the continued use of a navigational channel or area of 'Sea' by vessels?",
+      "text": "Is the dredging to enable vessels to continue using a navigational channel or area of sea?",
       "section": "dredging",
-      "hint": "Find out more about what we mean by <a target=\"_blank\" href=\"https://www.gov.uk/guidance/marine-licensing-definitions#what-do-we-mean-by-the-sea\">sea</a>",
       "answers": [
         {
           "id": "yes",
@@ -9069,9 +8631,8 @@
     },
     {
       "route": "/exemption/dredging/navigational-dredging/maintenance",
-      "text": "Will the dredging be carried out at a site, where at least one previous dredging campaign has taken place, to the same depth or deeper, in the last 10 years?",
+      "text": "Has the site been dredged to the same or greater depth in the last 10 years?",
       "section": "dredging",
-      "hint": "Find out more about <a target=\"_blank\" href=\" https://www.gov.uk/guidance/dredging#dredging-by-type\"> maintenance dredging</a>",
       "answers": [
         {
           "id": "yes",
@@ -9087,7 +8648,7 @@
     },
     {
       "route": "/exemption/dredging/navigational-dredging/previous-purpose",
-      "text": "Was the purpose of the previous dredge to enable the continued use of the area of 'Sea' by vessels?",
+      "text": "Was the previous dredging to enable vessels to continue using the area?",
       "section": "dredging",
       "answers": [
         {
@@ -9104,24 +8665,24 @@
     },
     {
       "route": "/exemption/dredging/navigational-dredging/quantity",
-      "text": "How many cubic meters will be dredged?",
+      "text": "How many cubic metres will be dredged?",
       "section": "dredging",
       "answers": [
         {
           "id": "lessThan501",
-          "text": "500m3 or less",
+          "text": "500 cubic metres or less",
           "nextQuestionRoute": "/exemption/dredging/navigational-dredging/last-12months"
         },
         {
           "id": "moreThan500",
-          "text": "More than 500m3",
+          "text": "More than 500 cubic metres",
           "outcomeRoute": "/exemption/dredging-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/dredging/navigational-dredging/last-12months",
-      "text": "Has any other dredging taken place at the site of the proposed dredge in the previous 12 months?",
+      "text": "Has any dredging taken place at this site in the previous 12 months?",
       "section": "dredging",
       "answers": [
         {
@@ -9138,7 +8699,7 @@
     },
     {
       "route": "/exemption/dredging/navigational-dredging/last-12-quantity",
-      "text": "Does the quantity of material dredged at the site in the previous 12 months, combined with the amount proposed to be dredged, exceed 1500m3?",
+      "text": "Will the amount of material dredged in the last 12 months plus the proposed amount exceed 1500 cubic metres?",
       "section": "dredging",
       "answers": [
         {
@@ -9155,9 +8716,9 @@
     },
     {
       "route": "/exemption/dredging/navigational-dredging/obstruction",
-      "text": "Is the activity one that will cause or be likely to cause obstruction or danger to navigation?",
+      "text": "Will this activity cause or be likely to cause obstruction or danger to navigation?",
       "section": "dredging",
-      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#navigational-risk\"> navigational risk </a> and the steps you can take to ensure your proposal is not one that will cause or be likely to cause and obstruction or danger.",
+      "hint": "<p>If you're unsure, you can check with the relevant harbour authority. If outside their jurisdiction, check with the <a target=\"_blank\" href=\"https://www.gov.uk/government/organisations/maritime-and-coastguard-agency\">Maritime and Coastguard Agency (opens in new tab)</a> or <a target=\"_blank\" href=\"https://www.trinityhouse.co.uk/\">Trinity House (opens in new tab)</a>.",
       "answers": [
         {
           "id": "yes",
@@ -9173,9 +8734,9 @@
     },
     {
       "route": "/exemption/dredging/navigational-dredging/mpa",
-      "text": "Will the activity take place in or within 200m of a Marine Protected Area (MPA)?",
-      "section": "deposit",
-  "hint": "<p>MPA's are an important part of the marine environment. </p><p>You are responsible for making sure you understand the status of the location where the activity is proposed. </p><p> ‘Marine protected areas’ mean:<ul><li>Highly Protected Marine Area (HPMA) (designated and candidate)</li><li>Marine Conservation Zones (MCZs) (designated and proposed)</li><li>Special Areas of Conservation (SACs) (designated and candidate)</li><li>Special Protection Areas (SPAs) (designated and potential)</li><li>Ramsar's</li><li>SSSIs</li></ul></p><p> If you are unsure of whether the activity falls within an MPA you should select the appropriate layer in the MMO’s <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c\"> GIS tool </a> to check.",
+      "text": "Will the activity take place within 200 metres of a Marine Protected Area (MPA)?",
+      "section": "dredging",
+      "hint": "<p>MPAs are designated areas of the sea protected from harmful human activity. Any activity within 200 metres of an MPA may need a marine licence. <p><p>To find out if the activity falls within 200 metres of an MPA, you can use the <a target=\"_blank\" href=\"https://defra.maps.arcgis.com/apps/webappviewer/index.html?id=28f91021979447d3b43dc83e6e93094c&showLayers=Marine%20Protected%20Areas\">marine licensing interactive map (opens in new tab)</a>.",
       "answers": [
         {
           "id": "yes",
@@ -9191,7 +8752,7 @@
     },
     {
       "route": "/exemption/dredging/navigational-dredging/mpa-management",
-      "text": "Is the activity directly connected with or necessary to the management of the Marine Protected Area?",
+      "text": "Is the activity necessary for managing the Marine Protected Area?",
       "section": "deposit",
       "answers": [
         {
@@ -9208,38 +8769,34 @@
     },
     {
       "route": "/exemption/dredging/navigational-dredging/lse",
-      "text": "Is the activity....",
+      "text": "Is the activity likely to affect any of the following?",
       "section": "deposit",
-      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities#marine-protected-areas\"> marine protected areas </a>.",
       "answers": [
         {
           "id": "europeanSiteNavigationalDredging",
-          "text": "Likely to have a significant effect on a European site?",
-          "outcomeRoute": "/exemption/dredging-exe-not-available-continue",
-          "hint": "either alone or in combination with other plans and projects"
+          "text": "A European site",
+          "outcomeRoute": "/exemption/dredging-exe-not-available-continue"
         },
         {
           "id": "ramsarSiteNavigationalDredging",
-          "text": "Likely to have a significant effect on a Ramsar site?",
-          "outcomeRoute": "/exemption/dredging-exe-not-available-continue",
-          "hint": "either alone or in combination with other plans and projects"
+          "text": "A Ramsar site",
+          "outcomeRoute": "/exemption/dredging-exe-not-available-continue"
         },
         {
           "id": "mczNavigationalDredging",
-          "text": "Capable of affecting (other than insignificantly), the protected features of a Marine Conservation Zone or Highly Protected Marine Area?",
-          "outcomeRoute": "/exemption/dredging-exe-not-available-continue",
-          "hint": "including any ecological or geomorphological process on which the conservation of any protected feature of an MCZ or HPMA is (wholly or in Part) dependant"
+          "text": "The protected features of a marine conservation zone or highly protected marine area",
+          "outcomeRoute": "/exemption/dredging-exe-not-available-continue"
         },
         {
           "id": "otherSNavigationalDredging",
-          "text": "Unlikely to have any relevant effect on any sites specified above",
+          "text": "Unlikely to affect any of the listed sites",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-18A"
         }
       ]
     },
     {
       "route": "/exemption/dredging/shellfish-propagation-cultivation",
-      "text": "Will the activity be carried out for the purpose of moving shellfish within the 'Sea' in the course of its propagation or cultivation?",
+      "text": "Is the purpose of the activity to move shellfish in the sea for propagation or cultivation?",
       "section": "dredging",
       "answers": [
         {
@@ -9256,7 +8813,7 @@
     },
     {
       "route": "/exemption/dredging/coastal-drainage-flood",
-      "text": "What does the dredging activity relate to?",
+      "text": "What is the purpose of the dredging?",
       "section": "dredging",
       "answers": [
         {
@@ -9271,46 +8828,47 @@
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/dredging-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/dredging/coastal-drainage-flood/maintenance",
-      "text": "Who will carry out the activity?",
+      "text": "Who will carry out the dredging?",
       "section": "dredging",
       "answers": [
         {
           "id": "environmentAgency",
-          "text": "The Environment Agency or someone on behalf of the Environment Agency",
+          "text": "The Environment Agency or someone working for them",
           "nextQuestionRoute": "/exemption/dredging/coastal-drainage-flood/maintenance/EA"
         },
         {
           "id": "coastProtectionAuthority",
-          "text": "The Coast Protection Authority or someone on behalf of the Coast Protection Authority",
+          "text": "The Coast Protection Authority or someone working for them",
           "nextQuestionRoute": "/exemption/dredging/coastal-drainage-flood/maintenance/CPA"
         },
         {
           "id": "localAuthority",
-          "text": "The Local Authority or someone on behalf of the Local Authority",
+          "text": "The local authority or someone working for them",
           "nextQuestionRoute": "/exemption/dredging/coastal-drainage-flood/maintenance/CPA"
         },
         {
           "id": "secretaryStateDefence",
-          "text": "The Secretary of State for Defence or someone on behalf of the Secretary of State for Defence",
+          "text": "The Secretary of State for Defence or someone working for them",
           "nextQuestionRoute": "/exemption/dredging/coastal-drainage-flood/maintenance/CPA"
         },
         {
           "id": "other",
           "text": "Someone else",
+          "hint": "This could be you or any organisation not listed",
           "outcomeRoute": "/exemption/dredging-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/dredging/coastal-drainage-flood/maintenance/EA",
-      "text": "Will the activity be carried out wholly within the existing 3 dimensional boundary of the works being maintained?",
+      "text": "Will the activity be carried out within the existing 3-dimensional boundary of the works?",
       "section": "dredging",
       "answers": [
         {
@@ -9328,7 +8886,7 @@
     {
       "route": "/exemption/dredging/coastal-drainage-flood/maintenance/EA/beach-replenishment",
       "text": "Does the activity involve beach replenishment?",
-            "hint": "'Beach replenishment' means the addition of material from land-based, off-shore or other coastal sources not connected to the beach or its associated sediment system to replace material permanently lost from the system.",
+      "hint": "<p>Beach replenishment means adding new material from outside sources on land, offshore or along the coast to replace material the beach has permanently lost.",
       "section": "dredging",
       "answers": [
         {
@@ -9345,8 +8903,8 @@
     },
     {
       "route": "/exemption/dredging/coastal-drainage-flood/maintenance/CPA",
-      "text": "Is the activity for the purpose of maintaining coast protection works?",
-            "hint": "'Coast protection works' include: </li><li><u>beach re-profiling</U>, which involves the movement of beach material in a cross-shore direction up or down the beach; and </li><li><u>beach recycling</u>, which involves the movement of beach material along the beach from areas of accretion to areas of erosion within the beach or associated sediment system.",
+      "text": "Is the purpose of the activity to maintain coast protection works?",
+      "hint": "<p>Coast protection works include beach re-profiling, which involves moving material up or down the beach. They also include beach recycling, which involves moving material along the beach to manage erosion.",
       "section": "dredging",
       "answers": [
         {
@@ -9364,7 +8922,7 @@
     {
       "route": "/exemption/dredging/coastal-drainage-flood/maintenance/CPA/beach-replenishment",
       "text": "Does the activity involve beach replenishment?",
-            "hint": "'Beach replenishment' means the addition of material from land-based, off-shore or other coastal sources not connected to the beach or its associated sediment system to replace material permanently lost from the system.",
+      "hint": "<p>Beach replenishment means adding new material from outside sources on land, offshore or along the coast to replace material the beach has permanently lost.",
       "section": "dredging",
       "answers": [
         {
@@ -9381,7 +8939,7 @@
     },
     {
       "route": "/exemption/dredging/coastal-drainage-flood/emergency",
-      "text": "Will the activity be carried out by or on behalf on the Environment Agency?",
+      "text": "Will the Environment Agency or someone working for them carry out the activity?",
       "section": "dredging",
       "answers": [
         {
@@ -9398,7 +8956,7 @@
     },
     {
       "route": "/exemption/dredging/coastal-drainage-flood/emergency/validation",
-      "text": "Are the circumstances serious, unexpected, and potentially dangerous requiring immediate action in response to either flooding or imminent risk of flooding?",
+      "text": "Is immediate action required because the situation is serious, unexpected or dangerous?",
       "section": "deposit",
       "answers": [
         {
@@ -9415,7 +8973,7 @@
     },
     {
       "route": "/exemption/dredging/emergency",
-      "text": "What does the dredging activity relate to?",
+      "text": "What does the emergency, safety or training involve?",
       "section": "dredging",
       "answers": [
         {
@@ -9431,8 +8989,7 @@
         {
           "id": "coastguardActivities",
           "text": "Coastguard activities",
-          "nextQuestionRoute": "/exemption/dredging/emergency/coastguard",
-          "hint": "safety purposes and training"
+          "nextQuestionRoute": "/exemption/dredging/emergency/coastguard"
         },
         {
           "id": "salvageOperation",
@@ -9446,14 +9003,14 @@
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/dredging-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/dredging/emergency/flood-flood-risk",
-      "text": "Will the activity be carried out by or on behalf of the Environment Agency?",
+      "text": "Will the Environment Agency or someone working for them carry out the activity?",
       "section": "dredging",
       "answers": [
         {
@@ -9470,7 +9027,7 @@
     },
     {
       "route": "/exemption/dredging/emergency/flood-flood-risk/emergency",
-      "text": "Are the circumstances serious, unexpected and potentially dangerous requiring immediate action in response to flood or imminent risk of flood?",
+      "text": "Is immediate action required due to flooding or an imminent risk of flooding?",
       "section": "dredging",
       "answers": [
         {
@@ -9487,8 +9044,7 @@
     },
     {
       "route": "/exemption/dredging/emergency/cables-pipelines",
-      "text": "Does the dredging activity relate to the inspection or repair of an existing cable or pipeline",
-      "hint": "Find out more about <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/marine-licensing-exempted-activities/marine-licensing-exempted-activities--2#cables-pipelines-oil-and-gas-and-carbon-capture-storage\"> cables and pipelines </a>.",
+      "text": "Does the dredging activity relate to the inspection or repair of an existing cable or pipeline?",
       "section": "dredging",
       "answers": [
         {
@@ -9505,7 +9061,7 @@
     },
     {
       "route": "/exemption/dredging/emergency/cables-pipelines/emergency",
-      "text": "Are the circumstances serious, unexpected and potentially dangerous requiring immediate action?",
+      "text": "Is immediate action required because the situation is serious, unexpected or dangerous?",
       "section": "dredging",
       "answers": [
         {
@@ -9522,8 +9078,8 @@
     },
     {
       "route": "/exemption/dredging/emergency/cables-pipelines/protection",
-      "text": "Will the activity proposed include the deposit of rock or other materials for the purpose of providing <u>new</U> cable or pipeline protection?",
-      "hint": "Deposits for these purposes, i.e. those beyond the replenishment or replacement of materials wholly within the three dimensional boundaries of those previously consented and deposited, will require a marine licence. If the maintenance, inspection or repair can be carried out without the need for new protection you are advised to adapt your proposed approach. <P><P>NOTE: If you intend to apply for a marine licence in respect of the addition of new or extended protection, where relevant, please select ‘No’ to continue.",
+      "text": "Does the activity involve depositing rock or other materials to provide new cable or pipeline protection?",
+      "hint": "<p>Only replacing material within the existing boundary is exempt. New or extended protection needs a marine licence. ",
       "section": "dredging",
       "answers": [
         {
@@ -9557,7 +9113,7 @@
     },
     {
       "route": "/exemption/dredging/emergency/coastguard",
-      "text": "Will the activity be carried out by or on behalf the Secretary of State for Transport, acting through the Maritime and Coastguard Agency?",
+      "text": "Will the Maritime and Coastguard Agency or someone working for them carry out the activity?",
       "section": "dredging",
       "answers": [
         {
@@ -9579,30 +9135,29 @@
       "answers": [
         {
           "id": "securingVesselAircraftMarineStructureSafety",
-          "text": "Securing the safety of a vessel, aircraft or marine structure ",
-          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-32",
-          "hint": "'marine structure' means a platform or other artificial structure at 'Sea', other than a pipeline."
+          "text": "To secure the safety of a vessel, aircraft or marine structure",
+          "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-32"
         },
         {
           "id": "savingLife",
-          "text": "Saving life",
+          "text": "To save life",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-32"
         },
         {
           "id": "training",
-          "text": "Training for either of the above two purposes",
+          "text": "Training for safety or life saving",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-32"
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/dredging-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/dredging/emergency/salvage-operation",
-      "text": "Will the activity be carried out in the course of an official salvage operation for the purpose of ensuring the safety of a vessel or preventing pollution?",
+      "text": "Is the activity part of an official salvage operation to make a vessel safe or prevent pollution?",
       "section": "dredging",
       "answers": [
         {
@@ -9624,12 +9179,12 @@
       "answers": [
         {
           "id": "secretaryOfStateSchedule3A",
-          "text": "In exercise of a power under Schedule 3A to the Merchant Shipping Act 1995 (safety directions) by or on behalf of the Secretary of State",
+          "text": "Exercising a power under Schedule 3A of the Merchant Shipping Act (safety directions)",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-8"
         },
         {
           "id": "schedule3ACompliance",
-          "text": "Compliance with a direction under Schedule 3A to the Merchant Shipping Act 1995 (safety directions)",
+          "text": "Complying with a direction under Schedule 3A of the Merchant Shipping Act (safety directions)",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-8"
         },
         {
@@ -9639,36 +9194,37 @@
         },
         {
           "id": "other",
-          "text": "Other",
+          "text": "Something else",
           "outcomeRoute": "/exemption/dredging-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/dredging/miscellaneous/deepsea-mining",
-      "text": "Is the activity carried out?",
+      "text": "What is the purpose of the deep sea mining?",
       "section": "dredging",
       "answers": [
         {
           "id": "explorationExploitationLicence",
-          "text": "In pursuance of an exploration or exploitation licence issued under the Deep Sea Mining (Temporary Provision) Act 1981",
+          "text": "To get an exploration or exploitation licence under the Deep Sea Mining (Temporary Provision) Act 1981",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-30"
         },
         {
           "id": "reciprocalauthorisation",
-          "text": "In pursuance of a reciprocal authorisation within the meaning given by section 3(3) of the Deep Sea Mining (Temporary Provision) Act 1981",
+          "text": "To get reciprocal authorisation under section 3(3) of the Deep Sea Mining (Temporary Provision) Act 1981",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-30"
         },
         {
           "id": "other",
-          "text": "for another reason",
+          "text": "Something else",
           "outcomeRoute": "/exemption/dredging-exe-not-available-continue"
         }
       ]
     },
     {
       "route": "/exemption/dredging/miscellaneous/crossrail-act",
-      "text": "Will the activity be carried out within the limits of deviation for scheduled works in exercise of powers conferred by the Crossrail Act 2008 in relation to those works or any work connected with them?",
+      "text": "Will the activity be carried out within the limits of deviation for scheduled works under the Crossrail Act 2008?",
+      "hint": "The limits of deviation are legal boundaries showing how far authorised works can move sideways, up or down on the plans.",
       "section": "dredging",
       "answers": [
         {


### PR DESCRIPTION
Add app/data/_iat.json containing the interactive assistance tool (IAT) configuration for the self-service marine licence checker. The new JSON holds sections, outcomeTypes, user-facing text, links to templates and guidance, and parameters for exemptions, enquiries and licence routes. Also update app/data/iat.json (modified) to reflect related changes to the existing IAT dataset.