### PR TITLE
Reorder and relabel pontoon summary fields

### DIFF
--- a/app/views/versions/multiple-sites-v2/low-complexity-v2/view-pontoon-details.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v2/view-pontoon-details.html
@@ -430,37 +430,21 @@
             </div>
             <div class="govuk-summary-card__content">
                 <dl class="govuk-summary-list">
-                    <div class="govuk-summary-list__row govuk-summary-list__row--no-border">
-                        <dt class="govuk-summary-list__key">Located in a harbour authority area?</dt>
-                        <dd class="govuk-summary-list__value">Yes</dd>
+                    <div class="govuk-summary-list__row">
+                        <dt class="govuk-summary-list__key">Special legal powers to do any of this project</dt>
+                        <dd class="govuk-summary-list__value">No</dd>
                     </div>
                     <div class="govuk-summary-list__row">
-                        <dt class="govuk-summary-list__key">Provide details of the harbour authority</dt>
+                        <dt class="govuk-summary-list__key">Located in a harbour authority area</dt>
                         <dd class="govuk-summary-list__value">Lyme Regis Harbour Authority (Dorset Council). We have been in contact with the Harbour Master, Mr D. Furner, who has confirmed in principle agreement for the proposed pontoon location. A formal harbour authority consent will be sought once marine licence approval is confirmed. Dorset Council Harbours ref: LRH/2026/MISC/041</dd>
                     </div>
                     <div class="govuk-summary-list__row">
-                        <dt class="govuk-summary-list__key">Does your organisation have special legal powers to do any of this project?</dt>
-                        <dd class="govuk-summary-list__value">No</dd>
-                    </div>
-                    <div class="govuk-summary-list__row govuk-summary-list__row--no-border">
-                        <dt class="govuk-summary-list__key">Permission from any other authorities in relation to this project?</dt>
-                        <dd class="govuk-summary-list__value">Yes</dd>
-                    </div>
-                    <div class="govuk-summary-list__row">
-                        <dt class="govuk-summary-list__key">Include details of the organisations, relevant contact details and any reference numbers</dt>
+                        <dt class="govuk-summary-list__key">Permission from any other authorities in relation to this project</dt>
                         <dd class="govuk-summary-list__value">Dorset Council Planning Department — a pre-application enquiry was made in February 2026 to confirm whether planning permission is required for the pontoon installation. We were advised that planning permission is not required as the works constitute permitted development within the harbour area, however this is subject to confirmation. Contact: planning.enquiries@dorset.gov.uk, ref PA-PRE-2026-00412.</dd>
                     </div>
-                    <div class="govuk-summary-list__row govuk-summary-list__row--no-border">
-                        <dt class="govuk-summary-list__key">Public groups or organisations consulted before making this application?</dt>
-                        <dd class="govuk-summary-list__value">Yes</dd>
-                    </div>
                     <div class="govuk-summary-list__row">
-                        <dt class="govuk-summary-list__key">Provide details of who you spoke to and the advice given</dt>
-                        <dd class="govuk-summary-list__value">
-                            <ul class="govuk-list govuk-list--bullet">
-                                We have consulted with the following: • Lyme Regis Harbour Authority (Harbour Master) — as above, in principle agreement to the proposed location obtained • Lyme Regis Fishermens Association — discussed the proposed pontoon location with the association secretary. No objections raised provided the pontoon does not obstruct access to the fishing quay, which it will not. • Dorset Wildlife Trust — contacted by email in March 2026 to flag the project and ask if there were any ecological concerns. No response received to date. • Natural England — pre-application enquiry submitted via the marine pre-application advice service. Response received confirming no objection in principle subject to confirmation that no protected species are present at the installation location.
-                            </ul>
-                        </dd>
+                        <dt class="govuk-summary-list__key">Pre-application public groups or organisations consultation</dt>
+                        <dd class="govuk-summary-list__value">We have consulted with the following: • Lyme Regis Harbour Authority (Harbour Master) — as above, in principle agreement to the proposed location obtained • Lyme Regis Fishermens Association — discussed the proposed pontoon location with the association secretary. No objections raised provided the pontoon does not obstruct access to the fishing quay, which it will not. • Dorset Wildlife Trust — contacted by email in March 2026 to flag the project and ask if there were any ecological concerns. No response received to date. • Natural England — pre-application enquiry submitted via the marine pre-application advice service. Response received confirming no objection in principle subject to confirmation that no protected species are present at the installation location.</dd>
                     </div>
                 </dl>
             </div>

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/view-details-coords-download.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/view-details-coords-download.html
@@ -434,37 +434,21 @@
             </div>
             <div class="govuk-summary-card__content">
                 <dl class="govuk-summary-list">
