### PR TITLE
Update construction drawing guidance and delete page

### DIFF
--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/site-details/delete-construction-file.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/site-details/delete-construction-file.html
@@ -11,7 +11,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set pageHeadingTextHTML %}
-Are you sure you want to delete construction drawing {{ fileNumber }} for Site {{ siteNumber }}?
+Are you sure you want to delete Site {{ siteNumber }} construction drawing {{ fileNumber }}?
 {% endset %}
 
 {% block pageTitle %}
@@ -26,10 +26,6 @@ Are you sure you want to delete construction drawing {{ fileNumber }} for Site {
     <h1 class="govuk-heading-l">
       {{ pageHeadingTextHTML }}
     </h1>
-
-    <div class="govuk-inset-text">
-      The drawing '{{ filename or 'tech-drawing.pdf' }}' will be removed from your application.
-    </div>
 
     <form action="delete-construction-file-router" method="post" novalidate>
       <input type="hidden" name="site-number" value="{{ siteNumber }}">

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/site-details/index.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/site-details/index.html
@@ -37,6 +37,7 @@ Site details
         <li>site name</li>
         <li>type of activity, for example construction</li>
         <li>category of activity, for example maintenance construction</li>
+        <li>a drawing or plan of any construction work - you only need this for construction activities</li>
         <li>activity description and methodology - a step-by-step explanation of how you will carry out the activity</li>
         <li>maximum duration of the activity</li>
         <li>schedule of when the activity will take place</li>
@@ -63,6 +64,32 @@ Site details
       <p class="govuk-body">The coordinates must mark the full boundary of every site, including space for any movement or small changes in the activity location.</p>
 
       <p>Your file must only contain sites drawn as polygons (shapes), not points or lines.</p>
+
+      <h2 class="govuk-heading-m">Providing construction drawings or plans</h2>
+
+      <p class="govuk-body">If any of your activities involve construction of new marine works, you must upload a drawing or plan for each one, showing what you plan to build.</p>
+
+      <p class="govuk-body">Your drawing does not need to be produced by an architect or other professional. A simple, clear drawing is fine, as long as it shows what you're building.</p>
+
+      <p class="govuk-body">If you already have drawings from an architect, engineer or contractor, you can use those.</p>
+
+      <p class="govuk-body">Your drawing must:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>be a PDF <span style="color: #d4351c;">(or other types - TBC)</span></li>
+        <li><span style="color: #d4351c;">(certain file size - TBC)</span></li>
+        <li>say whether or not it's drawn to scale</li>
+      </ul>
+
+      <p class="govuk-body">It also helps if your drawing shows:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>key dimensions</li>
+        <li>the direction of north</li>
+        <li>the scale and original paper size, for example 1:200 at A3</li>
+      </ul>
+
+      <p class="govuk-body">If we approve your application, your drawing may be attached to your licence. This means it should be clear enough for anyone to understand.</p>
 
         <form action="index-router" method="post" novalidate>
             


### PR DESCRIPTION
- Reword delete confirmation page heading for clarity
- Remove inset text showing filename from delete confirmation page
- Add construction drawings bullet point to site details intro list
- Add new 'Providing construction drawings or plans' section with requirements and guidance