### PR TITLE
Add email journey sign-in step pages

### DIFF
--- a/app/views/user-testing-links.html
+++ b/app/views/user-testing-links.html
@@ -15,16 +15,11 @@
         <h1 class="govuk-heading-l">
           Prototype journeys
         </h1>
+
         <ul class="govuk-list">
-          <li><a class="govuk-link" href="/versions/multiple-sites-v2/low-complexity-v2/homepage?state=eyJoZWFkZXJOYW1lIjoiR2V0IHBlcm1pc3Npb24gZm9yIG1hcmluZSB3b3JrIiwiaGVhZGVyTmFtZUV4ZW1wdGlvbiI6IkdldCBwZXJtaXNzaW9uIGZvciBtYXJpbmUgd29yayIsImhlYWRlck5hbWVTYW1wbGVQbGFuIjoiR2V0IGEgcGxhbiBmb3Igc2VkaW1lbnQgc2FtcGxlIGFuYWx5c2lzIiwiZXhlbXB0aW9uIjoiIiwiYW5hbHl0aWNzLWNvb2tpZXMiOiJubyIsInVzZXJfdHlwZSI6Im9yZ2FuaXNhdGlvbiIsIm1wcC12ZXJzaW9uIjoiMiIsIm1hcmluZS1wbGFuLXBvbGljaWVzLWNvbXBsZXRlZC1jb3VudCI6MCwibWFyaW5lLXBsYW4tcG9saWNpZXMtbm90LXN0YXJ0ZWQtY291bnQiOjM3LCJtYXJpbmUtcGxhbi1wb2xpY2llcy12Mi1jb21wbGV0ZWQtY291bnQiOjAsIm1hcmluZS1wbGFuLXBvbGljaWVzLXYyLW5vdC1zdGFydGVkLWNvdW50IjozNywidGVzIjoiY3NyZlRva2VuLHVzZXJfaWQscGFzc3dvcmQscHJvZmlsZTo0Njk2ODAxNTQxMjY3MTU4NTQ4OjpHVVFKSnMzT2NhODRQcDVOTlhEVGNrMnlUelRRcVNhMkVqd2J3QXQ4OXVLUGQ5TTEzRUtWSTlxT3BXMldINk83UnlWY2EyamV5SHlYZnByWTBiZHc9PSIsImNzcmZUb2tlbiI6IjZlOGJmYWJmMmNjNzVmMjZhMjAzNjEyYzE3YjdmZWQ0MTYyYjQ5YmQtMTc0MTE5NTQwMTc3Mi0zYTI3YmFiMmVhOTY5MDY5MjQ5YTk0MjAiLCJ1c2VyX2lkIjoiIiwicGFzc3dvcmQiOiIyNDY4Iiwib3JnYW5pc2F0aW9uLW5hbWUiOiJFeG1vdXRoIE95c3RlcnMgTHRkIiwiZXJyb3J0aGlzcGFnZSI6ImZhbHNlIiwiZXJyb3J0eXBlb25lIjoiZmFsc2UifQ==">Homepage</a></li>
-          <!-- <li><a class="govuk-link" href="versions/multiple-sites-v2/low-complexity-v2/sign-in?user_type=&goto=homepage&mpp-version=2">Individual user</a></li>
-          <li><a class="govuk-link" href="versions/multiple-sites-v2/low-complexity-v2/sign-in?user_type=organisation&goto=homepage&mpp-version=2">Organisation user</a></li>
-          <li><a class="govuk-link" href="#">Application answers complete</a></li>-->
+          <li><a class="govuk-link" href="/versions/multiple-sites-v2/low-complexity-v3/emails/inbox-transfer?organisation-name=Jurassic%20Coast%20SUP%20Ltd&user_type=organisation&low-complexity-project-name-text-input=Installation%20of%20floating%20pontoon%2C%20Lyme%20Regis%20Harbour%2C%20Dorset">Journey 1</a></li>
+          <li><a class="govuk-link" href="/versions/multiple-sites-v2/low-complexity-v3/emails/inbox-reject?organisation-name=Southwest%20Marine%20Works%20Ltd&user_type=organisation&low-complexity-project-name-text-input=Plymouth%20Sound%20cable%20laying">Journey 2</a></li>
         </ul>
