### PR TITLE
Use small label style for invoice inputs

### DIFF
--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/fee-and-invoicing/invoice-contact-details.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/fee-and-invoicing/invoice-contact-details.html
@@ -45,7 +45,7 @@ Invoice contact details
 		<form action="invoice-contact-details-router{% if returnTo %}?returnTo={{ returnTo }}{% endif %}" method="post" novalidate>
 
 			{{ govukInput({
-				label: { text: "Full name" },
+				label: { text: "Full name", classes: "govuk-label--s" },
 				id: "invoice-full-name",
 				name: "invoice-full-name",
 				value: data['invoice-full-name'],
@@ -55,7 +55,7 @@ Invoice contact details
 
 			{% if isOrganisation %}
 			{{ govukInput({
-				label: { text: "Organisation name" },
+				label: { text: "Organisation name", classes: "govuk-label--s" },
 				id: "invoice-organisation-name",
 				name: "invoice-organisation-name",
 				value: data['invoice-organisation-name'],
@@ -65,7 +65,7 @@ Invoice contact details
 			{% endif %}
 
 			{{ govukInput({
-				label: { text: "Phone number" if isInternational else "UK phone number" },
+				label: { text: "Phone number" if isInternational else "UK phone number", classes: "govuk-label--s" },
 				hint: { text: "For international numbers include the country code" } if isInternational,
 				classes: "govuk-!-width-two-thirds",
 				id: "invoice-phone",
@@ -77,7 +77,7 @@ Invoice contact details
 			}) }}
 
 			{{ govukInput({
-				label: { text: "Email address" },
+				label: { text: "Email address", classes: "govuk-label--s" },
 				classes: "govuk-!-width-two-thirds",
 				id: "invoice-email",
 				name: "invoice-email",

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/fee-and-invoicing/uk-invoice-address.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/fee-and-invoicing/uk-invoice-address.html
@@ -41,7 +41,7 @@ UK invoice address
 		<form action="uk-invoice-address-router{% if returnTo %}?returnTo={{ returnTo }}{% endif %}" method="post" novalidate>
 
 			{{ govukInput({
-				label: { text: "Address line 1" },
+				label: { text: "Address line 1", classes: "govuk-label--s" },
 				id: "invoice-address-line-1",
 				name: "invoice-address-line-1",
 				value: data['invoice-address-line-1'],
@@ -50,7 +50,7 @@ UK invoice address
 			}) }}
 
 			{{ govukInput({
-				label: { text: "Address line 2 (optional)" },
+				label: { text: "Address line 2 (optional)", classes: "govuk-label--s" },
 				id: "invoice-address-line-2",
 				name: "invoice-address-line-2",
 				value: data['invoice-address-line-2'],
@@ -58,7 +58,7 @@ UK invoice address
 			}) }}
 
 			{{ govukInput({
-				label: { text: "Town or city" },
+				label: { text: "Town or city", classes: "govuk-label--s" },
 				classes: "govuk-!-width-two-thirds",
 				id: "invoice-town-city",
 				name: "invoice-town-city",
@@ -68,7 +68,7 @@ UK invoice address
 			}) }}
 
 			{{ govukInput({
-				label: { text: "County (optional)" },
+				label: { text: "County (optional)", classes: "govuk-label--s" },
 				classes: "govuk-!-width-two-thirds",
 				id: "invoice-county",
 				name: "invoice-county",
@@ -76,7 +76,7 @@ UK invoice address
 			}) }}
 
 			{{ govukInput({
-				label: { text: "Postcode" },
+				label: { text: "Postcode", classes: "govuk-label--s" },
 				classes: "govuk-input--width-10",
 				id: "invoice-postcode",
 				name: "invoice-postcode",


### PR DESCRIPTION
Add the govuk-label--s class to input labels in invoice contact and UK invoice address templates to make labels smaller and consistent across the fee-and-invoicing forms. Files updated: invoice-contact-details.html and uk-invoice-address.html. No functional changes to inputs or validation.