### PR TITLE
Expand activity description guidance

### DIFF
--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/site-details/activity-description.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/site-details/activity-description.html
@@ -3,6 +3,7 @@
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% block beforeContent %}
     {% include "../../includes/phase-banner.html" %}
@@ -49,9 +50,25 @@ Activity description
                     </label>
                 </h1>
 
-                <p class="govuk-body">This is a summary of what you're going to do and in what order. Include the equipment you'll use, how you'll transport materials and the maximum dimensions of the marine works and materials.</p>
+                <p class="govuk-body">This is a summary of what you're going to do and in what order, including your methodology.</p>
 
-                <p class="govuk-body">For example, if you're constructing a sheet piled wall you need to tell us the maximum dimension of the wall, maximum dimension of the piles and the maximum number of piles.</p>
+                <p class="govuk-body">Your description should explain step by step how you will carry out the activity. Include:</p>
+
+                <ul class="govuk-list govuk-list--bullet">
+                    <li>the equipment you will use, including all plant and general tools</li>
+                    <li>the maximum amounts of materials you will use, for example, the total number of piles or gabion baskets</li>
+                    <li>how materials will be transported to the site, for example by road, boat or barge</li>
+                    <li>the route through the marine area if materials are transported by sea</li>
+                    <li>whether the activity will be carried out from land, the marine area, or both - and any temporary structures you will use</li>
+                    <li>the maximum dimensions of any works or structures, for example length, depth, volume and height</li>
+                </ul>
+
+                <p class="govuk-body">If the method could change, provide a worst-case scenario covering the maximum dimensions and duration.</p>
+
+                {{ govukDetails({
+                    summaryText: "Activity description example",
+                    html: "<p class=\"govuk-body\">Up to 15 existing timber fenders, together with associated fixings and fixtures (including bolts and brackets), will be removed from the quay face.</p><p class=\"govuk-body\">The fenders will be removed using a crane and man basket, operated from the quayside during low tide.</p><p class=\"govuk-body\">All removed materials, including timber fenders and associated debris (for example bolts and fittings), will be lifted directly onto the quayside.</p>"
+                }) }}
 
                 <div id="low-complexity-activity-description-hint" class="govuk-hint">
                     Enter a maximum of 1,000 characters

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/site-details/index.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/site-details/index.html
@@ -37,7 +37,7 @@ Site details
         <li>site name</li>
         <li>type of activity, for example construction</li>
         <li>category of activity, for example maintenance construction</li>
-        <li>activity description</li>
+        <li>activity description and methodology - a step-by-step explanation of how you will carry out the activity</li>
         <li>maximum duration of the activity</li>
         <li>schedule of when the activity will take place</li>
         <li>possible impacts of the activity and ways to reduce them</li>


### PR DESCRIPTION
Update the low-complexity site activity description page with clearer instructions on what applicants should include, add worst-case scenario guidance, and provide a GOV.UK details example to help users write more complete descriptions.