-
-
-
-        
 
 </div>
 

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/emails/_gg-sign-in.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/emails/_gg-sign-in.html
@@ -1,0 +1,94 @@
+{#
+  Detached Government Gateway sign-in page for the email journeys.
+  A static copy of ../sign-in.html with no session logic, so the
+  organisation name set up in the email journey is retained.
+  Set signInNext (the outcome page to open on sign in) before including.
+#}
+
+{% extends "../../layouts/low-complexity-v3.html" %}
+
+{% block header %}
+{% from "govuk/components/header/macro.njk" import govukHeader %}
+{% from "govuk/components/service-navigation/macro.njk" import govukServiceNavigation %}
+
+{{ govukHeader({
+  homepageUrl: "/",
+  classes: "govuk-header--full-width-border"
+}) }}
+{{ govukServiceNavigation({
+  serviceName: "Government Gateway"
+}) }}
+{% endblock %}
+
+{% block beforeContent %}
+	{% include "../../includes/phase-banner.html" %}
+{% endblock %}
+
+{% set pageHeadingTextHTML %}
+Sign in using Government Gateway
+{% endset %}
+
+{% block pageTitle %}
+    {{ pageHeadingTextHTML }} - Get permission for marine work
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-width-container govuk-!-margin-top-1">
+	<div class="govuk-grid-row">
+	 <div class="govuk-grid-column-two-thirds govuk-!-margin-top-1">
+	 </div>
+	 <div class="govuk-grid-column-one-third govuk-!-margin-top-3">
+
+	 </div>
+	</div>
+	<main class="govuk-main-wrapper govuk-!-padding-top-0" id="skip-target">
+	 <div class="govuk-grid-row">
+	  <div class="govuk-grid-column-two-thirds">
+	   <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" data-govuk-notification-banner-init="">
+		<div class="govuk-notification-banner__header">
+		 <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">Keeping your information secure</h2>
+		</div>
+		<div class="govuk-notification-banner__content">
+		 <p class="govuk-body">Do not share your Government Gateway user ID and password with anyone else.</p>
+		</div>
+	   </div>
+	   <h1 class="govuk-heading-xl">Sign in using Government Gateway</h1>
+	   <form action="{{ signInNext }}" method="GET" id="loginForm">
+		<div class="govuk-form-group">
+		 <label for="user_id" class="govuk-label"> Government Gateway user ID </label>
+		 <div class="govuk-hint" id="user_id-hint">
+		  This could be up to 12 characters.
+		 </div><input type="text" id="user_id" class="govuk-input govuk-!-width-one-half" value="" maxlength="22" aria-describedby="user_id-hint" autocomplete="off">
+		</div>
+		<div class="govuk-form-group govuk-password-input" data-module="govuk-password-input" data-i18n.show-password="Show" data-i18n.hide-password="Hide" data-i18n.show-password-aria-label="Show password" data-i18n.hide-password-aria-label="Hide password" data-i18n.password-shown-announcement="Your password is visible" data-i18n.password-hidden-announcement="Your password is hidden" data-govuk-password-input-init="">
+		 <label for="password" class="govuk-label"> Password </label>
+		 <div class="govuk-input__wrapper govuk-password-input__wrapper">
+		  <input type="password" id="password" class="govuk-input govuk-password-input__input govuk-js-password-input-input" spellcheck="false" autocapitalize="none" autocomplete="off"><div class="govuk-password-input__sr-status govuk-visually-hidden" aria-live="polite"></div>
+		  <button type="button" class="govuk-button govuk-button--secondary govuk-password-input__toggle govuk-js-password-input-toggle" data-module="govuk-button" aria-controls="password-input" aria-label="Show password" data-govuk-button-init="">Show</button>
+		 </div>
+		</div>
+
+		{{ govukButton({
+			text: "Sign in"
+		}) }}
+
+	   </form>
+	   <h2 class="govuk-heading-m">New users of Government Gateway</h2>
+	   <div class="govuk-body">
+		<a class="govuk-link" id="no-account" href="#">Create sign in details</a>
+	   </div>
+	   <h2 class="govuk-heading-m">Problems signing in</h2>
+	   <ul class="govuk-list">
+		<li><a class="govuk-link" href="#" id="forgotten-password">I have forgotten my password</a></li>
+		<li><a class="govuk-link" href="#" id="forgotten-user-id">I have forgotten my Government Gateway user ID</a></li>
+		<li><a class="govuk-link" href="#" id="forgotten-user-id-password">I have forgotten my Government Gateway user ID and password</a></li>
+	   </ul>
+	  </div>
+	 </div>
+	 <div class="govuk-body govuk-!-margin-top-6">
+	  <a class="govuk-link" href="#" id="getHelp">Get help with this page</a>
+	 </div>
+	</main>
+   </div>
+{% endblock %}

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/emails/sign-in-reject.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/emails/sign-in-reject.html
@@ -1,0 +1,2 @@
+{% set signInNext = "../email-landings/plymouth-sound-landing" %}
+{% include "./_gg-sign-in.html" %}

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/emails/sign-in-transfer.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/emails/sign-in-transfer.html
@@ -1,0 +1,2 @@
+{% set signInNext = "../email-landings/pontoon-landing" %}
+{% include "./_gg-sign-in.html" %}

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/emails/transfer.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/emails/transfer.html
@@ -64,7 +64,7 @@ h2 {
 
 <p>Your fee estimate may change but we will confirm that when we contact you.</p>
 
-<p><a href="../email-landings/pontoon-landing">View your application status</a></p>
+<p><a href="sign-in-transfer">Sign in to view your application status</a></p>
 
 <p>From Marine Management Organisation</p>
 

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/emails/unable-to-progress.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/emails/unable-to-progress.html
@@ -76,7 +76,7 @@ ul {
 
 <p>You do not need to submit a completely new application. We will create a new draft containing all of your application information for you to update and resubmit.</p>
 
-<p><a href="../email-landings/plymouth-sound-landing">Sign in to find out what you need to do next</a></p>
+<p><a href="sign-in-reject">Sign in to find out what you need to do next</a></p>
 
 <p>From Marine Management Organisation</p>
 


### PR DESCRIPTION
Introduces a reusable static Government Gateway sign-in template for low-complexity v3 email journeys, plus dedicated transfer and reject sign-in entry pages that route to the correct landing outcomes. Updates the transfer and unable-to-progress email links to go through sign-in first, and refreshes user-testing-links with direct Journey 1 and Journey 2 entry points.