### PR TITLE
Rename IAT page and update navigation

### DIFF
--- a/app/views/exemptions-private-beta.html
+++ b/app/views/exemptions-private-beta.html
@@ -127,22 +127,6 @@ html: ''
       </div>
     </details>
 
-    <details class="govuk-details govuk-!-margin-bottom-2">
-      <summary class="govuk-details__summary">
-        <span class="govuk-details__summary-text">
-          IAT replica journeys
-        </span>
-      </summary>
-      <div class="govuk-details__text">
-        <ul class="govuk-list govuk-list--spaced">
-          <li><a href="versions/multiple-sites-v2/start" class="govuk-link--no-visited-state">Start the IAT replica
-              journey</a></li>
-          <li><a href="versions/multiple-sites-v2/start-improved" class="govuk-link--no-visited-state">Start the IAT
-              replica journey with the improved content</a></li>
-        </ul>
-      </div>
-    </details>
-
     <details class="govuk-details">
       <summary class="govuk-details__summary">
         <span class="govuk-details__summary-text">

--- a/app/views/iat.html
+++ b/app/views/iat.html
@@ -4,10 +4,10 @@
 
 <!-- Setting the big main heading at the top of the page -->
 {% set pageHeadingTextHTML %}
-IAT archive
+Interactive Assistance Tool (IAT)
 {% endset %}
 
-{% set navActive = "iat-archive" %}
+{% set navActive = "iat" %}
 
 <!-- Text that show in the browser tab. Does NOT need changing -->
 {% block pageTitle %}
@@ -48,13 +48,15 @@ html: ''
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
     <!-- End of session warning text -->
 
-    <!-- Start of Interactive Assistance Tool (IAT) -->
-    <h2 class="govuk-heading-m">Interactive Assistance Tool (IAT) <strong class="govuk-tag govuk-tag--green"
-        style="float:right">Finished</strong></h2>
+    <h2 class="govuk-heading-m">IAT replica journey</h2>
+    
+    <p><a href="versions/multiple-sites-v2/start" class="govuk-link--no-visited-state">Start the IAT replica journey</a></p>
+
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+    <h2 class="govuk-heading-m">IAT archive</h2>
 
     <p><a href="versions/iat/start" class="govuk-link--no-visited-state">Start the IAT journey</a></p>
-
-    <p><a href="versions/iat/start-99" class="govuk-link--no-visited-state">Start the mock IAT journey</a></p>
 
     <p>This is a replica of the live Interactive Assistance Tool (IAT) which helps users determine whether they need a
       marine licence. The tool guides users through a series of questions to assess their proposed marine activities.
@@ -125,9 +127,6 @@ html: ''
 
       </div>
     </details>
-
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-    <!-- End of Interactive Assistance Tool (IAT) -->
 
   </div>
 

--- a/app/views/includes/proto-nav.html
+++ b/app/views/includes/proto-nav.html
@@ -5,11 +5,11 @@
       { text: "Home – LCML iteration 3", href: "index.html", active: navActive == "index" },
       { text: "LCML – previous iterations", href: "lcml-archive.html", active: navActive == "lcml-archive" },
       { text: "Exemptions – Private beta", href: "exemptions-private-beta.html", active: navActive == "exemptions-private-beta" },
+      { text: "IAT", href: "iat.html", active: navActive == "iat" },
       { text: "Defra ID tactical fix", href: "defra-id-tactical-fix.html", active: navActive == "defra-id-tactical-fix" },
       { text: "Exemptions – Alpha", href: "exemptions-alpha.html", active: navActive == "exemptions-alpha" },
       { text: "Exemptions archive", href: "exemptions-archive.html", active: navActive == "exemptions-archive" },
       { text: "Sample Plans", href: "sample-plans.html", active: navActive == "sample-plans" },
-      { text: "IAT archive", href: "iat-archive.html", active: navActive == "iat-archive" },
       { text: "About this prototype", href: "about-the-prototype.html", active: navActive == "about-the-prototype" },
       { text: "Previous alpha", href: "alpha-2024.html", active: navActive == "alpha-2024" }
     ]


### PR DESCRIPTION
Rename iat-archive.html to iat.html and update its heading, navActive key and page content to expose the IAT replica journey and the archive separately. Remove the IAT replica details block from exemptions-private-beta.html. Update proto-nav to point to iat.html and use navActive == "iat" so the navigation highlights the renamed page.