### PR TITLE
Add reject inbox and split email scenarios

### DIFF
--- a/app/routes/versions/multiple-sites-v2/low-complexity-v3.js
+++ b/app/routes/versions/multiple-sites-v2/low-complexity-v3.js
@@ -1236,7 +1236,7 @@ module.exports = function (router) {
 
     // --- Project details ---
     d['low-complexity-project-name-text-input'] = 'Plymouth Sound cable laying';
-    d['low-complexity-project-background'] = "Jurassic Coast SUP Ltd will install a subsea telecommunications cable across Plymouth Sound to connect a new coastal monitoring station on Mount Batten to the mainland network. The works involve laying approximately 2.4 kilometres of fibre optic cable along a pre-surveyed route on the seabed, with sections buried using a jetting sled to protect the cable from vessel anchors and fishing activity. Landfall points will be established at Mount Batten Pier and Queen Anne's Battery, with cable protection installed at both shore ends.";
+    d['low-complexity-project-background'] = "Southwest Marine Works Ltd will install a subsea telecommunications cable across Plymouth Sound to connect a new coastal monitoring station on Mount Batten to the mainland network. The works involve laying approximately 2.4 kilometres of fibre optic cable along a pre-surveyed route on the seabed, with sections buried using a jetting sled to protect the cable from vessel anchors and fishing activity. Landfall points will be established at Mount Batten Pier and Queen Anne's Battery, with cable protection installed at both shore ends.";
     d['low-complexity-project-background-completed'] = true;
 
     d['start-date-month'] = '6';
@@ -1320,7 +1320,7 @@ module.exports = function (router) {
     d['invoice-county'] = 'Devon';
     d['invoice-postcode'] = 'PL4 0LP';
     d['invoice-full-name'] = 'Rachel Stow';
-    d['invoice-organisation-name'] = 'Jurassic Coast SUP Ltd';
+    d['invoice-organisation-name'] = 'Southwest Marine Works Ltd';
     d['invoice-phone'] = '01752 900123';
     d['invoice-email'] = 'accounts@southwestmarineworks.co.uk';
     d['invoice-po-required'] = 'no';

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -80,12 +80,14 @@ html: ''
     <h3 class="govuk-heading-s">Notifications</h3>
 
     <ul class="govuk-list govuk-list--spaced">
-      <li><a href="versions/multiple-sites-v2/low-complexity-v3/emails/inbox?organisation-name=Jurassic%20Coast%20SUP%20Ltd&user_type=organisation"
-          class="govuk-link--no-visited-state">Inbox</a></li>
       <li><a href="versions/multiple-sites-v2/low-complexity-v3/emails/transfer?organisation-name=Jurassic%20Coast%20SUP%20Ltd&user_type=organisation&low-complexity-project-name-text-input=Installation%20of%20floating%20pontoon%2C%20Lyme%20Regis%20Harbour%2C%20Dorset"
           class="govuk-link--no-visited-state">Transfer application to MCMS</a></li>
-      <li><a href="versions/multiple-sites-v2/low-complexity-v3/emails/unable-to-progress?organisation-name=Jurassic%20Coast%20SUP%20Ltd&user_type=organisation&low-complexity-project-name-text-input=Plymouth%20Sound%20cable%20laying"
+      <li><a href="versions/multiple-sites-v2/low-complexity-v3/emails/inbox-transfer?organisation-name=Jurassic%20Coast%20SUP%20Ltd&user_type=organisation&low-complexity-project-name-text-input=Installation%20of%20floating%20pontoon%2C%20Lyme%20Regis%20Harbour%2C%20Dorset"
+          class="govuk-link--no-visited-state">Transfer inbox</a></li>
+      <li><a href="versions/multiple-sites-v2/low-complexity-v3/emails/unable-to-progress?organisation-name=Southwest%20Marine%20Works%20Ltd&user_type=organisation&low-complexity-project-name-text-input=Plymouth%20Sound%20cable%20laying"
           class="govuk-link--no-visited-state">Reject application</a></li>
+      <li><a href="versions/multiple-sites-v2/low-complexity-v3/emails/inbox-reject?organisation-name=Southwest%20Marine%20Works%20Ltd&user_type=organisation&low-complexity-project-name-text-input=Plymouth%20Sound%20cable%20laying"
+          class="govuk-link--no-visited-state">Reject inbox</a></li>
     </ul>
 
     <h3 class="govuk-heading-s">Check if you need a marine licence (IAT) with multiple activities and LCML filtering</h3>

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/emails/_inbox-styles.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/emails/_inbox-styles.html
@@ -1,0 +1,179 @@
+{#
+  Shared inbox styles - folder rail and message list.
+  Included by inbox-transfer.html and inbox-reject.html.
+#}
+
+<style>
+  body, .govuk-template__body {
+    background: #f3f4f6;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+  }
+  .govuk-width-container,
+  .govuk-main-wrapper {
+    max-width: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .mail {
+    background: #fff;
+  }
+
+  /* Body — fills what is left below the shared top bar */
+  .mail__body {
+    display: flex;
+    height: calc(100vh - 53px);
+    min-height: 0;
+  }
+
+  /* Folder rail */
+  .mail__rail {
+    flex: 0 0 220px;
+    background: #fafafa;
+    border-right: 1px solid #e3e4e6;
+    padding: 16px 0;
+    overflow-y: auto;
+  }
+  .mail__account {
+    padding: 0 16px 14px;
+    border-bottom: 1px solid #e3e4e6;
+    margin-bottom: 10px;
+  }
+  .mail__account-name {
+    font-size: 14px;
+    font-weight: 600;
+    color: #1a1a1a;
+  }
+  .mail__account-org {
+    font-size: 12px;
+    color: #6b6f76;
+    margin-top: 2px;
+  }
+  .mail__folders {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+  .mail__folder {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 16px;
+    font-size: 14px;
+    color: #333;
+  }
+  .mail__folder--current {
+    background: #e6ecf3;
+    font-weight: 600;
+    box-shadow: inset 3px 0 0 #1f3a5f;
+  }
+  .mail__folder-count {
+    font-size: 12px;
+    font-weight: 600;
+    color: #1f3a5f;
+  }
+
+  /* Message list */
+  .mail__list {
+    flex: 1 1 auto;
+    overflow-y: auto;
+    min-width: 0;
+  }
+  .mail__list-header {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    padding: 14px 20px 10px;
+    border-bottom: 1px solid #e3e4e6;
+  }
+  .mail__list-header h1 {
+    font-size: 18px;
+    font-weight: 600;
+    margin: 0;
+    color: #1a1a1a;
+  }
+  .mail__list-header span {
+    font-size: 13px;
+    color: #6b6f76;
+  }
+
+  .mail__msg {
+    display: block;
+    text-decoration: none;
+    color: inherit;
+    border-bottom: 1px solid #eceef0;
+    padding: 12px 20px 12px 34px;
+    position: relative;
+    cursor: default;
+  }
+  a.mail__msg {
+    cursor: pointer;
+  }
+  a.mail__msg:hover {
+    background: #f5f8fb;
+  }
+  a.mail__msg:focus {
+    outline: 3px solid #ffdd00;
+    outline-offset: -3px;
+    background: #ffdd00;
+  }
+  .mail__msg--unread::before {
+    content: "";
+    position: absolute;
+    left: 16px;
+    top: 18px;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: #1f6fd4;
+  }
+  .mail__msg-top {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+  }
+  .mail__msg-from {
+    font-size: 14px;
+    color: #1a1a1a;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .mail__msg-date {
+    margin-left: auto;
+    font-size: 12px;
+    color: #6b6f76;
+    white-space: nowrap;
+    flex: 0 0 auto;
+  }
+  .mail__msg-subject {
+    font-size: 14px;
+    color: #1a1a1a;
+    margin-top: 2px;
+  }
+  .mail__msg-preview {
+    font-size: 13px;
+    color: #6b6f76;
+    margin-top: 2px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .mail__msg--unread .mail__msg-from,
+  .mail__msg--unread .mail__msg-subject {
+    font-weight: 700;
+  }
+  .mail__msg--unread .mail__msg-date {
+    color: #1f6fd4;
+    font-weight: 600;
+  }
+
+  @media (max-width: 640px) {
+    .mail__rail {
+      display: none;
+    }
+    .mail__brand {
+      font-size: 15px;
+    }
+  }
+</style>

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/emails/_mail-chrome.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/emails/_mail-chrome.html
@@ -56,7 +56,7 @@
 </style>
 
 <div class="mail__topbar">
-  <span class="mail__brand"><a href="inbox">Mail</a></span>
+  <span class="mail__brand"><a href="{{ inboxHref }}">Mail</a></span>
   <input class="mail__search" type="text" placeholder="Search mail" aria-label="Search mail">
   <span class="mail__avatar">SE</span>
 </div>

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/emails/_message-header.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/emails/_message-header.html
@@ -1,6 +1,6 @@
 {#
   The mail client's message header, shown above the email itself.
-  Set messageSubject and messageDate before including.
+  Set messageSubject, messageDate and inboxHref before including.
 #}
 
 <style>
@@ -72,7 +72,7 @@
 </style>
 
 <div class="msg-head">
-  <p class="msg-head__back"><a href="inbox">Back to inbox</a></p>
+  <p class="msg-head__back"><a href="{{ inboxHref }}">Back to inbox</a></p>
   <div class="msg-head__row">
     <span class="msg-head__avatar">MMO</span>
     <div class="msg-head__detail">

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/emails/inbox-reject.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/emails/inbox-reject.html
@@ -1,0 +1,141 @@
+{% extends "govuk-prototype-kit/layouts/govuk-branded.njk" %}
+
+{% block pageTitle %}
+  Inbox - Sam Evans
+{% endblock %}
+
+{% set inboxHref = "inbox-reject" %}
+
+{% block header %}
+  {% include "./_mail-chrome.html" %}
+{% endblock %}
+
+{% block beforeContent %}{% endblock %}
+{% block footer %}{% endblock %}
+
+{% block content %}
+
+{% include "./_inbox-styles.html" %}
+
+<div class="mail">
+  <div class="mail__body">
+
+    <nav class="mail__rail" aria-label="Folders">
+      <div class="mail__account">
+        <div class="mail__account-name">Sam Evans</div>
+        <div class="mail__account-org">Southwest Marine Works Ltd</div>
+      </div>
+      <ul class="mail__folders">
+        <li class="mail__folder mail__folder--current">
+          <span>Inbox</span>
+          <span class="mail__folder-count">2</span>
+        </li>
+        <li class="mail__folder"><span>Sent</span></li>
+        <li class="mail__folder"><span>Drafts</span><span class="mail__folder-count">3</span></li>
+        <li class="mail__folder"><span>Archive</span></li>
+        <li class="mail__folder"><span>Deleted</span></li>
+      </ul>
+    </nav>
+
+    <div class="mail__list">
+
+      <div class="mail__list-header">
+        <h1>Inbox</h1>
+        <span>2 unread</span>
+      </div>
+
+      <a class="mail__msg mail__msg--unread" href="unable-to-progress">
+        <div class="mail__msg-top">
+          <span class="mail__msg-from">Marine Management Organisation</span>
+          <span class="mail__msg-date">10:42</span>
+        </div>
+        <div class="mail__msg-subject">Update on your marine licence application MLA/2026/10002</div>
+        <div class="mail__msg-preview">Dear Sam Evans, We have reviewed your application and we are unable to progress it as submitted.</div>
+      </a>
+
+      <div class="mail__msg mail__msg--unread">
+        <div class="mail__msg-top">
+          <span class="mail__msg-from">Cable Route Survey Team</span>
+          <span class="mail__msg-date">{{ -1 | inboxDate }}</span>
+        </div>
+        <div class="mail__msg-subject">Mount Batten landfall — revised route plan</div>
+        <div class="mail__msg-preview">Revised alignment for the shore end following last week's walkover. Drawing rev C attached for your comment.</div>
+      </div>
+
+      <div class="mail__msg">
+        <div class="mail__msg-top">
+          <span class="mail__msg-from">Plymouth City Council</span>
+          <span class="mail__msg-date">{{ -2 | inboxDate }}</span>
+        </div>
+        <div class="mail__msg-subject">Pre-application enquiry PA-PRE-2026-01188</div>
+        <div class="mail__msg-preview">Our informal advice on the landfall works and onshore ducting at Queen Anne's Battery is attached.</div>
+      </div>
+
+      <div class="mail__msg">
+        <div class="mail__msg-top">
+          <span class="mail__msg-from">Devon and Severn IFCA</span>
+          <span class="mail__msg-date">{{ -3 | inboxDate }}</span>
+        </div>
+        <div class="mail__msg-subject">Notice to mariners — seasonal restrictions</div>
+        <div class="mail__msg-preview">Seasonal restrictions come into effect from 1 May across parts of the district. Full details are on our website.</div>
+      </div>
+
+      <div class="mail__msg">
+        <div class="mail__msg-top">
+          <span class="mail__msg-from">Queen Anne's Battery Marina</span>
+          <span class="mail__msg-date">{{ -4 | inboxDate }}</span>
+        </div>
+        <div class="mail__msg-subject">Workboat berthing — April availability</div>
+        <div class="mail__msg-preview">We can hold two berths for the survey vessel through April. Let us know dates to confirm.</div>
+      </div>
+
+      <div class="mail__msg">
+        <div class="mail__msg-top">
+          <span class="mail__msg-from">Met Office Weather Warnings</span>
+          <span class="mail__msg-date">{{ -5 | inboxDate }}</span>
+        </div>
+        <div class="mail__msg-subject">Yellow warning of wind — Devon and Cornwall</div>
+        <div class="mail__msg-preview">Gusts of 45 to 55 mph are expected in exposed coastal areas. Consider the impact on planned marine operations.</div>
+      </div>
+
+      <div class="mail__msg">
+        <div class="mail__msg-top">
+          <span class="mail__msg-from">Subsea Plant Hire</span>
+          <span class="mail__msg-date">{{ -7 | inboxDate }}</span>
+        </div>
+        <div class="mail__msg-subject">Quotation Q-20261-04 — jetting sled hire</div>
+        <div class="mail__msg-preview">Thank you for your enquiry. Our quotation for the 6 week hire period is attached and held for 30 days.</div>
+      </div>
+
+      <div class="mail__msg">
+        <div class="mail__msg-top">
+          <span class="mail__msg-from">Natural England</span>
+          <span class="mail__msg-date">{{ -9 | inboxDate }}</span>
+        </div>
+        <div class="mail__msg-subject">Pre-application advice — Plymouth Sound SAC</div>
+        <div class="mail__msg-preview">Further to your enquiry regarding the proposed route, our advice in relation to the SAC and MCZ is attached.</div>
+      </div>
+
+      <div class="mail__msg">
+        <div class="mail__msg-top">
+          <span class="mail__msg-from">Health and Safety Team</span>
+          <span class="mail__msg-date">{{ -11 | inboxDate }}</span>
+        </div>
+        <div class="mail__msg-subject">Toolbox talk records due</div>
+        <div class="mail__msg-preview">Please upload signed toolbox talk records for the March works before the end of the month.</div>
+      </div>
+
+      <div class="mail__msg">
+        <div class="mail__msg-top">
+          <span class="mail__msg-from">Xero</span>
+          <span class="mail__msg-date">{{ -13 | inboxDate }}</span>
+        </div>
+        <div class="mail__msg-subject">Your VAT return is due</div>
+        <div class="mail__msg-preview">Your VAT return for the quarter is due in 7 days. Review and submit from your account.</div>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/emails/inbox-transfer.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/emails/inbox-transfer.html
@@ -4,191 +4,20 @@
   Inbox - Sam Evans
 {% endblock %}
 
+{% set inboxHref = "inbox-transfer" %}
+
 {% block header %}
   {% include "./_mail-chrome.html" %}
 {% endblock %}
+
 {% block beforeContent %}{% endblock %}
 {% block footer %}{% endblock %}
 
 {% block content %}
 
-<style>
-  body, .govuk-template__body {
-    background: #f3f4f6;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
-  }
-  .govuk-width-container,
-  .govuk-main-wrapper {
-    max-width: none;
-    margin: 0;
-    padding: 0;
-  }
-
-  .mail {
-    background: #fff;
-  }
-
-  /* Body — fills what is left below the shared top bar */
-  .mail__body {
-    display: flex;
-    height: calc(100vh - 53px);
-    min-height: 0;
-  }
-
-  /* Folder rail */
-  .mail__rail {
-    flex: 0 0 220px;
-    background: #fafafa;
-    border-right: 1px solid #e3e4e6;
-    padding: 16px 0;
-    overflow-y: auto;
-  }
-  .mail__account {
-    padding: 0 16px 14px;
-    border-bottom: 1px solid #e3e4e6;
-    margin-bottom: 10px;
-  }
-  .mail__account-name {
-    font-size: 14px;
-    font-weight: 600;
-    color: #1a1a1a;
-  }
-  .mail__account-org {
-    font-size: 12px;
-    color: #6b6f76;
-    margin-top: 2px;
-  }
-  .mail__folders {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-  }
-  .mail__folder {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 8px 16px;
-    font-size: 14px;
-    color: #333;
-  }
-  .mail__folder--current {
-    background: #e6ecf3;
-    font-weight: 600;
-    box-shadow: inset 3px 0 0 #1f3a5f;
-  }
-  .mail__folder-count {
-    font-size: 12px;
-    font-weight: 600;
-    color: #1f3a5f;
-  }
-
-  /* Message list */
-  .mail__list {
-    flex: 1 1 auto;
-    overflow-y: auto;
-    min-width: 0;
-  }
-  .mail__list-header {
-    display: flex;
-    align-items: baseline;
-    gap: 10px;
-    padding: 14px 20px 10px;
-    border-bottom: 1px solid #e3e4e6;
-  }
-  .mail__list-header h1 {
-    font-size: 18px;
-    font-weight: 600;
-    margin: 0;
-    color: #1a1a1a;
-  }
-  .mail__list-header span {
-    font-size: 13px;
-    color: #6b6f76;
-  }
-
-  .mail__msg {
-    display: block;
-    text-decoration: none;
-    color: inherit;
-    border-bottom: 1px solid #eceef0;
-    padding: 12px 20px 12px 34px;
-    position: relative;
-    cursor: default;
-  }
-  a.mail__msg {
-    cursor: pointer;
-  }
-  a.mail__msg:hover {
-    background: #f5f8fb;
-  }
-  a.mail__msg:focus {
-    outline: 3px solid #ffdd00;
-    outline-offset: -3px;
-    background: #ffdd00;
-  }
-  .mail__msg--unread::before {
-    content: "";
-    position: absolute;
-    left: 16px;
-    top: 18px;
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    background: #1f6fd4;
-  }
-  .mail__msg-top {
-    display: flex;
-    align-items: baseline;
-    gap: 12px;
-  }
-  .mail__msg-from {
-    font-size: 14px;
-    color: #1a1a1a;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-  .mail__msg-date {
-    margin-left: auto;
-    font-size: 12px;
-    color: #6b6f76;
-    white-space: nowrap;
-    flex: 0 0 auto;
-  }
-  .mail__msg-subject {
-    font-size: 14px;
-    color: #1a1a1a;
-    margin-top: 2px;
-  }
-  .mail__msg-preview {
-    font-size: 13px;
-    color: #6b6f76;
-    margin-top: 2px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-  .mail__msg--unread .mail__msg-from,
-  .mail__msg--unread .mail__msg-subject {
-    font-weight: 700;
-  }
-  .mail__msg--unread .mail__msg-date {
-    color: #1f6fd4;
-    font-weight: 600;
-  }
-
-  @media (max-width: 640px) {
-    .mail__rail {
-      display: none;
-    }
-    .mail__brand {
-      font-size: 15px;
-    }
-  }
-</style>
+{% include "./_inbox-styles.html" %}
 
 <div class="mail">
-
   <div class="mail__body">
 
     <nav class="mail__rail" aria-label="Folders">
@@ -199,7 +28,7 @@
       <ul class="mail__folders">
         <li class="mail__folder mail__folder--current">
           <span>Inbox</span>
-          <span class="mail__folder-count">3</span>
+          <span class="mail__folder-count">2</span>
         </li>
         <li class="mail__folder"><span>Sent</span></li>
         <li class="mail__folder"><span>Drafts</span><span class="mail__folder-count">2</span></li>
@@ -212,17 +41,8 @@
 
       <div class="mail__list-header">
         <h1>Inbox</h1>
-        <span>3 unread</span>
+        <span>2 unread</span>
       </div>
-
-      <a class="mail__msg mail__msg--unread" href="unable-to-progress">
-        <div class="mail__msg-top">
-          <span class="mail__msg-from">Marine Management Organisation</span>
-          <span class="mail__msg-date">10:42</span>
-        </div>
-        <div class="mail__msg-subject">Update on your marine licence application MLA/2026/10002</div>
-        <div class="mail__msg-preview">Dear Sam Evans, We have reviewed your application and we are unable to progress it as submitted.</div>
-      </a>
 
       <a class="mail__msg mail__msg--unread" href="transfer">
         <div class="mail__msg-top">

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/emails/transfer.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/emails/transfer.html
@@ -4,6 +4,8 @@
   Email - Update on your marine licence application
 {% endblock %}
 
+{% set inboxHref = "inbox-transfer" %}
+
 {% block header %}
   {% include "./_mail-chrome.html" %}
   {% set messageSubject = "Update on your marine licence application MLA/2026/10003" %}

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/emails/unable-to-progress.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/emails/unable-to-progress.html
@@ -4,6 +4,8 @@
   Email - Your marine licence application MLA/2026/10002
 {% endblock %}
 
+{% set inboxHref = "inbox-reject" %}
+
 {% block header %}
   {% include "./_mail-chrome.html" %}
   {% set messageSubject = "Update on your marine licence application MLA/2026/10002" %}

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/view-details/plymouth-sound-cable-laying.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/view-details/plymouth-sound-cable-laying.html
@@ -2,7 +2,7 @@
 
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
-{% set organisationName = data['organisation-name'] or 'Jurassic Coast SUP Ltd' %}
+{% set organisationName = data['organisation-name'] or 'Southwest Marine Works Ltd' %}
 
 {% block head %}
   {{ super() }}
@@ -147,7 +147,7 @@
                 <dl class="govuk-summary-list">
                     <div class="govuk-summary-list__row">
                         <dt class="govuk-summary-list__key">Project background</dt>
-                        <dd class="govuk-summary-list__value">Jurassic Coast SUP Ltd will install a subsea telecommunications cable across Plymouth Sound to connect a new coastal monitoring station on Mount Batten to the mainland network. The works involve laying approximately 2.4 kilometres of fibre optic cable along a pre-surveyed route on the seabed, with sections buried using a jetting sled to protect the cable from vessel anchors and fishing activity. Landfall points will be established at Mount Batten Pier and Queen Anne's Battery, with cable protection installed at both shore ends.</dd>
+                        <dd class="govuk-summary-list__value">Southwest Marine Works Ltd will install a subsea telecommunications cable across Plymouth Sound to connect a new coastal monitoring station on Mount Batten to the mainland network. The works involve laying approximately 2.4 kilometres of fibre optic cable along a pre-surveyed route on the seabed, with sections buried using a jetting sled to protect the cable from vessel anchors and fishing activity. Landfall points will be established at Mount Batten Pier and Queen Anne's Battery, with cable protection installed at both shore ends.</dd>
                     </div>
                     <div class="govuk-summary-list__row">
                         <dt class="govuk-summary-list__key">Preferred start and end dates of the licence</dt>


### PR DESCRIPTION
- Rename inbox.html to inbox-transfer.html and add new inbox-reject.html for separate transfer/reject scenarios
- Extract shared inbox CSS into _inbox-styles.html partial
- Make 'Back to inbox' and 'Mail' links dynamic via inboxHref variable
- Set inboxHref in transfer.html and unable-to-progress.html
- Update organisation name from 'Jurassic Coast SUP Ltd' to 'Southwest Marine Works Ltd' in Plymouth Sound cable laying scenario
- Update index.html shortcuts to reflect new inbox URLs