-                    <div class="govuk-summary-list__row govuk-summary-list__row--no-border">
-                        <dt class="govuk-summary-list__key">Located in a harbour authority area?</dt>
-                        <dd class="govuk-summary-list__value">Yes</dd>
+                    <div class="govuk-summary-list__row">
+                        <dt class="govuk-summary-list__key">Special legal powers to do any of this project</dt>
+                        <dd class="govuk-summary-list__value">No</dd>
                     </div>
                     <div class="govuk-summary-list__row">
-                        <dt class="govuk-summary-list__key">Provide details of the harbour authority</dt>
+                        <dt class="govuk-summary-list__key">Located in a harbour authority area</dt>
                         <dd class="govuk-summary-list__value">Lyme Regis Harbour Authority (Dorset Council). We have been in contact with the Harbour Master, Mr D. Furner, who has confirmed in principle agreement for the proposed pontoon location. A formal harbour authority consent will be sought once marine licence approval is confirmed. Dorset Council Harbours ref: LRH/2026/MISC/041</dd>
                     </div>
                     <div class="govuk-summary-list__row">
-                        <dt class="govuk-summary-list__key">Does your organisation have special legal powers to do any of this project?</dt>
-                        <dd class="govuk-summary-list__value">No</dd>
-                    </div>
-                    <div class="govuk-summary-list__row govuk-summary-list__row--no-border">
-                        <dt class="govuk-summary-list__key">Permission from any other authorities in relation to this project?</dt>
-                        <dd class="govuk-summary-list__value">Yes</dd>
-                    </div>
-                    <div class="govuk-summary-list__row">
-                        <dt class="govuk-summary-list__key">Include details of the organisations, relevant contact details and any reference numbers</dt>
+                        <dt class="govuk-summary-list__key">Permission from any other authorities in relation to this project</dt>
                         <dd class="govuk-summary-list__value">Dorset Council Planning Department — a pre-application enquiry was made in February 2026 to confirm whether planning permission is required for the pontoon installation. We were advised that planning permission is not required as the works constitute permitted development within the harbour area, however this is subject to confirmation. Contact: planning.enquiries@dorset.gov.uk, ref PA-PRE-2026-00412.</dd>
                     </div>
-                    <div class="govuk-summary-list__row govuk-summary-list__row--no-border">
-                        <dt class="govuk-summary-list__key">Public groups or organisations consulted before making this application?</dt>
-                        <dd class="govuk-summary-list__value">Yes</dd>
-                    </div>
                     <div class="govuk-summary-list__row">
-                        <dt class="govuk-summary-list__key">Provide details of who you spoke to and the advice given</dt>
-                        <dd class="govuk-summary-list__value">
-                            <ul class="govuk-list govuk-list--bullet">
-                                We have consulted with the following: • Lyme Regis Harbour Authority (Harbour Master) — as above, in principle agreement to the proposed location obtained • Lyme Regis Fishermens Association — discussed the proposed pontoon location with the association secretary. No objections raised provided the pontoon does not obstruct access to the fishing quay, which it will not. • Dorset Wildlife Trust — contacted by email in March 2026 to flag the project and ask if there were any ecological concerns. No response received to date. • Natural England — pre-application enquiry submitted via the marine pre-application advice service. Response received confirming no objection in principle subject to confirmation that no protected species are present at the installation location.
-                            </ul>
-                        </dd>
+                        <dt class="govuk-summary-list__key">Pre-application public groups or organisations consultation</dt>
+                        <dd class="govuk-summary-list__value">We have consulted with the following: • Lyme Regis Harbour Authority (Harbour Master) — as above, in principle agreement to the proposed location obtained • Lyme Regis Fishermens Association — discussed the proposed pontoon location with the association secretary. No objections raised provided the pontoon does not obstruct access to the fishing quay, which it will not. • Dorset Wildlife Trust — contacted by email in March 2026 to flag the project and ask if there were any ecological concerns. No response received to date. • Natural England — pre-application enquiry submitted via the marine pre-application advice service. Response received confirming no objection in principle subject to confirmation that no protected species are present at the installation location.</dd>
                     </div>
                 </dl>
             </div>

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/view-pontoon-details.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/view-pontoon-details.html
@@ -430,37 +430,21 @@
             </div>
             <div class="govuk-summary-card__content">
                 <dl class="govuk-summary-list">
