### PR TITLE
Add construction file upload workflow

### DIFF
--- a/app/routes/versions/multiple-sites-v2/low-complexity-v3-manual-entry.js
+++ b/app/routes/versions/multiple-sites-v2/low-complexity-v3-manual-entry.js
@@ -7,6 +7,8 @@ module.exports = function (router) {
   const manualEntry = "manual-entry";
   const basePath = `/versions/multiple-sites-v2/low-complexity-v3/site-details/manual-entry`;
   const viewBase = `${version}/${section}/${subsection}/${manualEntry}`;
+  // Shared activity/upload views live in site-details/ (not the manual-entry subfolder)
+  const sharedViewBase = `${version}/${section}/${subsection}`;
 
   // ==============================================================================================
   // Activity data keys - these are the flat session keys used by the shared activity pages
@@ -161,6 +163,28 @@ module.exports = function (router) {
         delete activity[key];
       }
     });
+  }
+
+  // ==============================================================================================
+  // Construction file upload helpers (manual entry path — per site)
+  // ==============================================================================================
+
+  // True if any activity in the given site is "Construction of new works"
+  function siteHasConstructionNew(site) {
+    if (!site || !site.activities) return false;
+    return site.activities.some(a => a['low-complexity-type-of-works'] === 'construction-new');
+  }
+
+  // Returns a site's construction files array, lazily seeding the first (mandatory)
+  // card only when the site has a construction-new activity.
+  function getConstructionFiles(site) {
+    if (siteHasConstructionNew(site)) {
+      if (!site.constructionFiles) {
+        site.constructionFiles = [{ fileNumber: 1 }];
+      }
+      return site.constructionFiles;
+    }
+    return site.constructionFiles || [];
   }
 
   // ==============================================================================================
@@ -662,6 +686,10 @@ module.exports = function (router) {
       delete req.session.data['low-complexity-manual-current-edit-activity'];
     }
 
+    // Seed the mandatory construction file card for any site with a construction-new
+    // activity (after pending activity data has been saved back to the site above)
+    sites.forEach(site => { getConstructionFiles(site); });
+
     res.render(`${viewBase}/review-site-details`, {
       data: req.session.data,
       sites: sites
@@ -690,6 +718,12 @@ module.exports = function (router) {
         if (!act['low-complexity-months-of-activity-completed']) allComplete = false;
         if (!act['low-complexity-working-hours-completed']) allComplete = false;
       });
+      // Construction file uploads must all be complete when the site has a construction-new activity
+      if (siteHasConstructionNew(site)) {
+        const files = getConstructionFiles(site);
+        if (files.length === 0) allComplete = false;
+        files.forEach(f => { if (!f.filename) allComplete = false; });
+      }
     });
 
     if (allComplete) {
@@ -852,6 +886,88 @@ module.exports = function (router) {
       const site = getSiteByNumber(req.session, siteParam);
       if (site) {
         deleteActivityFromSite(site, activityParam);
+      }
+    }
+    res.redirect(`${basePath}/review-site-details`);
+  });
+
+  // ==============================================================================================
+  // Construction file upload cards (manual entry path)
+  // ==============================================================================================
+
+  // Upload construction drawing page
+  router.get(`${basePath}/construction-upload`, function (req, res) {
+    const site = getSiteByNumber(req.session, req.query.site);
+    if (!site) {
+      return res.redirect(`${basePath}/review-site-details`);
+    }
+    const fileNumber = parseInt(req.query.file) || 1;
+    const files = getConstructionFiles(site);
+    const file = files.find(f => f.fileNumber === fileNumber) || {};
+    res.render(`${sharedViewBase}/construction-upload`, {
+      data: req.session.data,
+      siteNumber: site.siteNumber,
+      fileNumber: fileNumber,
+      filename: file.filename
+    });
+  });
+
+  // Upload construction drawing router (POST) — fakes an uploaded file
+  router.post(`${basePath}/construction-upload-router`, function (req, res) {
+    const site = getSiteByNumber(req.session, req.body['site-number']);
+    const fileNumber = parseInt(req.body['file-number']) || 1;
+    if (site) {
+      const files = getConstructionFiles(site);
+      const file = files.find(f => f.fileNumber === fileNumber);
+      if (file) file.filename = 'tech-drawing.pdf';
+    }
+    const siteNum = site ? site.siteNumber : '';
+    res.redirect(`${basePath}/review-site-details#site-${siteNum}-construction-file-${fileNumber}`);
+  });
+
+  // Add another construction file upload card
+  router.get(`${basePath}/add-construction-file`, function (req, res) {
+    const site = getSiteByNumber(req.session, req.query.site);
+    if (!site) {
+      return res.redirect(`${basePath}/review-site-details`);
+    }
+    const files = getConstructionFiles(site);
+    const fileNumber = files.length + 1;
+    files.push({ fileNumber: fileNumber });
+    // New incomplete card means site details are no longer confirmed complete
+    delete req.session.data['site-details-confirmed-complete'];
+    res.redirect(`${basePath}/review-site-details#site-${site.siteNumber}-construction-file-${fileNumber}`);
+  });
+
+  // Delete construction file upload card — confirmation page
+  router.get(`${basePath}/delete-construction-file`, function (req, res) {
+    const site = getSiteByNumber(req.session, req.query.site);
+    if (!site) {
+      return res.redirect(`${basePath}/review-site-details`);
+    }
+    const fileNumber = parseInt(req.query.file);
+    const files = getConstructionFiles(site);
+    const file = files.find(f => f.fileNumber === fileNumber);
+    if (!file) {
+      return res.redirect(`${basePath}/review-site-details`);
+    }
+    res.render(`${sharedViewBase}/delete-construction-file`, {
+      data: req.session.data,
+      siteNumber: site.siteNumber,
+      fileNumber: fileNumber,
+      filename: file.filename
+    });
+  });
+
+  router.post(`${basePath}/delete-construction-file-router`, function (req, res) {
+    const site = getSiteByNumber(req.session, req.body['site-number']);
+    const fileNumber = parseInt(req.body['file-number']);
+    if (site && fileNumber) {
+      const files = getConstructionFiles(site);
+      const index = files.findIndex(f => f.fileNumber === fileNumber);
+      if (index > -1) {
+        files.splice(index, 1);
+        files.forEach((f, i) => { f.fileNumber = i + 1; });
       }
     }
     res.redirect(`${basePath}/review-site-details`);

--- a/app/routes/versions/multiple-sites-v2/low-complexity-v3-site-locations.js
+++ b/app/routes/versions/multiple-sites-v2/low-complexity-v3-site-locations.js
@@ -89,6 +89,59 @@ module.exports = function (router) {
     });
   }
 
