### PR TITLE
Reorganise marine plan policy sections of Check page

### DIFF
--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/check-your-answers.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/check-your-answers.html
@@ -890,12 +890,107 @@ Check your answers before sending your information
 		{% endif %}
 
 		{# ================================================= #}
-		{# MARINE PLAN POLICIES — Environmental protection    #}
+		{# MARINE PLAN POLICIES — Cross-cutting               #}
 		{# ================================================= #}
 		<div class="govuk-summary-card">
 			<div class="govuk-summary-card__title-wrapper">
 				<h2 class="govuk-summary-card__title">
-					Marine plan policies – Environmental protection and impacts
+					Marine plan policies – Cross-cutting
+				</h2>
+			</div>
+			<div class="govuk-summary-card__content">
+				<dl class="govuk-summary-list">
+					<div class="govuk-summary-list__row">
+						<dt class="govuk-summary-list__key">South Climate change 1 (S-CC-1)</dt>
+						<dd class="govuk-summary-list__value">Vivamus luctus urna sed urna ultricies ac tempor dui sagittis in hac habitasse platea dictumst. Morbi tincidunt ornare massa eget egestas purus viverra accumsan in nisl nisi scelerisque eu ultrices vitae auctor eu augue ut lectus arcu bibendum at varius vel pharetra vel turpis.</dd>
+						<dd class="govuk-summary-list__actions"><a class="govuk-link govuk-link--no-visited-state" href="#">Change<span class="govuk-visually-hidden"> South Climate change 1</span></a></dd>
+					</div>
+					<div class="govuk-summary-list__row">
+						<dt class="govuk-summary-list__key">South Climate change 2 (S-CC-2)</dt>
+						<dd class="govuk-summary-list__value">Fringilla est ullamcorper eget nulla facilisi etiam dignissim diam quis enim lobortis scelerisque fermentum dui faucibus. Amet consectetur adipiscing elit pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas sed tempus urna et pharetra pharetra massa vel eros donec.</dd>
+						<dd class="govuk-summary-list__actions"><a class="govuk-link govuk-link--no-visited-state" href="#">Change<span class="govuk-visually-hidden"> South Climate change 2</span></a></dd>
+					</div>
+					<div class="govuk-summary-list__row">
+						<dt class="govuk-summary-list__key">South Climate change 3 (S-CC-3)</dt>
+						<dd class="govuk-summary-list__value">Facilisis magna etiam tempor orci eu lobortis elementum nibh tellus molestie nunc non blandit massa enim nec dui nunc mattis enim ut tellus. Elementum sagittis vitae et leo duis ut diam quam nulla porttitor massa id neque aliquam vestibulum morbi blandit cursus risus at.</dd>
+						<dd class="govuk-summary-list__actions"><a class="govuk-link govuk-link--no-visited-state" href="#">Change<span class="govuk-visually-hidden"> South Climate change 3</span></a></dd>
+					</div>
+					<div class="govuk-summary-list__row">
+						<dt class="govuk-summary-list__key">South Climate change 4 (S-CC-4)</dt>
+						<dd class="govuk-summary-list__value">Ultrices sagittis orci a scelerisque purus semper eget duis at tellus at urna condimentum mattis pellentesque id nibh. Tortor pretium viverra suspendisse potenti nullam ac tortor vitae purus faucibus ornare suspendisse sed nisi lacus sed viverra tellus in hac habitasse platea dictumst vestibulum.</dd>
+						<dd class="govuk-summary-list__actions"><a class="govuk-link govuk-link--no-visited-state" href="#">Change<span class="govuk-visually-hidden"> South Climate change 4</span></a></dd>
+					</div>
+					<div class="govuk-summary-list__row">
+						<dt class="govuk-summary-list__key">South Co-existence 1 (S-CO-1)</dt>
+						<dd class="govuk-summary-list__value">Amet venenatis urna cursus eget nunc scelerisque viverra mauris in aliquam sem fringilla ut morbi tincidunt augue interdum velit euismod. Eu volutpat odio facilisis mauris sit amet massa vitae tortor condimentum lacinia quis vel eros donec ac odio tempor orci dapibus ultrices iaculis.</dd>
+						<dd class="govuk-summary-list__actions"><a class="govuk-link govuk-link--no-visited-state" href="#">Change<span class="govuk-visually-hidden"> South Co-existence 1</span></a></dd>
+					</div>
+				</dl>
+			</div>
+		</div>
+
+		{# ================================================= #}
+		{# MARINE PLAN POLICIES — Economic                    #}
+		{# ================================================= #}
+		<div class="govuk-summary-card">
+			<div class="govuk-summary-card__title-wrapper">
+				<h2 class="govuk-summary-card__title">
+					Marine plan policies – Economic
+				</h2>
+			</div>
+			<div class="govuk-summary-card__content">
+				<dl class="govuk-summary-list">
+					<div class="govuk-summary-list__row">
+						<dt class="govuk-summary-list__key">South Aggregates 4 (S-AGG-4)</dt>
+						<dd class="govuk-summary-list__value">Tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam feugiat vitae ultricies eget tempor sit amet ante donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est mauris placerat eleifend leo vel orci porta non pulvinar neque laoreet.</dd>
+						<dd class="govuk-summary-list__actions"><a class="govuk-link govuk-link--no-visited-state" href="#">Change<span class="govuk-visually-hidden"> South Aggregates 4</span></a></dd>
+					</div>
+					<div class="govuk-summary-list__row">
+						<dt class="govuk-summary-list__key">South Aquaculture 2 (S-AQ-2)</dt>
+						<dd class="govuk-summary-list__value">Phasellus egestas tellus rutrum tellus pellentesque eu tincidunt tortor aliquam nulla facilisi cras fermentum odio eu feugiat pretium nibh ipsum consequat. Nisl condimentum id venenatis a condimentum vitae sapien pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas maecenas.</dd>
+						<dd class="govuk-summary-list__actions"><a class="govuk-link govuk-link--no-visited-state" href="#">Change<span class="govuk-visually-hidden"> South Aquaculture 2</span></a></dd>
+					</div>
+					<div class="govuk-summary-list__row">
+						<dt class="govuk-summary-list__key">South Cables 1 (S-CAB-1)</dt>
+						<dd class="govuk-summary-list__value">Dignissim cras tincidunt lobortis feugiat vivamus at augue eget arcu dictum varius duis at consectetur lorem donec massa sapien faucibus et molestie ac feugiat. Sed vulputate odio ut enim blandit volutpat maecenas volutpat blandit aliquam etiam erat velit scelerisque in dictum non consectetur a erat.</dd>
+						<dd class="govuk-summary-list__actions"><a class="govuk-link govuk-link--no-visited-state" href="#">Change<span class="govuk-visually-hidden"> South Cables 1</span></a></dd>
+					</div>
+					<div class="govuk-summary-list__row">
+						<dt class="govuk-summary-list__key">South Cables 2 (S-CAB-2)</dt>
+						<dd class="govuk-summary-list__value">Sit amet mauris commodo quis imperdiet massa tincidunt nunc pulvinar sapien et ligula ullamcorper malesuada proin libero nunc consequat interdum varius sit amet mattis. Vulputate dignissim suspendisse in est ante in nibh mauris cursus mattis molestie a iaculis at erat pellentesque adipiscing commodo.</dd>
+						<dd class="govuk-summary-list__actions"><a class="govuk-link govuk-link--no-visited-state" href="#">Change<span class="govuk-visually-hidden"> South Cables 2</span></a></dd>
+					</div>
+					<div class="govuk-summary-list__row">
+						<dt class="govuk-summary-list__key">South Dredging and disposal 2 (S-DD-2)</dt>
+						<dd class="govuk-summary-list__value">Egestas integer eget aliquet nibh praesent tristique magna sit amet purus gravida quis blandit turpis cursus in hac habitasse platea dictumst. Quisque sagittis purus sit amet volutpat consequat mauris nunc congue nisi vitae suscipit tellus mauris a diam maecenas sed enim ut sem viverra.</dd>
+						<dd class="govuk-summary-list__actions"><a class="govuk-link govuk-link--no-visited-state" href="#">Change<span class="govuk-visually-hidden"> South Dredging and disposal 2</span></a></dd>
+					</div>
+					<div class="govuk-summary-list__row">
+						<dt class="govuk-summary-list__key">South Infrastructure 1 (S-INF-1)</dt>
+						<dd class="govuk-summary-list__value">Arcu cursus vitae congue mauris rhoncus aenean vel elit scelerisque mauris pellentesque pulvinar pellentesque habitant morbi tristique senectus. Vel risus commodo viverra maecenas accumsan lacus vel facilisis volutpat est velit egestas dui id ornare arcu odio ut sem nulla pharetra diam sit amet.</dd>
+						<dd class="govuk-summary-list__actions"><a class="govuk-link govuk-link--no-visited-state" href="#">Change<span class="govuk-visually-hidden"> South Infrastructure 1</span></a></dd>
+					</div>
+					<div class="govuk-summary-list__row">
+						<dt class="govuk-summary-list__key">South Ports, harbours and shipping 1 (S-PS-1)</dt>
+						<dd class="govuk-summary-list__value">Adipiscing vitae proin sagittis nisl rhoncus mattis rhoncus urna neque viverra justo nec ultrices dui sapien eget mi proin sed libero enim sed faucibus turpis. In eu mi bibendum neque egestas congue quisque egestas diam in arcu cursus euismod quis viverra nibh cras pulvinar.</dd>
+						<dd class="govuk-summary-list__actions"><a class="govuk-link govuk-link--no-visited-state" href="#">Change<span class="govuk-visually-hidden"> South Ports, harbours and shipping 1</span></a></dd>
+					</div>
+					<div class="govuk-summary-list__row">
+						<dt class="govuk-summary-list__key">South Renewables 1 (S-REN-1)</dt>
+						<dd class="govuk-summary-list__value">Faucibus nisl tincidunt eget nullam non nisi est sit amet facilisis magna etiam tempor orci eu lobortis elementum nibh tellus molestie. Nunc non blandit massa enim nec dui nunc mattis enim ut tellus elementum sagittis vitae et leo duis ut diam quam nulla porttitor.</dd>
+						<dd class="govuk-summary-list__actions"><a class="govuk-link govuk-link--no-visited-state" href="#">Change<span class="govuk-visually-hidden"> South Renewables 1</span></a></dd>
+					</div>
+				</dl>
+			</div>
+		</div>
+
+		{# ================================================= #}
+		{# MARINE PLAN POLICIES — Environmental               #}
+		{# ================================================= #}
+		<div class="govuk-summary-card">
+			<div class="govuk-summary-card__title-wrapper">
+				<h2 class="govuk-summary-card__title">
+					Marine plan policies – Environmental
 				</h2>
 			</div>
 			<div class="govuk-summary-card__content">
@@ -965,107 +1060,12 @@ Check your answers before sending your information
 		</div>
 
 		{# ================================================= #}
-		{# MARINE PLAN POLICIES — Climate change              #}
+		{# MARINE PLAN POLICIES — Social                      #}
 		{# ================================================= #}
 		<div class="govuk-summary-card">
 			<div class="govuk-summary-card__title-wrapper">
 				<h2 class="govuk-summary-card__title">
-					Marine plan policies – Climate change and cumulative effects
-				</h2>
-			</div>
-			<div class="govuk-summary-card__content">
-				<dl class="govuk-summary-list">
-					<div class="govuk-summary-list__row">
-						<dt class="govuk-summary-list__key">South Climate change 1 (S-CC-1)</dt>
-						<dd class="govuk-summary-list__value">Vivamus luctus urna sed urna ultricies ac tempor dui sagittis in hac habitasse platea dictumst. Morbi tincidunt ornare massa eget egestas purus viverra accumsan in nisl nisi scelerisque eu ultrices vitae auctor eu augue ut lectus arcu bibendum at varius vel pharetra vel turpis.</dd>
-						<dd class="govuk-summary-list__actions"><a class="govuk-link govuk-link--no-visited-state" href="#">Change<span class="govuk-visually-hidden"> South Climate change 1</span></a></dd>
-					</div>
-					<div class="govuk-summary-list__row">
-						<dt class="govuk-summary-list__key">South Climate change 2 (S-CC-2)</dt>
-						<dd class="govuk-summary-list__value">Fringilla est ullamcorper eget nulla facilisi etiam dignissim diam quis enim lobortis scelerisque fermentum dui faucibus. Amet consectetur adipiscing elit pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas sed tempus urna et pharetra pharetra massa vel eros donec.</dd>
-						<dd class="govuk-summary-list__actions"><a class="govuk-link govuk-link--no-visited-state" href="#">Change<span class="govuk-visually-hidden"> South Climate change 2</span></a></dd>
-					</div>
-					<div class="govuk-summary-list__row">
-						<dt class="govuk-summary-list__key">South Climate change 3 (S-CC-3)</dt>
-						<dd class="govuk-summary-list__value">Facilisis magna etiam tempor orci eu lobortis elementum nibh tellus molestie nunc non blandit massa enim nec dui nunc mattis enim ut tellus. Elementum sagittis vitae et leo duis ut diam quam nulla porttitor massa id neque aliquam vestibulum morbi blandit cursus risus at.</dd>
-						<dd class="govuk-summary-list__actions"><a class="govuk-link govuk-link--no-visited-state" href="#">Change<span class="govuk-visually-hidden"> South Climate change 3</span></a></dd>
-					</div>
-					<div class="govuk-summary-list__row">
-						<dt class="govuk-summary-list__key">South Climate change 4 (S-CC-4)</dt>
-						<dd class="govuk-summary-list__value">Ultrices sagittis orci a scelerisque purus semper eget duis at tellus at urna condimentum mattis pellentesque id nibh. Tortor pretium viverra suspendisse potenti nullam ac tortor vitae purus faucibus ornare suspendisse sed nisi lacus sed viverra tellus in hac habitasse platea dictumst vestibulum.</dd>
-						<dd class="govuk-summary-list__actions"><a class="govuk-link govuk-link--no-visited-state" href="#">Change<span class="govuk-visually-hidden"> South Climate change 4</span></a></dd>
-					</div>
-					<div class="govuk-summary-list__row">
-						<dt class="govuk-summary-list__key">South Co-existence 1 (S-CO-1)</dt>
-						<dd class="govuk-summary-list__value">Amet venenatis urna cursus eget nunc scelerisque viverra mauris in aliquam sem fringilla ut morbi tincidunt augue interdum velit euismod. Eu volutpat odio facilisis mauris sit amet massa vitae tortor condimentum lacinia quis vel eros donec ac odio tempor orci dapibus ultrices iaculis.</dd>
-						<dd class="govuk-summary-list__actions"><a class="govuk-link govuk-link--no-visited-state" href="#">Change<span class="govuk-visually-hidden"> South Co-existence 1</span></a></dd>
-					</div>
-				</dl>
-			</div>
-		</div>
-
-		{# ================================================= #}
-		{# MARINE PLAN POLICIES — Marine activities           #}
-		{# ================================================= #}
-		<div class="govuk-summary-card">
-			<div class="govuk-summary-card__title-wrapper">
-				<h2 class="govuk-summary-card__title">
-					Marine plan policies – Marine activities and infrastructure
-				</h2>
-			</div>
-			<div class="govuk-summary-card__content">
-				<dl class="govuk-summary-list">
-					<div class="govuk-summary-list__row">
-						<dt class="govuk-summary-list__key">South Aggregates 4 (S-AGG-4)</dt>
-						<dd class="govuk-summary-list__value">Tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam feugiat vitae ultricies eget tempor sit amet ante donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est mauris placerat eleifend leo vel orci porta non pulvinar neque laoreet.</dd>
-						<dd class="govuk-summary-list__actions"><a class="govuk-link govuk-link--no-visited-state" href="#">Change<span class="govuk-visually-hidden"> South Aggregates 4</span></a></dd>
-					</div>
-					<div class="govuk-summary-list__row">
-						<dt class="govuk-summary-list__key">South Aquaculture 2 (S-AQ-2)</dt>
-						<dd class="govuk-summary-list__value">Phasellus egestas tellus rutrum tellus pellentesque eu tincidunt tortor aliquam nulla facilisi cras fermentum odio eu feugiat pretium nibh ipsum consequat. Nisl condimentum id venenatis a condimentum vitae sapien pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas maecenas.</dd>
-						<dd class="govuk-summary-list__actions"><a class="govuk-link govuk-link--no-visited-state" href="#">Change<span class="govuk-visually-hidden"> South Aquaculture 2</span></a></dd>
-					</div>
-					<div class="govuk-summary-list__row">
-						<dt class="govuk-summary-list__key">South Cables 1 (S-CAB-1)</dt>
-						<dd class="govuk-summary-list__value">Dignissim cras tincidunt lobortis feugiat vivamus at augue eget arcu dictum varius duis at consectetur lorem donec massa sapien faucibus et molestie ac feugiat. Sed vulputate odio ut enim blandit volutpat maecenas volutpat blandit aliquam etiam erat velit scelerisque in dictum non consectetur a erat.</dd>
-						<dd class="govuk-summary-list__actions"><a class="govuk-link govuk-link--no-visited-state" href="#">Change<span class="govuk-visually-hidden"> South Cables 1</span></a></dd>
-					</div>
-					<div class="govuk-summary-list__row">
-						<dt class="govuk-summary-list__key">South Cables 2 (S-CAB-2)</dt>
-						<dd class="govuk-summary-list__value">Sit amet mauris commodo quis imperdiet massa tincidunt nunc pulvinar sapien et ligula ullamcorper malesuada proin libero nunc consequat interdum varius sit amet mattis. Vulputate dignissim suspendisse in est ante in nibh mauris cursus mattis molestie a iaculis at erat pellentesque adipiscing commodo.</dd>
-						<dd class="govuk-summary-list__actions"><a class="govuk-link govuk-link--no-visited-state" href="#">Change<span class="govuk-visually-hidden"> South Cables 2</span></a></dd>
-					</div>
-					<div class="govuk-summary-list__row">
-						<dt class="govuk-summary-list__key">South Dredging and disposal 2 (S-DD-2)</dt>
-						<dd class="govuk-summary-list__value">Egestas integer eget aliquet nibh praesent tristique magna sit amet purus gravida quis blandit turpis cursus in hac habitasse platea dictumst. Quisque sagittis purus sit amet volutpat consequat mauris nunc congue nisi vitae suscipit tellus mauris a diam maecenas sed enim ut sem viverra.</dd>
-						<dd class="govuk-summary-list__actions"><a class="govuk-link govuk-link--no-visited-state" href="#">Change<span class="govuk-visually-hidden"> South Dredging and disposal 2</span></a></dd>
-					</div>
-					<div class="govuk-summary-list__row">
-						<dt class="govuk-summary-list__key">South Infrastructure 1 (S-INF-1)</dt>
-						<dd class="govuk-summary-list__value">Arcu cursus vitae congue mauris rhoncus aenean vel elit scelerisque mauris pellentesque pulvinar pellentesque habitant morbi tristique senectus. Vel risus commodo viverra maecenas accumsan lacus vel facilisis volutpat est velit egestas dui id ornare arcu odio ut sem nulla pharetra diam sit amet.</dd>
-						<dd class="govuk-summary-list__actions"><a class="govuk-link govuk-link--no-visited-state" href="#">Change<span class="govuk-visually-hidden"> South Infrastructure 1</span></a></dd>
-					</div>
-					<div class="govuk-summary-list__row">
-						<dt class="govuk-summary-list__key">South Ports, harbours and shipping 1 (S-PS-1)</dt>
-						<dd class="govuk-summary-list__value">Adipiscing vitae proin sagittis nisl rhoncus mattis rhoncus urna neque viverra justo nec ultrices dui sapien eget mi proin sed libero enim sed faucibus turpis. In eu mi bibendum neque egestas congue quisque egestas diam in arcu cursus euismod quis viverra nibh cras pulvinar.</dd>
-						<dd class="govuk-summary-list__actions"><a class="govuk-link govuk-link--no-visited-state" href="#">Change<span class="govuk-visually-hidden"> South Ports, harbours and shipping 1</span></a></dd>
-					</div>
-					<div class="govuk-summary-list__row">
-						<dt class="govuk-summary-list__key">South Renewables 1 (S-REN-1)</dt>
-						<dd class="govuk-summary-list__value">Faucibus nisl tincidunt eget nullam non nisi est sit amet facilisis magna etiam tempor orci eu lobortis elementum nibh tellus molestie. Nunc non blandit massa enim nec dui nunc mattis enim ut tellus elementum sagittis vitae et leo duis ut diam quam nulla porttitor.</dd>
-						<dd class="govuk-summary-list__actions"><a class="govuk-link govuk-link--no-visited-state" href="#">Change<span class="govuk-visually-hidden"> South Renewables 1</span></a></dd>
-					</div>
-				</dl>
-			</div>
-		</div>
-
-		{# ================================================= #}
-		{# MARINE PLAN POLICIES — Access, fisheries           #}
-		{# ================================================= #}
-		<div class="govuk-summary-card">
-			<div class="govuk-summary-card__title-wrapper">
-				<h2 class="govuk-summary-card__title">
-					Marine plan policies – Access, fisheries and sea use
+					Marine plan policies – Social
 				</h2>
 			</div>
 			<div class="govuk-summary-card__content">
@@ -1081,6 +1081,16 @@ Check your answers before sending your information
 						<dd class="govuk-summary-list__actions"><a class="govuk-link govuk-link--no-visited-state" href="#">Change<span class="govuk-visually-hidden"> South Access 2</span></a></dd>
 					</div>
 					<div class="govuk-summary-list__row">
+						<dt class="govuk-summary-list__key">South Employment 1 (S-EMP-1)</dt>
+						<dd class="govuk-summary-list__value">Aliquet sagittis id consectetur purus ut faucibus pulvinar elementum integer enim neque volutpat ac tincidunt vitae semper quis lectus nulla at volutpat. Diam maecenas ultricies mi eget mauris pharetra et ultrices neque ornare aenean euismod elementum nisi quis eleifend quam adipiscing vitae proin sagittis.</dd>
+						<dd class="govuk-summary-list__actions"><a class="govuk-link govuk-link--no-visited-state" href="#">Change<span class="govuk-visually-hidden"> South Employment 1</span></a></dd>
+					</div>
+					<div class="govuk-summary-list__row">
+						<dt class="govuk-summary-list__key">South Employment 2 (S-EMP-2)</dt>
+						<dd class="govuk-summary-list__value">Nisl rhoncus mattis rhoncus urna neque viverra justo nec ultrices dui sapien eget mi proin sed libero enim sed faucibus turpis in eu mi. Bibendum neque egestas congue quisque egestas diam in arcu cursus euismod quis viverra nibh cras pulvinar mattis nunc sed blandit libero.</dd>
+						<dd class="govuk-summary-list__actions"><a class="govuk-link govuk-link--no-visited-state" href="#">Change<span class="govuk-visually-hidden"> South Employment 2</span></a></dd>
+					</div>
+					<div class="govuk-summary-list__row">
 						<dt class="govuk-summary-list__key">South Fisheries 1 (S-FISH-1)</dt>
 						<dd class="govuk-summary-list__value">Turpis massa tincidunt dui ut ornare lectus sit amet est placerat in egestas erat imperdiet sed euismod nisi porta lorem mollis aliquam ut porttitor leo. A pellentesque sit amet porttitor eget dolor morbi non arcu risus quis varius quam quisque id diam vel quam elementum.</dd>
 						<dd class="govuk-summary-list__actions"><a class="govuk-link govuk-link--no-visited-state" href="#">Change<span class="govuk-visually-hidden"> South Fisheries 1</span></a></dd>
@@ -1094,31 +1104,6 @@ Check your answers before sending your information
 						<dt class="govuk-summary-list__key">South Fisheries 4 (S-FISH-4)</dt>
 						<dd class="govuk-summary-list__value">Volutpat lacus laoreet non curabitur gravida arcu ac tortor dignissim convallis aenean et tortor at risus viverra adipiscing at in tellus integer. Feugiat pretium nibh ipsum consequat nisl vel pretium lectus quam id leo in vitae turpis massa sed elementum tempus egestas sed sed.</dd>
 						<dd class="govuk-summary-list__actions"><a class="govuk-link govuk-link--no-visited-state" href="#">Change<span class="govuk-visually-hidden"> South Fisheries 4</span></a></dd>
-					</div>
-				</dl>
-			</div>
-		</div>
-
-		{# ================================================= #}
-		{# MARINE PLAN POLICIES — Social, economic, cultural  #}
-		{# ================================================= #}
-		<div class="govuk-summary-card">
-			<div class="govuk-summary-card__title-wrapper">
-				<h2 class="govuk-summary-card__title">
-					Marine plan policies – Social, economic and cultural considerations
-				</h2>
-			</div>
-			<div class="govuk-summary-card__content">
-				<dl class="govuk-summary-list">
-					<div class="govuk-summary-list__row">
-						<dt class="govuk-summary-list__key">South Employment 1 (S-EMP-1)</dt>
-						<dd class="govuk-summary-list__value">Aliquet sagittis id consectetur purus ut faucibus pulvinar elementum integer enim neque volutpat ac tincidunt vitae semper quis lectus nulla at volutpat. Diam maecenas ultricies mi eget mauris pharetra et ultrices neque ornare aenean euismod elementum nisi quis eleifend quam adipiscing vitae proin sagittis.</dd>
-						<dd class="govuk-summary-list__actions"><a class="govuk-link govuk-link--no-visited-state" href="#">Change<span class="govuk-visually-hidden"> South Employment 1</span></a></dd>
-					</div>
-					<div class="govuk-summary-list__row">
-						<dt class="govuk-summary-list__key">South Employment 2 (S-EMP-2)</dt>
-						<dd class="govuk-summary-list__value">Nisl rhoncus mattis rhoncus urna neque viverra justo nec ultrices dui sapien eget mi proin sed libero enim sed faucibus turpis in eu mi. Bibendum neque egestas congue quisque egestas diam in arcu cursus euismod quis viverra nibh cras pulvinar mattis nunc sed blandit libero.</dd>
-						<dd class="govuk-summary-list__actions"><a class="govuk-link govuk-link--no-visited-state" href="#">Change<span class="govuk-visually-hidden"> South Employment 2</span></a></dd>
 					</div>
 					<div class="govuk-summary-list__row">
 						<dt class="govuk-summary-list__key">South Heritage assets 1 (S-HER-1)</dt>


### PR DESCRIPTION
Retitle and restructure the marine plan policy summary cards in the check-your-answers template. Section headings were updated to 'Cross-cutting', 'Economic', 'Environmental', and 'Social', and policy rows were moved accordingly (Biodiversity, Disturbance, NIS, Marine litter, Underwater noise, Water quality moved into Environmental; Access and Fisheries moved into Social). Removed the old 'Environmental protection and impacts' block and adjusted content order to match the new categorisation.