-                    <div class="govuk-summary-list__row govuk-summary-list__row--no-border">
-                        <dt class="govuk-summary-list__key">Located in a harbour authority area?</dt>
-                        <dd class="govuk-summary-list__value">Yes</dd>
+                    <div class="govuk-summary-list__row">
+                        <dt class="govuk-summary-list__key">Special legal powers to do any of this project</dt>
+                        <dd class="govuk-summary-list__value">No</dd>
                     </div>
                     <div class="govuk-summary-list__row">
-                        <dt class="govuk-summary-list__key">Provide details of the harbour authority</dt>
+                        <dt class="govuk-summary-list__key">Located in a harbour authority area</dt>
                         <dd class="govuk-summary-list__value">Lyme Regis Harbour Authority (Dorset Council). We have been in contact with the Harbour Master, Mr D. Furner, who has confirmed in principle agreement for the proposed pontoon location. A formal harbour authority consent will be sought once marine licence approval is confirmed. Dorset Council Harbours ref: LRH/2026/MISC/041</dd>
                     </div>
                     <div class="govuk-summary-list__row">
-                        <dt class="govuk-summary-list__key">Does your organisation have special legal powers to do any of this project?</dt>
-                        <dd class="govuk-summary-list__value">No</dd>
-                    </div>
-                    <div class="govuk-summary-list__row govuk-summary-list__row--no-border">
-                        <dt class="govuk-summary-list__key">Permission from any other authorities in relation to this project?</dt>
-                        <dd class="govuk-summary-list__value">Yes</dd>
-                    </div>
-                    <div class="govuk-summary-list__row">
-                        <dt class="govuk-summary-list__key">Include details of the organisations, relevant contact details and any reference numbers</dt>
+                        <dt class="govuk-summary-list__key">Permission from any other authorities in relation to this project</dt>
                         <dd class="govuk-summary-list__value">Dorset Council Planning Department — a pre-application enquiry was made in February 2026 to confirm whether planning permission is required for the pontoon installation. We were advised that planning permission is not required as the works constitute permitted development within the harbour area, however this is subject to confirmation. Contact: planning.enquiries@dorset.gov.uk, ref PA-PRE-2026-00412.</dd>
                     </div>
-                    <div class="govuk-summary-list__row govuk-summary-list__row--no-border">
-                        <dt class="govuk-summary-list__key">Public groups or organisations consulted before making this application?</dt>
-                        <dd class="govuk-summary-list__value">Yes</dd>
-                    </div>
                     <div class="govuk-summary-list__row">
-                        <dt class="govuk-summary-list__key">Provide details of who you spoke to and the advice given</dt>
-                        <dd class="govuk-summary-list__value">
-                            <ul class="govuk-list govuk-list--bullet">
-                                We have consulted with the following: • Lyme Regis Harbour Authority (Harbour Master) — as above, in principle agreement to the proposed location obtained • Lyme Regis Fishermens Association — discussed the proposed pontoon location with the association secretary. No objections raised provided the pontoon does not obstruct access to the fishing quay, which it will not. • Dorset Wildlife Trust — contacted by email in March 2026 to flag the project and ask if there were any ecological concerns. No response received to date. • Natural England — pre-application enquiry submitted via the marine pre-application advice service. Response received confirming no objection in principle subject to confirmation that no protected species are present at the installation location.
-                            </ul>
-                        </dd>
+                        <dt class="govuk-summary-list__key">Pre-application public groups or organisations consultation</dt>
+                        <dd class="govuk-summary-list__value">We have consulted with the following: • Lyme Regis Harbour Authority (Harbour Master) — as above, in principle agreement to the proposed location obtained • Lyme Regis Fishermens Association — discussed the proposed pontoon location with the association secretary. No objections raised provided the pontoon does not obstruct access to the fishing quay, which it will not. • Dorset Wildlife Trust — contacted by email in March 2026 to flag the project and ask if there were any ecological concerns. No response received to date. • Natural England — pre-application enquiry submitted via the marine pre-application advice service. Response received confirming no objection in principle subject to confirmation that no protected species are present at the installation location.</dd>
                     </div>
                 </dl>
             </div>


### PR DESCRIPTION
Reordered and relabeled rows in the pontoon summary lists for clarity and consistency. Updated dt copy (eg. 'Special legal powers to do any of this project', 'Located in a harbour authority area', 'Permission from any other authorities...', 'Pre-application public groups or organisations consultation'), removed redundant no-border rows, and converted the consultation bullet list into an inline paragraph. Applied to low-complexity-v2 and v3 templates (view-pontoon-details.html and view-details-coords-download.html).