+  // ==============================================================================================
+  // Construction file upload helpers (file upload path — single Site 1)
+  // ==============================================================================================
+
+  // True if any activity in the site is "Construction of new works"
+  function siteHasConstructionNew(session) {
+    const activities = getFileUploadActivities(session);
+    return activities.some(a => a['low-complexity-type-of-works'] === 'construction-new');
+  }
+
+  // Returns the construction files array, lazily seeding the first (mandatory)
+  // card only when the site actually has a construction-new activity.
+  function getConstructionFiles(session) {
+    if (siteHasConstructionNew(session)) {
+      if (!session.data['low-complexity-construction-files']) {
+        session.data['low-complexity-construction-files'] = [{ fileNumber: 1 }];
+      }
+      return session.data['low-complexity-construction-files'];
+    }
+    return session.data['low-complexity-construction-files'] || [];
+  }
+
+  function clearConstructionFiles(session) {
+    delete session.data['low-complexity-construction-files'];
+    delete session.data['construction-delete-next'];
+  }
+
+  // The type-of-activity page is shared by the file upload and manual entry paths.
+  // This returns the activity/file context for whichever path is currently editing,
+  // so the "changing your activity deletes your files" flow works for both.
+  function getConstructionEditContext(session) {
+    if (session.data['low-complexity-site-location-method'] === 'manual-entry') {
+      const siteNum = parseInt(session.data['low-complexity-manual-current-edit-site']);
+      const actNum = parseInt(session.data['low-complexity-manual-current-edit-activity']);
+      const sites = session.data['low-complexity-manual-sites'] || [];
+      const site = sites.find(s => s.siteNumber === siteNum);
+      return {
+        method: 'manual-entry',
+        site: site,
+        activities: site ? (site.activities || []) : [],
+        actNum: actNum,
+        files: site ? site.constructionFiles : undefined
+      };
+    }
+    return {
+      method: 'file-upload',
+      site: null,
+      activities: getFileUploadActivities(session),
+      actNum: parseInt(session.data['low-complexity-current-edit-activity']),
+      files: session.data['low-complexity-construction-files']
+    };
+  }
+
   // Helper to redirect to the correct review page based on entry method
   function getReviewUrl(session, anchor) {
     const isManual = session.data['low-complexity-site-location-method'] === 'manual-entry';
@@ -254,8 +307,14 @@ module.exports = function (router) {
     // Ensure activities array exists
     const activities = getFileUploadActivities(req.session);
 
+    // Construction file uploads (only relevant when a construction-new activity exists)
+    const hasConstructionNew = siteHasConstructionNew(req.session);
+    const constructionFiles = hasConstructionNew ? getConstructionFiles(req.session) : [];
+
     res.render(`versions/${version}/${section}/${subsection}/review-site-details`, {
-      activities: activities
+      activities: activities,
+      hasConstructionNew: hasConstructionNew,
+      constructionFiles: constructionFiles
     });
   });
 
