### PR TITLE
Clarify invoicing labels and link text

### DIFF
--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/check-your-answers.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/check-your-answers.html
@@ -1600,7 +1600,7 @@ Check your answers before sending your information
 					{% endif %}
 
 					<div class="govuk-summary-list__row govuk-summary-list__row--no-border">
-						<dt class="govuk-summary-list__key">Telephone number</dt>
+						<dt class="govuk-summary-list__key">{% if data['invoice-address-type'] == 'international' %}Phone number{% else %}UK phone number{% endif %}</dt>
 						<dd class="govuk-summary-list__value">{{ data['invoice-phone'] }}</dd>
 					</div>
 

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/fee-and-invoicing/check-invoicing-details.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/fee-and-invoicing/check-invoicing-details.html
@@ -74,14 +74,14 @@ Check your invoicing details
 
 			{% if isOrganisation %}
 			<div class="govuk-summary-list__row govuk-summary-list__row--no-border">
-				<dt class="govuk-summary-list__key">Organisation</dt>
+				<dt class="govuk-summary-list__key">Organisation name</dt>
 				<dd class="govuk-summary-list__value">{{ data['invoice-organisation-name'] }}</dd>
 				<dd class="govuk-summary-list__actions"></dd>
 			</div>
 			{% endif %}
 
 			<div class="govuk-summary-list__row govuk-summary-list__row--no-border">
-				<dt class="govuk-summary-list__key">Telephone number</dt>
+				<dt class="govuk-summary-list__key">{% if data['invoice-address-type'] == 'international' %}Phone number{% else %}UK phone number{% endif %}</dt>
 				<dd class="govuk-summary-list__value">{{ data['invoice-phone'] }}</dd>
 				<dd class="govuk-summary-list__actions"></dd>
 			</div>

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/marine-licence-start-page.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/marine-licence-start-page.html
@@ -328,7 +328,7 @@ Marine licence start page
 			<li class="govuk-task-list__item govuk-task-list__item--with-link">
 			  <div class="govuk-task-list__name-and-hint">
 				<a class="govuk-link govuk-task-list__link govuk-link--no-visited-state" href="fee-and-invoicing/{% if data['low-complexity-invoicing-completed'] %}check-invoicing-details{% else %}invoicing-start{% endif %}" aria-describedby="invoicing-status">
-				  Invoicing
+				  Invoicing details
 				</a>
 			  </div>
 


### PR DESCRIPTION
Update UI text in invoicing-related templates to improve clarity: change the phone label to be conditional on invoice-address-type (shows "Phone number" for international addresses and "UK phone number" otherwise), rename "Organisation" to "Organisation name" on the invoicing summary, and update the task list link text from "Invoicing" to "Invoicing details". Changes affect check-your-answers.html, check-invoicing-details.html, and marine-licence-start-page.html.