### PR TITLE
Add email inbox view and mail chrome components

### DIFF
--- a/app/filters.js
+++ b/app/filters.js
@@ -81,6 +81,22 @@ addFilter('daysFromToday', function(offset) {
 });
 
 /**
+ * Returns a short date relative to today, as email clients show it
+ * Usage: {{ -5 | inboxDate }} gives "15 Jul"
+ */
+addFilter('inboxDate', function(offset) {
+  const days = parseInt(offset, 10) || 0;
+  const date = new Date();
+  date.setDate(date.getDate() + days);
+
+  const monthNames = [
+    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
+  ];
+  return `${date.getDate()} ${monthNames[date.getMonth()]}`;
+});
+
+/**
  * Returns a YYMMDD sort value for a date relative to today
  * Usage: {{ -5 | daysFromTodaySort }}
  */

--- a/app/routes/versions/multiple-sites-v2/low-complexity-v3.js
+++ b/app/routes/versions/multiple-sites-v2/low-complexity-v3.js
@@ -1236,7 +1236,7 @@ module.exports = function (router) {
 
     // --- Project details ---
     d['low-complexity-project-name-text-input'] = 'Plymouth Sound cable laying';
-    d['low-complexity-project-background'] = "Southwest Marine Works Ltd will install a subsea telecommunications cable across Plymouth Sound to connect a new coastal monitoring station on Mount Batten to the mainland network. The works involve laying approximately 2.4 kilometres of fibre optic cable along a pre-surveyed route on the seabed, with sections buried using a jetting sled to protect the cable from vessel anchors and fishing activity. Landfall points will be established at Mount Batten Pier and Queen Anne's Battery, with cable protection installed at both shore ends.";
+    d['low-complexity-project-background'] = "Jurassic Coast SUP Ltd will install a subsea telecommunications cable across Plymouth Sound to connect a new coastal monitoring station on Mount Batten to the mainland network. The works involve laying approximately 2.4 kilometres of fibre optic cable along a pre-surveyed route on the seabed, with sections buried using a jetting sled to protect the cable from vessel anchors and fishing activity. Landfall points will be established at Mount Batten Pier and Queen Anne's Battery, with cable protection installed at both shore ends.";
     d['low-complexity-project-background-completed'] = true;
 
     d['start-date-month'] = '6';
@@ -1320,7 +1320,7 @@ module.exports = function (router) {
     d['invoice-county'] = 'Devon';
     d['invoice-postcode'] = 'PL4 0LP';
     d['invoice-full-name'] = 'Rachel Stow';
-    d['invoice-organisation-name'] = 'Southwest Marine Works Ltd';
+    d['invoice-organisation-name'] = 'Jurassic Coast SUP Ltd';
     d['invoice-phone'] = '01752 900123';
     d['invoice-email'] = 'accounts@southwestmarineworks.co.uk';
     d['invoice-po-required'] = 'no';

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -80,9 +80,11 @@ html: ''
     <h3 class="govuk-heading-s">Notifications</h3>
 
     <ul class="govuk-list govuk-list--spaced">
+      <li><a href="versions/multiple-sites-v2/low-complexity-v3/emails/inbox?organisation-name=Jurassic%20Coast%20SUP%20Ltd&user_type=organisation"
+          class="govuk-link--no-visited-state">Inbox</a></li>
       <li><a href="versions/multiple-sites-v2/low-complexity-v3/emails/transfer?organisation-name=Jurassic%20Coast%20SUP%20Ltd&user_type=organisation&low-complexity-project-name-text-input=Installation%20of%20floating%20pontoon%2C%20Lyme%20Regis%20Harbour%2C%20Dorset"
           class="govuk-link--no-visited-state">Transfer application to MCMS</a></li>
-      <li><a href="versions/multiple-sites-v2/low-complexity-v3/emails/unable-to-progress?organisation-name=Southwest%20Marine%20Works%20Ltd&user_type=organisation&low-complexity-project-name-text-input=Plymouth%20Sound%20cable%20laying"
+      <li><a href="versions/multiple-sites-v2/low-complexity-v3/emails/unable-to-progress?organisation-name=Jurassic%20Coast%20SUP%20Ltd&user_type=organisation&low-complexity-project-name-text-input=Plymouth%20Sound%20cable%20laying"
           class="govuk-link--no-visited-state">Reject application</a></li>
     </ul>
 

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/email-landings/pontoon-landing.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/email-landings/pontoon-landing.html
@@ -27,7 +27,7 @@ Your application has been transferred - {{ data['headerNameExemption'] }}
 
 		<h1 class="govuk-heading-l">Your application has been transferred</h1>
 
-		<p class="govuk-body">Your application [MLA/2026/10003] has been transferred from Get permission for marine work to our Marine Case Management System (MCMS).</p>
+		<p class="govuk-body">Your application (MLA/2026/10003) has been transferred from Get permission for marine work to our Marine Case Management System (MCMS).</p>
 
 		<p class="govuk-body">Get permission for marine work currently processes certain types of marine licence application. MCMS processes all types, so we have transferred your application there.</p>
 

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/emails/_mail-chrome.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/emails/_mail-chrome.html
@@ -1,0 +1,62 @@
+{#
+  Shared webmail top bar. Included from the header block of inbox.html and of
+  each email page, so the chrome stays visible when a message is open.
+#}
+
+<style>
+  .mail__topbar {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    padding: 10px 16px;
+    background: #1f3a5f;
+    color: #fff;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+  }
+  .mail__brand {
+    font-size: 17px;
+    font-weight: 600;
+    letter-spacing: -0.2px;
+    white-space: nowrap;
+  }
+  .mail__brand a {
+    color: #fff;
+    text-decoration: none;
+  }
+  .mail__search {
+    flex: 1 1 auto;
+    max-width: 520px;
+    border: 0;
+    border-radius: 4px;
+    padding: 7px 12px;
+    font-size: 14px;
+    font-family: inherit;
+    background: #fff;
+    color: #333;
+  }
+  .mail__avatar {
+    margin-left: auto;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: #6a8fb8;
+    color: #fff;
+    font-size: 13px;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+  }
+  @media (max-width: 640px) {
+    .mail__brand {
+      font-size: 15px;
+    }
+  }
+</style>
+
+<div class="mail__topbar">
+  <span class="mail__brand"><a href="inbox">Mail</a></span>
+  <input class="mail__search" type="text" placeholder="Search mail" aria-label="Search mail">
+  <span class="mail__avatar">SE</span>
+</div>

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/emails/_message-header.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/emails/_message-header.html
@@ -1,0 +1,88 @@
+{#
+  The mail client's message header, shown above the email itself.
+  Set messageSubject and messageDate before including.
+#}
+
+<style>
+  .msg-head {
+    max-width: 640px;
+    margin: 0 auto;
+    padding: 16px 15px 18px;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+    border-bottom: 1px solid #e3e4e6;
+  }
+  .msg-head__back {
+    font-size: 14px;
+    margin-bottom: 16px;
+  }
+  .msg-head__back a {
+    color: #1f6fd4;
+  }
+  .msg-head__row {
+    display: flex;
+    gap: 12px;
+  }
+  .msg-head__avatar {
+    flex: 0 0 auto;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background: #6a8fb8;
+    color: #fff;
+    font-size: 13px;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .msg-head__detail {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+  .msg-head__from {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+  }
+  .msg-head__sender {
+    font-size: 15px;
+    font-weight: 700;
+    color: #1a1a1a;
+  }
+  .msg-head__date {
+    margin-left: auto;
+    font-size: 13px;
+    color: #6b6f76;
+    white-space: nowrap;
+    flex: 0 0 auto;
+  }
+  .msg-head__subject {
+    font-size: 15px;
+    color: #1a1a1a;
+    margin-top: 2px;
+  }
+  .msg-head__meta {
+    font-size: 13px;
+    color: #6b6f76;
+    margin-top: 4px;
+  }
+  .msg-head__meta span {
+    color: #1a1a1a;
+  }
+</style>
+
+<div class="msg-head">
+  <p class="msg-head__back"><a href="inbox">Back to inbox</a></p>
+  <div class="msg-head__row">
+    <span class="msg-head__avatar">MMO</span>
+    <div class="msg-head__detail">
+      <div class="msg-head__from">
+        <span class="msg-head__sender">Marine Management Organisation (MMO)</span>
+        <span class="msg-head__date">{{ messageDate }}</span>
+      </div>
+      <div class="msg-head__subject">{{ messageSubject }}</div>
+      <div class="msg-head__meta">To: <span>Sam Evans</span></div>
+      <div class="msg-head__meta">Reply-To: <span>marine.consents@marinemanagement.org.uk</span></div>
+    </div>
+  </div>
+</div>

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/emails/inbox.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/emails/inbox.html
@@ -1,0 +1,321 @@
+{% extends "govuk-prototype-kit/layouts/govuk-branded.njk" %}
+
+{% block pageTitle %}
+  Inbox - Sam Evans
+{% endblock %}
+
+{% block header %}
+  {% include "./_mail-chrome.html" %}
+{% endblock %}
+{% block beforeContent %}{% endblock %}
+{% block footer %}{% endblock %}
+
+{% block content %}
+
+<style>
+  body, .govuk-template__body {
+    background: #f3f4f6;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+  }
+  .govuk-width-container,
+  .govuk-main-wrapper {
+    max-width: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .mail {
+    background: #fff;
+  }
+
+  /* Body — fills what is left below the shared top bar */
+  .mail__body {
+    display: flex;
+    height: calc(100vh - 53px);
+    min-height: 0;
+  }
+
+  /* Folder rail */
+  .mail__rail {
+    flex: 0 0 220px;
+    background: #fafafa;
+    border-right: 1px solid #e3e4e6;
+    padding: 16px 0;
+    overflow-y: auto;
+  }
+  .mail__account {
+    padding: 0 16px 14px;
+    border-bottom: 1px solid #e3e4e6;
+    margin-bottom: 10px;
+  }
+  .mail__account-name {
+    font-size: 14px;
+    font-weight: 600;
+    color: #1a1a1a;
+  }
+  .mail__account-org {
+    font-size: 12px;
+    color: #6b6f76;
+    margin-top: 2px;
+  }
+  .mail__folders {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+  .mail__folder {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 16px;
+    font-size: 14px;
+    color: #333;
+  }
+  .mail__folder--current {
+    background: #e6ecf3;
+    font-weight: 600;
+    box-shadow: inset 3px 0 0 #1f3a5f;
+  }
+  .mail__folder-count {
+    font-size: 12px;
+    font-weight: 600;
+    color: #1f3a5f;
+  }
+
+  /* Message list */
+  .mail__list {
+    flex: 1 1 auto;
+    overflow-y: auto;
+    min-width: 0;
+  }
+  .mail__list-header {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    padding: 14px 20px 10px;
+    border-bottom: 1px solid #e3e4e6;
+  }
+  .mail__list-header h1 {
+    font-size: 18px;
+    font-weight: 600;
+    margin: 0;
+    color: #1a1a1a;
+  }
+  .mail__list-header span {
+    font-size: 13px;
+    color: #6b6f76;
+  }
+
+  .mail__msg {
+    display: block;
+    text-decoration: none;
+    color: inherit;
+    border-bottom: 1px solid #eceef0;
+    padding: 12px 20px 12px 34px;
+    position: relative;
+    cursor: default;
+  }
+  a.mail__msg {
+    cursor: pointer;
+  }
+  a.mail__msg:hover {
+    background: #f5f8fb;
+  }
+  a.mail__msg:focus {
+    outline: 3px solid #ffdd00;
+    outline-offset: -3px;
+    background: #ffdd00;
+  }
+  .mail__msg--unread::before {
+    content: "";
+    position: absolute;
+    left: 16px;
+    top: 18px;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: #1f6fd4;
+  }
+  .mail__msg-top {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+  }
+  .mail__msg-from {
+    font-size: 14px;
+    color: #1a1a1a;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .mail__msg-date {
+    margin-left: auto;
+    font-size: 12px;
+    color: #6b6f76;
+    white-space: nowrap;
+    flex: 0 0 auto;
+  }
+  .mail__msg-subject {
+    font-size: 14px;
+    color: #1a1a1a;
+    margin-top: 2px;
+  }
+  .mail__msg-preview {
+    font-size: 13px;
+    color: #6b6f76;
+    margin-top: 2px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .mail__msg--unread .mail__msg-from,
+  .mail__msg--unread .mail__msg-subject {
+    font-weight: 700;
+  }
+  .mail__msg--unread .mail__msg-date {
+    color: #1f6fd4;
+    font-weight: 600;
+  }
+
+  @media (max-width: 640px) {
+    .mail__rail {
+      display: none;
+    }
+    .mail__brand {
+      font-size: 15px;
+    }
+  }
+</style>
+
+<div class="mail">
+
+  <div class="mail__body">
+
+    <nav class="mail__rail" aria-label="Folders">
+      <div class="mail__account">
+        <div class="mail__account-name">Sam Evans</div>
+        <div class="mail__account-org">Jurassic Coast SUP Ltd</div>
+      </div>
+      <ul class="mail__folders">
+        <li class="mail__folder mail__folder--current">
+          <span>Inbox</span>
+          <span class="mail__folder-count">3</span>
+        </li>
+        <li class="mail__folder"><span>Sent</span></li>
+        <li class="mail__folder"><span>Drafts</span><span class="mail__folder-count">2</span></li>
+        <li class="mail__folder"><span>Archive</span></li>
+        <li class="mail__folder"><span>Deleted</span></li>
+      </ul>
+    </nav>
+
+    <div class="mail__list">
+
+      <div class="mail__list-header">
+        <h1>Inbox</h1>
+        <span>3 unread</span>
+      </div>
+
+      <a class="mail__msg mail__msg--unread" href="unable-to-progress">
+        <div class="mail__msg-top">
+          <span class="mail__msg-from">Marine Management Organisation</span>
+          <span class="mail__msg-date">10:42</span>
+        </div>
+        <div class="mail__msg-subject">Update on your marine licence application MLA/2026/10002</div>
+        <div class="mail__msg-preview">Dear Sam Evans, We have reviewed your application and we are unable to progress it as submitted.</div>
+      </a>
+
+      <a class="mail__msg mail__msg--unread" href="transfer">
+        <div class="mail__msg-top">
+          <span class="mail__msg-from">Marine Management Organisation</span>
+          <span class="mail__msg-date">09:15</span>
+        </div>
+        <div class="mail__msg-subject">Update on your marine licence application MLA/2026/10003</div>
+        <div class="mail__msg-preview">Dear Sam Evans, Your application has been transferred from Get permission for marine work to our Marine Case Management System.</div>
+      </a>
+
+      <div class="mail__msg mail__msg--unread">
+        <div class="mail__msg-top">
+          <span class="mail__msg-from">Lyme Regis Harbour Office</span>
+          <span class="mail__msg-date">{{ -1 | inboxDate }}</span>
+        </div>
+        <div class="mail__msg-subject">Summer berth holder briefing — 14 May</div>
+        <div class="mail__msg-preview">All berth holders and harbour users are invited to the annual briefing at the Harbour Office. Please confirm attendance.</div>
+      </div>
+
+      <div class="mail__msg">
+        <div class="mail__msg-top">
+          <span class="mail__msg-from">Dorset Council Planning</span>
+          <span class="mail__msg-date">{{ -2 | inboxDate }}</span>
+        </div>
+        <div class="mail__msg-subject">Pre-application enquiry PA-PRE-2026-00412</div>
+        <div class="mail__msg-preview">Further to your enquiry regarding works within the harbour area, please find our informal advice attached.</div>
+      </div>
+
+      <div class="mail__msg">
+        <div class="mail__msg-top">
+          <span class="mail__msg-from">Devon and Severn IFCA</span>
+          <span class="mail__msg-date">{{ -3 | inboxDate }}</span>
+        </div>
+        <div class="mail__msg-subject">Notice to mariners — seasonal restrictions</div>
+        <div class="mail__msg-preview">Seasonal restrictions come into effect from 1 May across parts of the district. Full details are on our website.</div>
+      </div>
+
+      <div class="mail__msg">
+        <div class="mail__msg-top">
+          <span class="mail__msg-from">Met Office Weather Warnings</span>
+          <span class="mail__msg-date">{{ -4 | inboxDate }}</span>
+        </div>
+        <div class="mail__msg-subject">Yellow warning of wind — Dorset coast</div>
+        <div class="mail__msg-preview">Gusts of 45 to 55 mph are expected along exposed coastal stretches. Take care near the water.</div>
+      </div>
+
+      <div class="mail__msg">
+        <div class="mail__msg-top">
+          <span class="mail__msg-from">Aquapac Marine Supplies</span>
+          <span class="mail__msg-date">{{ -5 | inboxDate }}</span>
+        </div>
+        <div class="mail__msg-subject">Your order #48213 has been dispatched</div>
+        <div class="mail__msg-preview">Your order of 12 buoyancy aids and 4 tow lines is on its way. Expected delivery in 2 working days.</div>
+      </div>
+
+      <div class="mail__msg">
+        <div class="mail__msg-top">
+          <span class="mail__msg-from">RYA Training</span>
+          <span class="mail__msg-date">{{ -7 | inboxDate }}</span>
+        </div>
+        <div class="mail__msg-subject">Instructor certificate renewal due</div>
+        <div class="mail__msg-preview">One of your instructor certificates expires in 60 days. Renew online to avoid a lapse in cover.</div>
+      </div>
+
+      <div class="mail__msg">
+        <div class="mail__msg-top">
+          <span class="mail__msg-from">Bookings (no-reply)</span>
+          <span class="mail__msg-date">{{ -8 | inboxDate }}</span>
+        </div>
+        <div class="mail__msg-subject">3 new paddleboard bookings this week</div>
+        <div class="mail__msg-preview">You have 3 new bookings for group sessions. Sign in to your dashboard to view the schedule.</div>
+      </div>
+
+      <div class="mail__msg">
+        <div class="mail__msg-top">
+          <span class="mail__msg-from">Dorset Wildlife Trust</span>
+          <span class="mail__msg-date">{{ -11 | inboxDate }}</span>
+        </div>
+        <div class="mail__msg-subject">Seagrass survey volunteers wanted</div>
+        <div class="mail__msg-preview">We are looking for local water users to help with this summer's seagrass monitoring along the Jurassic Coast.</div>
+      </div>
+
+      <div class="mail__msg">
+        <div class="mail__msg-top">
+          <span class="mail__msg-from">Xero</span>
+          <span class="mail__msg-date">{{ -13 | inboxDate }}</span>
+        </div>
+        <div class="mail__msg-subject">Your VAT return is due</div>
+        <div class="mail__msg-preview">Your VAT return for the quarter is due in 7 days. Review and submit from your account.</div>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/emails/transfer.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/emails/transfer.html
@@ -4,6 +4,17 @@
   Email - Update on your marine licence application
 {% endblock %}
 
+{% block header %}
+  {% include "./_mail-chrome.html" %}
+  {% set messageSubject = "Update on your marine licence application MLA/2026/10003" %}
+  {% set messageDate = "Today at 09:15" %}
+  {% include "./_message-header.html" %}
+  {{ govukHeader({
+    homepageUrl: "/",
+    classes: "govuk-header--full-width-border"
+  }) }}
+{% endblock %}
+
 {% block content %}
 
 <style>

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/emails/unable-to-progress.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/emails/unable-to-progress.html
@@ -4,6 +4,17 @@
   Email - Your marine licence application MLA/2026/10002
 {% endblock %}
 
+{% block header %}
+  {% include "./_mail-chrome.html" %}
+  {% set messageSubject = "Update on your marine licence application MLA/2026/10002" %}
+  {% set messageDate = "Today at 10:42" %}
+  {% include "./_message-header.html" %}
+  {{ govukHeader({
+    homepageUrl: "/",
+    classes: "govuk-header--full-width-border"
+  }) }}
+{% endblock %}
+
 {% block content %}
 
 <style>
@@ -40,7 +51,7 @@ ul {
 </style>
 
 
-<h1>Your marine licence application MLA/2026/10002</h1>
+<h1>Update on your marine licence application MLA/2026/10002</h1>
 
 <p>Dear Sam Evans,</p>
 

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/view-details/plymouth-sound-cable-laying.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/view-details/plymouth-sound-cable-laying.html
@@ -2,7 +2,7 @@
 
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
-{% set organisationName = data['organisation-name'] or 'Southwest Marine Works Ltd' %}
+{% set organisationName = data['organisation-name'] or 'Jurassic Coast SUP Ltd' %}
 
 {% block head %}
   {{ super() }}
@@ -147,7 +147,7 @@
                 <dl class="govuk-summary-list">
                     <div class="govuk-summary-list__row">
                         <dt class="govuk-summary-list__key">Project background</dt>
-                        <dd class="govuk-summary-list__value">Southwest Marine Works Ltd will install a subsea telecommunications cable across Plymouth Sound to connect a new coastal monitoring station on Mount Batten to the mainland network. The works involve laying approximately 2.4 kilometres of fibre optic cable along a pre-surveyed route on the seabed, with sections buried using a jetting sled to protect the cable from vessel anchors and fishing activity. Landfall points will be established at Mount Batten Pier and Queen Anne's Battery, with cable protection installed at both shore ends.</dd>
+                        <dd class="govuk-summary-list__value">Jurassic Coast SUP Ltd will install a subsea telecommunications cable across Plymouth Sound to connect a new coastal monitoring station on Mount Batten to the mainland network. The works involve laying approximately 2.4 kilometres of fibre optic cable along a pre-surveyed route on the seabed, with sections buried using a jetting sled to protect the cable from vessel anchors and fishing activity. Landfall points will be established at Mount Batten Pier and Queen Anne's Battery, with cable protection installed at both shore ends.</dd>
                     </div>
                     <div class="govuk-summary-list__row">
                         <dt class="govuk-summary-list__key">Preferred start and end dates of the licence</dt>


### PR DESCRIPTION
Adds a simulated webmail inbox page with shared _mail-chrome and _message-header partials. Email pages (transfer, unable-to-progress) now render within the mail client chrome. Also renames the applicant organisation from 'Southwest Marine Works Ltd' to 'Jurassic Coast SUP Ltd' throughout, adds an inboxDate Nunjucks filter, and links the inbox from the prototype index.