@@ -280,6 +339,13 @@ module.exports = function (router) {
       if (!act['low-complexity-months-of-activity-completed']) allComplete = false;
       if (!act['low-complexity-working-hours-completed']) allComplete = false;
     });
+
+    // Construction file uploads must all be complete when a construction-new activity exists
+    if (siteHasConstructionNew(req.session)) {
+      const constructionFiles = getConstructionFiles(req.session);
+      if (constructionFiles.length === 0) allComplete = false;
+      constructionFiles.forEach(f => { if (!f.filename) allComplete = false; });
+    }
 
     if (allComplete) {
       // Validate the radio selection
@@ -379,6 +445,117 @@ module.exports = function (router) {
   });
 
   /////////////////////////////////////////////////////////
+  //////// Construction file upload cards (file upload path)
+  /////////////////////////////////////////////////////////
+
+  // Upload construction drawing page
+  router.get(`/versions/${version}/${section}/${subsection}/construction-upload`, function (req, res) {
+    const fileNumber = parseInt(req.query.file) || 1;
+    const files = getConstructionFiles(req.session);
+    const file = files.find(f => f.fileNumber === fileNumber) || {};
+    res.render(`versions/${version}/${section}/${subsection}/construction-upload`, {
+      siteNumber: 1,
+      fileNumber: fileNumber,
+      filename: file.filename
+    });
+  });
+
+  // Upload construction drawing router (POST) — fakes an uploaded file
+  router.post(`/versions/${version}/${section}/${subsection}/construction-upload-router`, function (req, res) {
+    const fileNumber = parseInt(req.body['file-number']) || 1;
+    const files = getConstructionFiles(req.session);
+    const file = files.find(f => f.fileNumber === fileNumber);
+    if (file) {
+      file.filename = 'tech-drawing.pdf';
+    }
+    res.redirect(`/versions/${version}/${section}/${subsection}/review-site-details#site-1-construction-file-${fileNumber}`);
+  });
+
+  // Add another construction file upload card
+  router.get(`/versions/${version}/${section}/${subsection}/add-construction-file`, function (req, res) {
+    const files = getConstructionFiles(req.session);
+    const fileNumber = files.length + 1;
+    files.push({ fileNumber: fileNumber });
+    // New incomplete card means site details are no longer confirmed complete
+    delete req.session.data['site-details-confirmed-complete'];
+    res.redirect(`/versions/${version}/${section}/${subsection}/review-site-details#site-1-construction-file-${fileNumber}`);
+  });
+
+  // Delete construction file upload card — confirmation page
+  router.get(`/versions/${version}/${section}/${subsection}/delete-construction-file`, function (req, res) {
+    const fileNumber = parseInt(req.query.file);
+    const files = getConstructionFiles(req.session);
+    const file = files.find(f => f.fileNumber === fileNumber);
+    if (!file) {
+      return res.redirect(`/versions/${version}/${section}/${subsection}/review-site-details`);
+    }
+    res.render(`versions/${version}/${section}/${subsection}/delete-construction-file`, {
+      siteNumber: 1,
+      fileNumber: fileNumber,
+      filename: file.filename
+    });
+  });
+
+  router.post(`/versions/${version}/${section}/${subsection}/delete-construction-file-router`, function (req, res) {
+    const fileNumber = parseInt(req.body['file-number']);
+    if (fileNumber) {
+      const files = getConstructionFiles(req.session);
+      const index = files.findIndex(f => f.fileNumber === fileNumber);
+      if (index > -1) {
+        files.splice(index, 1);
+        // Renumber remaining cards
+        files.forEach((f, i) => { f.fileNumber = i + 1; });
+      }
+    }
+    res.redirect(`/versions/${version}/${section}/${subsection}/review-site-details`);
+  });
+
+  // Delete-on-change confirmation page (shared by both paths)
+  router.get(`/versions/${version}/${section}/${subsection}/delete-construction-files-on-change`, function (req, res) {
+    const ctx = getConstructionEditContext(req.session);
+    res.render(`versions/${version}/${section}/${subsection}/delete-construction-files-on-change`, {
+      siteNumber: ctx.method === 'manual-entry' ? (ctx.site ? ctx.site.siteNumber : '') : 1
+    });
+  });
+
+  // Delete-on-change confirmation — Yes, delete files (method-aware)
+  router.post(`/versions/${version}/${section}/${subsection}/delete-construction-files-on-change-router`, function (req, res) {
+    const ctx = getConstructionEditContext(req.session);
+    // Capture the onward URL before clearing (clearConstructionFiles also wipes it)
+    const next = req.session.data['construction-delete-next'] || 'review-site-details';
+    if (ctx.method === 'manual-entry') {
+      if (ctx.site) delete ctx.site.constructionFiles;
+      delete req.session.data['construction-delete-next'];
+    } else {
+      clearConstructionFiles(req.session);
+    }
+    res.redirect(next);
+  });
+
+  // Delete-on-change confirmation — Cancel (courtesy: go back a page to
+  // type-of-activity with the original "Construction of new works" restored)
+  router.get(`/versions/${version}/${section}/${subsection}/delete-construction-files-on-change-cancel`, function (req, res) {
+    const ctx = getConstructionEditContext(req.session);
+    if (ctx.method === 'manual-entry') {
+      // Reload the manual site's activity so the type-of-works reverts to construction-new
+      const activity = ctx.activities.find(a => a.activityNumber === ctx.actNum);
+      if (activity) {
+        ACTIVITY_DATA_KEYS.forEach(key => { delete req.session.data[key]; });
+        ACTIVITY_DATA_KEYS.forEach(key => {
+          if (activity[key] !== undefined) req.session.data[key] = activity[key];
+        });
+      }
+    } else {
+      const currentEditActivity = req.session.data['low-complexity-current-edit-activity'];
+      if (currentEditActivity) {
+        loadFileUploadActivityToSession(req.session, currentEditActivity);
+      }
+    }
+    delete req.session.data['construction-delete-next'];
+    res.redirect('type-of-activity');
+  });
+
+  /////////////////////////////////////////////////////////
   //////// Site name page
   /////////////////////////////////////////////////////////
   router.get(`/versions/${version}/${section}/${subsection}/site-name`, function (req, res) {
@@ -425,6 +602,13 @@ module.exports = function (router) {
     delete req.session.data['low-complexity-type-of-works-error'];
     delete req.session.data['low-complexity-deposit-type-error'];
     delete req.session.data['low-complexity-removal-type-error'];
+
+    // Capture whether the activity being edited was previously "Construction of
+    // new works" — its old value still lives in the activities array (session is
+    // only saved back to the array on the review page). Works for both paths.
+    const editContext = getConstructionEditContext(req.session);
+    const editingActivity = editContext.activities.find(a => a.activityNumber === editContext.actNum);
+    const oldWasConstructionNew = editingActivity && editingActivity['low-complexity-type-of-works'] === 'construction-new';
 
     // Detect changes in sub-types to clear page 2 data when sub-type changes
     const previousTypeOfActivity = req.session.data['low-complexity-type-of-activity-previous'];
@@ -532,18 +716,36 @@ module.exports = function (router) {
     req.session.data['low-complexity-deposit-type-previous'] = req.session.data['low-complexity-deposit-type'];
     req.session.data['low-complexity-removal-type-previous'] = req.session.data['low-complexity-removal-type'];
 
-    // Route based on activity type
+    // Work out where the change would normally take the user next
+    let nextUrl;
     if (req.session.data['low-complexity-type-of-activity'] === 'construction') {
-      res.redirect('construction-structures');
+      nextUrl = 'construction-structures';
     } else if (req.session.data['low-complexity-type-of-activity'] === 'deposit') {
-      res.redirect('deposit-substances-objects');
+      nextUrl = 'deposit-substances-objects';
     } else if (req.session.data['low-complexity-type-of-activity'] === 'removal') {
-      res.redirect('removal-substances-objects');
+      nextUrl = 'removal-substances-objects';
     } else {
-      // Mark as completed and redirect to review page for other activities
+      // Mark as completed and go to review page for other activities
       req.session.data['low-complexity-type-of-activity-completed'] = true;
-      res.redirect(getReviewUrl(req.session, 'site-1-activity-1'));
+      nextUrl = getReviewUrl(req.session, 'site-1-activity-1');
     }
+
+    // If the activity was "Construction of new works" and is being changed away
+    // from it, leaving the site with no construction-new activity while uploaded
+    // drawings exist, warn the user their files will be deleted before proceeding.
+    const newTypeOfWorks = req.session.data['low-complexity-type-of-works'];
+    if (oldWasConstructionNew && newTypeOfWorks !== 'construction-new') {
+      const otherConstructionNew = editContext.activities.some(a =>
+        a.activityNumber !== editContext.actNum &&
+        a['low-complexity-type-of-works'] === 'construction-new');
+      const hasFiles = editContext.files && editContext.files.length > 0;
+      if (!otherConstructionNew && hasFiles) {
+        req.session.data['construction-delete-next'] = nextUrl;
+        return res.redirect('delete-construction-files-on-change');
+      }
+    }
+
+    res.redirect(nextUrl);
   });
 
   /////////////////////////////////////////////////////////
@@ -928,6 +1130,10 @@ module.exports = function (router) {
     // File upload activities array
     delete req.session.data['low-complexity-file-upload-activities'];
     delete req.session.data['low-complexity-current-edit-activity'];
+
+    // Construction file uploads
+    delete req.session.data['low-complexity-construction-files'];
+    delete req.session.data['construction-delete-next'];
 
     // Flat activity session keys
     ACTIVITY_DATA_KEYS.forEach(key => {

--- a/app/routes/versions/multiple-sites-v2/low-complexity-v3.js
+++ b/app/routes/versions/multiple-sites-v2/low-complexity-v3.js
@@ -827,6 +827,8 @@ module.exports = function (router) {
     // Clear site details data
     delete req.session.data['has-visited-site-details'];
     delete req.session.data['low-complexity-site-name-completed'];
+    delete req.session.data['low-complexity-construction-files'];
+    delete req.session.data['construction-delete-next'];
     delete req.session.data['low-complexity-type-of-activity'];
     delete req.session.data['low-complexity-type-of-works'];
     delete req.session.data['low-complexity-type-of-works-previous'];
@@ -1179,7 +1181,8 @@ module.exports = function (router) {
       'start-date-month', 'start-date-year', 'end-date-month', 'end-date-year', 'low-complexity-dates-completed',
       'low-complexity-site-location-method', 'has-visited-site-details',
       'low-complexity-site-name', 'low-complexity-site-name-completed',
-      'low-complexity-file-upload-activities', 'site-details-confirmed-complete',
+      'low-complexity-file-upload-activities', 'low-complexity-construction-files',
+      'construction-delete-next', 'site-details-confirmed-complete',
       'mpp-previously-unlocked',
       'low-complexity-wfd-within-nautical-mile', 'low-complexity-wfd-completed',
       'low-complexity-special-legal-powers', 'low-complexity-special-legal-powers-completed',
@@ -1267,6 +1270,10 @@ module.exports = function (router) {
         'low-complexity-working-hours': 'Marine operations on a 24-hour basis over a continuous installation window of up to 5 days. Landfall works at each shore end limited to Monday to Saturday, 07:00 to 19:00.',
         'low-complexity-working-hours-completed': true
       }
+    ];
+    // Construction of new works activity — seed a completed construction drawing upload
+    d['low-complexity-construction-files'] = [
+      { fileNumber: 1, filename: 'tech-drawing.pdf' }
     ];
     d['site-details-confirmed-complete'] = true;
 

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/site-details/construction-upload.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/site-details/construction-upload.html
@@ -1,0 +1,58 @@
+{% extends "../../layouts/low-complexity-v3.html" %}
+
+{% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block beforeContent %}
+    {% include "../../includes/phase-banner.html" %}
+    {% if data['organisation-name'] %}
+        {% include "../../includes/organisation-switcher.html" %}
+    {% endif %}
+    <a class="govuk-back-link" href="javascript:history.back()">Back</a>
+{% endblock %}
+
+{% set pageHeadingTextHTML %}
+Site {{ siteNumber }}: Upload construction drawing {{ fileNumber }}
+{% endset %}
+
+{% block pageTitle %}
+    {{ pageHeadingTextHTML }} - {{ data['headerNameExemption'] }}
+{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+        <form action="construction-upload-router" method="post" novalidate>
+            <input type="hidden" name="site-number" value="{{ siteNumber }}">
+            <input type="hidden" name="file-number" value="{{ fileNumber }}">
+
+            <div class="govuk-form-group">
+                <span class="govuk-caption-l">{{ data['low-complexity-project-name-text-input'] }}</span>
+                <h1 class="govuk-label-wrapper">
+                    <label class="govuk-label govuk-label--l" for="file-upload-1" id="file-upload-1-label">
+                        {{ pageHeadingTextHTML }}
+                    </label>
+                </h1>
+
+                <p class="govuk-body">Upload a drawing showing what you plan to build. A simple, clear drawing is fine. It does not need to be produced by an architect or other professional. The file must be a PDF (TBC). (add max file size here - tbc)</p>
+
+                {{ govukFileUpload({
+                    id: "file-upload-1",
+                    name: "fileUpload1",
+                    javascript: true
+                }) }}
+
+                <div class="govuk-button-group">
+                    {{ govukButton({
+                        text: "Save and continue"
+                    }) }}
+                    <a class="govuk-link govuk-link--no-visited-state" href="review-site-details">Cancel</a>
+                </div>
+            </div>
+        </form>
+
+    </div>
+</div>
+
+{% endblock %}

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/site-details/delete-construction-file.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/site-details/delete-construction-file.html
@@ -1,0 +1,48 @@
+{% extends "../../layouts/low-complexity-v3.html" %}
+
+{% block beforeContent %}
+    {% include "../../includes/phase-banner.html" %}
+    {% if data['organisation-name'] %}
+        {% include "../../includes/organisation-switcher.html" %}
+    {% endif %}
+    <a class="govuk-back-link" href="javascript:history.back()">Back</a>
+{% endblock %}
+
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set pageHeadingTextHTML %}
+Are you sure you want to delete construction drawing {{ fileNumber }} for Site {{ siteNumber }}?
+{% endset %}
+
+{% block pageTitle %}
+    {{ pageHeadingTextHTML }} - {{ data['headerNameExemption'] }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l">{{ data['low-complexity-project-name-text-input'] }}</span>
+    <h1 class="govuk-heading-l">
+      {{ pageHeadingTextHTML }}
+    </h1>
+
+    <div class="govuk-inset-text">
+      The drawing '{{ filename or 'tech-drawing.pdf' }}' will be removed from your application.
+    </div>
+
+    <form action="delete-construction-file-router" method="post" novalidate>
+      <input type="hidden" name="site-number" value="{{ siteNumber }}">
+      <input type="hidden" name="file-number" value="{{ fileNumber }}">
+      <div class="govuk-button-group govuk-!-margin-top-7">
+        {{ govukButton({
+          text: "Yes, delete file upload",
+          classes: "govuk-button--warning"
+        }) }}
+        <a class="govuk-link govuk-link--no-visited-state" href="review-site-details">Cancel</a>
+      </div>
+    </form>
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/site-details/delete-construction-files-on-change.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/site-details/delete-construction-files-on-change.html
@@ -1,0 +1,47 @@
+{% extends "../../layouts/low-complexity-v3.html" %}
+
+{% block beforeContent %}
+    {% include "../../includes/phase-banner.html" %}
+    {% if data['organisation-name'] %}
+        {% include "../../includes/organisation-switcher.html" %}
+    {% endif %}
+    <a class="govuk-back-link" href="javascript:history.back()">Back</a>
+{% endblock %}
+
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set pageHeadingTextHTML %}
+Changing your type of activity will delete your construction drawings
+{% endset %}
+
+{% block pageTitle %}
+    {{ pageHeadingTextHTML }} - {{ data['headerNameExemption'] }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l">{{ data['low-complexity-project-name-text-input'] }}</span>
+    <h1 class="govuk-heading-l">
+      {{ pageHeadingTextHTML }}
+    </h1>
+
+    <div class="govuk-inset-text">
+      <p class="govuk-body">You only need construction drawings for construction of new marine works.</p>
+      <p class="govuk-body govuk-!-margin-bottom-0">If you select construction of new marine works again later, you'll need to upload your drawings again.</p>
+    </div>
+
+    <form action="delete-construction-files-on-change-router" method="post" novalidate>
+      <div class="govuk-button-group govuk-!-margin-top-7">
+        {{ govukButton({
+          text: "Yes, continue",
+          classes: "govuk-button--warning"
+        }) }}
+        <a class="govuk-link govuk-link--no-visited-state" href="delete-construction-files-on-change-cancel">Cancel</a>
+      </div>
+    </form>
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/site-details/manual-entry/review-site-details.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/site-details/manual-entry/review-site-details.html
@@ -59,6 +59,18 @@ Review site details
                 {% if not activity['low-complexity-months-of-activity-completed'] %}{% set allComplete = false %}{% endif %}
                 {% if not activity['low-complexity-working-hours-completed'] %}{% set allComplete = false %}{% endif %}
             {% endfor %}
+            {# Construction file uploads must all be complete when the site has a construction-new activity #}
+            {% set siteHasConstructionNewCheck = false %}
+            {% for activity in siteActivities %}
+                {% if activity['low-complexity-type-of-works'] == 'construction-new' %}{% set siteHasConstructionNewCheck = true %}{% endif %}
+            {% endfor %}
+            {% if siteHasConstructionNewCheck %}
+                {% set siteFiles = site.constructionFiles if site.constructionFiles else [] %}
+                {% if siteFiles.length == 0 %}{% set allComplete = false %}{% endif %}
+                {% for file in siteFiles %}
+                    {% if not file.filename %}{% set allComplete = false %}{% endif %}
+                {% endfor %}
+            {% endif %}
         {% endfor %}
 
         {% if not allComplete %}
@@ -637,6 +649,57 @@ Review site details
             <p class="govuk-body govuk-!-margin-bottom-6">
                 <a href="add-activity?site={{ site.siteNumber }}" class="govuk-button govuk-button--secondary">Add another activity for site {{ site.siteNumber }}</a>
             </p>
+
+            <!-- Construction activity file uploads for this site (only when a construction-new activity exists) -->
+            {% set siteHasConstructionNew = false %}
+            {% for a in siteActivities %}
+                {% if a['low-complexity-type-of-works'] == 'construction-new' %}{% set siteHasConstructionNew = true %}{% endif %}
+            {% endfor %}
+            {% if siteHasConstructionNew %}
+                {% for file in (site.constructionFiles if site.constructionFiles else []) %}
+                <div id="site-{{ site.siteNumber }}-construction-file-{{ file.fileNumber }}" class="govuk-summary-card">
+                    <div class="govuk-summary-card__title-wrapper">
+                        <h2 class="govuk-summary-card__title">
+                            Site {{ site.siteNumber }} - Construction activity file upload {{ file.fileNumber }}
+                        </h2>
+                        {% if file.fileNumber > 1 %}
+                        <ul class="govuk-summary-card__actions">
+                            <li class="govuk-summary-card__action">
+                                <a class="govuk-link govuk-link--no-visited-state" href="delete-construction-file?site={{ site.siteNumber }}&file={{ file.fileNumber }}">
+                                    Delete file upload<span class="govuk-visually-hidden"> {{ file.fileNumber }} for site {{ site.siteNumber }}</span>
+                                </a>
+                            </li>
+                        </ul>
+                        {% endif %}
+                    </div>
+                    <div class="govuk-summary-card__content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row">
+                                <dt class="govuk-summary-list__key">
+                                    File upload
+                                </dt>
+                                <dd class="govuk-summary-list__value">
+                                    {% if file.filename %}
+                                        {{ file.filename }}
+                                    {% else %}
+                                        <span class="govuk-tag govuk-tag--red">Incomplete</span>
+                                    {% endif %}
+                                </dd>
+                                <dd class="govuk-summary-list__actions">
+                                    <a href="construction-upload?site={{ site.siteNumber }}&file={{ file.fileNumber }}" class="govuk-link govuk-link--no-visited-state">
+                                        {% if file.filename %}Change{% else %}Add{% endif %}<span class="govuk-visually-hidden"> construction file upload {{ file.fileNumber }} for site {{ site.siteNumber }}</span>
+                                    </a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                {% endfor %}
+
+                <p class="govuk-body govuk-!-margin-bottom-6">
+                    <a href="add-construction-file?site={{ site.siteNumber }}" class="govuk-button govuk-button--secondary">Add another construction file upload for site {{ site.siteNumber }}</a>
+                </p>
+            {% endif %}
 
             {% endfor %}
         {% else %}

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/site-details/review-site-details.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/site-details/review-site-details.html
@@ -56,7 +56,13 @@ Review site details
             {% if not act['low-complexity-months-of-activity-completed'] %}{% set allComplete = false %}{% endif %}
             {% if not act['low-complexity-working-hours-completed'] %}{% set allComplete = false %}{% endif %}
         {% endfor %}
-        
+        {% if hasConstructionNew %}
+            {% if constructionFiles.length == 0 %}{% set allComplete = false %}{% endif %}
+            {% for file in constructionFiles %}
+                {% if not file.filename %}{% set allComplete = false %}{% endif %}
+            {% endfor %}
+        {% endif %}
+
         {% if not allComplete %}
             {{ govukInsetText({
                 html: "The site details you've provided are saved.<br>You must complete all sections marked <span class='govuk-tag govuk-tag--red govuk-!-margin-bottom-2 govuk-!-margin-top-2'>Incomplete</span> before you can send your information.<br>If you cannot finish now, you can return to this page later."
@@ -486,6 +492,53 @@ Review site details
         <p class="govuk-body">
             <a href="add-activity" class="govuk-button govuk-button--secondary">Add another activity for site 1</a>
         </p>
+
+        <!-- Construction activity file uploads (only when a construction-new activity exists) -->
+        {% if hasConstructionNew %}
+            {% for file in constructionFiles %}
+            <div id="site-1-construction-file-{{ file.fileNumber }}" class="govuk-summary-card">
+                <div class="govuk-summary-card__title-wrapper">
+                    <h2 class="govuk-summary-card__title">
+                        Site 1 - Construction activity file upload {{ file.fileNumber }}
+                    </h2>
+                    {% if file.fileNumber > 1 %}
+                    <ul class="govuk-summary-card__actions">
+                        <li class="govuk-summary-card__action">
+                            <a class="govuk-link govuk-link--no-visited-state" href="delete-construction-file?file={{ file.fileNumber }}">
+                                Delete file upload<span class="govuk-visually-hidden"> {{ file.fileNumber }} for site 1</span>
+                            </a>
+                        </li>
+                    </ul>
+                    {% endif %}
+                </div>
+                <div class="govuk-summary-card__content">
+                    <dl class="govuk-summary-list">
+                        <div class="govuk-summary-list__row">
+                            <dt class="govuk-summary-list__key">
+                                File upload
+                            </dt>
+                            <dd class="govuk-summary-list__value">
+                                {% if file.filename %}
+                                    {{ file.filename }}
+                                {% else %}
+                                    <span class="govuk-tag govuk-tag--red">Incomplete</span>
+                                {% endif %}
+                            </dd>
+                            <dd class="govuk-summary-list__actions">
+                                <a href="construction-upload?file={{ file.fileNumber }}" class="govuk-link govuk-link--no-visited-state">
+                                    {% if file.filename %}Change{% else %}Add{% endif %}<span class="govuk-visually-hidden"> construction file upload {{ file.fileNumber }} for site 1</span>
+                                </a>
+                            </dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+            {% endfor %}
+
+            <p class="govuk-body">
+                <a href="add-construction-file" class="govuk-button govuk-button--secondary">Add another construction file upload for site 1</a>
+            </p>
+        {% endif %}
 
         <form action="review-site-details-router" method="post" novalidate>
             {% if allComplete %}


### PR DESCRIPTION
Add file upload functionality for construction drawings in low-complexity-v3. Users can now upload, add, and delete construction drawing files when a site has a 'construction of new marine works' activity. Includes:

- Construction file upload, add, and delete routes for both file-upload and manual-entry paths
- Lazy-seeded construction files array (only created when construction-new activity exists)
- Validation ensuring all construction files are complete before submission
- Warning page when users change activity type away from construction (if drawings exist)
- New templates for file upload, delete confirmation, and delete-on-change flows
- Updated review pages to display construction file upload cards with completion status

Some content is placeholder and the Before you start page content will change