### PR TITLE
LCML transfer to MCMS updates

### DIFF
--- a/app/routes/versions/multiple-sites-v2/low-complexity-v3.js
+++ b/app/routes/versions/multiple-sites-v2/low-complexity-v3.js
@@ -1129,4 +1129,18 @@ module.exports = function (router) {
     res.redirect(returnPage);
   });
 
+  // Pontoon landing page – pass showBackToProjects explicitly (query is not
+  // available in auto-rendered views; only session data is)
+  router.get(`/versions/${version}/${section}/email-landings/pontoon-landing`, function (req, res) {
+    const showBackToProjects = req.query.from === 'projects';
+
+    if (!showBackToProjects) {
+      delete req.session.data.from;
+    }
+
+    res.render(`versions/${version}/${section}/email-landings/pontoon-landing`, {
+      showBackToProjects: showBackToProjects
+    });
+  });
+
 }

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/email-landings/pontoon-landing.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/email-landings/pontoon-landing.html
@@ -5,6 +5,9 @@
     {% if data['organisation-name'] %}
         {% include "../../includes/organisation-switcher.html" %}
     {% endif %}
+	{% if showBackToProjects %}
+    <a class="govuk-back-link govuk-link--no-visited-state" href="../projects">Back</a>
+    {% endif %}
 {% endblock %}
 
 {% block pageTitle %}
@@ -24,7 +27,7 @@ Your application has been transferred - {{ data['headerNameExemption'] }}
 
 		<h1 class="govuk-heading-l">Your application has been transferred</h1>
 
-		<p class="govuk-body">Your application has been transferred from Get permission for marine work to our Marine Case Management System (MCMS).</p>
+		<p class="govuk-body">Your application [MLA/2026/10003] has been transferred from Get permission for marine work to our Marine Case Management System (MCMS).</p>
 
 		<p class="govuk-body">Get permission for marine work currently processes certain types of marine licence application. MCMS processes all types, so we have transferred your application there.</p>
 
@@ -34,13 +37,15 @@ Your application has been transferred - {{ data['headerNameExemption'] }}
 
 		<p class="govuk-body">Your fee estimate may change but we will confirm that when we contact you.</p>
 
-		<p class="govuk-body">If you have an MCMS account you can <a class="govuk-link govuk-link--no-visited-state" href="../view-details/transfer">track the progress of your application</a>.</p>
+		<p class="govuk-body">If you have an MCMS account you can <a class="govuk-link" href="https://marinelicensing.marinemanagement.org.uk/mmofox5/fox/live/MMO_LOGIN/login">track the progress of your application</a>.</p>
 
 		<p class="govuk-body">If you have not heard from us or do not have access to MCMS, contact us:</p>
 
-		<p class="govuk-body">Email: <a class="govuk-link govuk-link--no-visited-state" href="#">marine.consents@marinemanagement.org.uk</a></p>
+		<p class="govuk-body">Email: <a class="govuk-link" href="#">marine.consents@marinemanagement.org.uk</a></p>
 
 		<p class="govuk-body">Phone: 0191 376 2791</p>
