### PR TITLE
Clarify marine litter options and hints

### DIFF
--- a/app/data/iat.json
+++ b/app/data/iat.json
@@ -7358,20 +7358,21 @@
         },
         {
           "id": "marineLitter",
-          "text": "Marine litter left by divers",
-          "nextQuestionRoute": "/exemption/removal/waste/marine-litter",
-          "hint": "Any persistent, manufactured or processed solid material discarded, disposed of or abandoned in the marine and coastal environment"
+          "text": "Marine litter recovered during the course of diving activities",
+          "nextQuestionRoute": "/exemption/removal/waste/marine-litter/historic-interest",
+          "hint": "This includes any solid manufactured or processed waste and lost or discarded fishing gear."
         },
         {
           "id": "litterSeaweed",
           "text": "Litter or seaweed",
-          "nextQuestionRoute": "/exemption/removal/waste/litter-seaweed"
+          "nextQuestionRoute": "/exemption/removal/waste/litter-seaweed",
+          "hint": "By or on behalf of a local authority."
         },
         {
           "id": "litterDebris",
           "text": "Marine litter and debris",
           "nextQuestionRoute": "/exemption/removal/waste/litter-debris",
-          "hint": "Debris includes remains of something destroyed or unwanted material left scattered around"
+          "hint": "By or on behalf of a harbour authority"
         },
         {
           "id": "other",
@@ -7496,23 +7497,6 @@
           "id": "otherDeadAnimals",
           "text": "Unlikely to affect any of the listed sites",
           "outcomeRoute": "/exemption/licence-not-required-exemption-available-article-21"
-        }
-      ]
-    },
-    {
-      "route": "/exemption/removal/waste/marine-litter",
-      "text": "Will the activity involve removing marine litter or fishing gear that was discarded or lost during a dive?",
-      "section": "removal",
-      "answers": [
-        {
-          "id": "yes",
-          "text": "Yes",
-          "nextQuestionRoute": "/exemption/removal/waste/marine-litter/historic-interest"
-        },
-        {
-          "id": "no",
-          "text": "No",
-          "outcomeRoute": "/exemption/removal-exe-not-available-continue"
         }
       ]
     },


### PR DESCRIPTION
Update marine litter entry: change text to indicate litter recovered during diving activities, route directly to /exemption/removal/waste/marine-litter/historic-interest, and revise the hint. Add responsibility hints for litterSeaweed (local authority) and litterDebris (harbour authority). Remove the now-redundant intermediate question route /exemption/removal/waste/marine-litter to simplify the question flow.