### PR TITLE
Add withdraw application email prototype

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -105,6 +105,8 @@ html: ''
           class="govuk-link--no-visited-state">Reject application</a></li>
       <li><a href="versions/multiple-sites-v2/low-complexity-v3/emails/inbox-reject?organisation-name=Southwest%20Marine%20Works%20Ltd&user_type=organisation&low-complexity-project-name-text-input=Plymouth%20Sound%20cable%20laying"
           class="govuk-link--no-visited-state">Reject inbox</a></li>
+      <li><a href="versions/multiple-sites-v2/low-complexity-v3/emails/withdraw"
+          class="govuk-link--no-visited-state">Withdraw application</a></li>
     </ul>
 
     <h3 class="govuk-heading-s">Check if you need a marine licence (IAT) with multiple activities and LCML filtering</h3>

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/emails/withdraw.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/emails/withdraw.html
@@ -1,0 +1,65 @@
+{% extends "../../layouts/email.html" %}
+
+{% block pageTitle %}
+  Email - Confirming you've withdrawn your marine licence application
+{% endblock %}
+
+{% block header %}
+  {{ govukHeader({
+    homepageUrl: "/",
+    classes: "govuk-header--full-width-border"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<style>
+.govuk-width-container {
+	max-width: 640px;
+}
+.govuk-main-wrapper {
+    padding-top: 10px;
+    padding-bottom: 40px;
+}
+h1 {
+	font-size: 36px;
+	font-family: Arial,Helvetica;
+	color: #000;
+}
+p {
+	font-size: 21px;
+	font-family: Arial,Helvetica;
+	color: #000;
+}
+h2 {
+	font-size: 30px;
+	font-family: Arial,Helvetica;
+	color: #000;
+}
+.govuk-template {
+    background-color: #fff;
+}
+</style>
+
+
+<h1>Confirming you've withdrawn your marine licence application MLA/2026/10002</h1>
+
+<p>Dear Sam Evans,</p>
+
+<p>You've withdrawn your application. We will not progress it any further.</p>
+
+<h2>Charges for processing your application</h2>
+
+<p>We will charge you for the time we have spent processing your application up to the date of withdrawal, in accordance with our <a href="https://assets.publishing.service.gov.uk/media/6938145b6a12691d48491c56/Terms_and_Conditions_for_carrying_out_chargeable_activities_for_marine_licensing.pdf">terms and conditions</a>.</p>
+
+<h2>What you need to know</h2>
+
+<p>You must not carry out the proposed works unless a valid marine licence is in place.</p>
+
+<p>Before starting any marine works in the future, check whether you need a marine licence. You'll need to submit a new application if one is required.</p>
+
+<p><a href="#">Sign in to view your withdrawn application</a></p>
+
+<p>From Marine Management Organisation</p>
+
+{% endblock %}


### PR DESCRIPTION
Adds a new low-complexity v3 email template for confirming a withdrawn marine licence application, including withdrawal confirmation wording, charging information, and next-step guidance. Also updates the prototype index shortcuts to include a direct link to the new withdraw email page.