+
+		<p class="govuk-body"><a class="govuk-link" href="../view-details/installation-of-floating-pontoon-lyme-regis-harbour-dorset">View your submitted application in this service</a></p>
 
 	</div>
 </div>

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/emails/transfer.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/emails/transfer.html
@@ -35,7 +35,7 @@ h2 {
 </style>
 
 
-<h1>Update on your marine licence application MLA/2026/00003</h1>
+<h1>Update on your marine licence application MLA/2026/10003</h1>
 
 <p>Dear Sam Evans,</p>
 
@@ -51,13 +51,7 @@ h2 {
 
 <p>Your fee estimate may change but we will confirm that when we contact you.</p>
 
-<h2>Contact us</h2>
-
-<p>Email: <a href="#">marine.consents@marinemanagement.org.uk</a></p>
-
-<p>Phone: 0191 376 2791</p>
-
-<p><a href="../email-landings/transfer">View your application status</a></p>
+<p><a href="../email-landings/pontoon-landing">View your application status</a></p>
 
 <p>From Marine Management Organisation</p>
 

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/projects.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/projects.html
@@ -123,10 +123,10 @@ Projects
 				</tr>
 			  </thead>
 			<tbody class="govuk-table__body">
-				<tr class="govuk-table__row" data-creator="jon-doe" data-project-name="Installation of floating pontoon, Lyme Regis Harbour, Dorset" data-type="Marine licence application" data-reference="MLA-00003" data-status="Transferred">
+				<tr class="govuk-table__row" data-creator="jon-doe" data-project-name="Installation of floating pontoon, Lyme Regis Harbour, Dorset" data-type="Marine licence application" data-reference="MLA-10003" data-status="Transferred">
 					<th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Installation of floating pontoon, Lyme Regis Harbour, Dorset</th>
 					<td class="govuk-table__cell">Marine licence application</td>
-					<td class="govuk-table__cell" data-sort-value="MLA-00003">MLA/2026/00003</td>
+					<td class="govuk-table__cell" data-sort-value="MLA-10003">MLA/2026/10003</td>
 					<td class="govuk-table__cell" data-sort-value="004">
 						{{ govukTag({
 							text: "Transferred",
@@ -138,7 +138,7 @@ Projects
 					<td class="govuk-table__cell">Sam Evans</td>
 					{% endif %}
 					<td class="govuk-table__cell">
-						<a href="view-details/transfer" class="govuk-link--no-visited-state">View details</a>
+						<a href="email-landings/pontoon-landing?from=projects" class="govuk-link--no-visited-state">View details</a>
 					</td>
 				</tr>
 

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/view-details/installation-of-floating-pontoon-lyme-regis-harbour-dorset.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/view-details/installation-of-floating-pontoon-lyme-regis-harbour-dorset.html
@@ -24,7 +24,28 @@
 }) }}
 {{ govukServiceNavigation({
   serviceName: "Get permission for marine work",
-  serviceUrl: "/versions/multiple-sites-v2/low-complexity-v3/homepage"
+  serviceUrl: "/versions/multiple-sites-v2/low-complexity-v3/homepage",
+  navigation: [
+    {
+      href: "../homepage",
+      text: "Home",
+      active: false
+    },
+    {
+      href: "../projects",
+      text: "Projects",
+      active: false
+    },
+    {
+      href: "#",
+      text: "Defra account",
+      active: false
+    },
+    {
+      href: "../sign-in?goto=homepage",
+      text: "Sign out"
+    }
+  ]
 }) }}
 {% endblock %}
 
@@ -33,7 +54,7 @@
     {% if data['organisation-name'] %}
         {% include "../../includes/organisation-switcher.html" %}
     {% endif %}
-    <a class="govuk-back-link govuk-link--no-visited-state" href="../projects">Back to your projects</a>
+    <a class="govuk-back-link govuk-link--no-visited-state" href="javascript:history.back()">Back</a>
 {% endblock %}
 
 {% block pageTitle %}
@@ -45,7 +66,7 @@
 <div class="govuk-grid-row app-read-only">
     <div class="govuk-grid-column-full">
 
-        <span class="govuk-caption-l">MLA/2026/00003 – Marine licence</span>
+        <span class="govuk-caption-l">MLA/2026/10003</span>
         <h1 class="govuk-heading-l">
             Installation of floating pontoon, Lyme Regis Harbour, Dorset
         </h1>
@@ -74,7 +95,7 @@
                     </div>
                     <div class="govuk-summary-list__row">
                         <dt class="govuk-summary-list__key">Reference number</dt>
-                        <dd class="govuk-summary-list__value">MLA/2026/00003</dd>
+                        <dd class="govuk-summary-list__value">MLA/2026/10003</dd>
                     </div>
                     <div class="govuk-summary-list__row">
                         <dt class="govuk-summary-list__key">Who the Marine licence is for</dt>
@@ -85,7 +106,7 @@
                         <dd class="govuk-summary-list__value">{{ -5 | daysFromToday }}</dd>
                     </div>
                     <div class="govuk-summary-list__row">
-                        <dt class="govuk-summary-list__key">Date of move</dt>
+                        <dt class="govuk-summary-list__key">Date of transfer</dt>
                         <dd class="govuk-summary-list__value">{{ "" | todayDate }}</dd>
                     </div>
                 </dl>


### PR DESCRIPTION
Reworked the transferred-project journey to use a dedicated pontoon landing page, including a new route that passes `showBackToProjects` from the query string so the back link only appears when coming from Projects. Updated email and project table links to point to the new landing page, renamed transfer detail templates to project-specific filenames, and aligned displayed reference numbers/content to MLA/2026/10003.