### PR TITLE
LCML fee estimate on CYA - iteration 1

### DIFF
--- a/app/routes/versions/multiple-sites-v2/low-complexity-v3-fee-and-invoicing.js
+++ b/app/routes/versions/multiple-sites-v2/low-complexity-v3-fee-and-invoicing.js
@@ -13,6 +13,12 @@ module.exports = function (router) {
     req.session.data['low-complexity-fee-errortypeone'] = "false";
     req.session.data['low-complexity-fee-errortypetwo'] = "false";
 
+    // Arriving via the "Change" link on the main check-your-answers page:
+    // remember so an accepted fee returns there rather than to the task list.
+    if (req.query.camefromcheckanswers === 'true') {
+      req.session.data['camefromcheckanswers'] = 'true';
+    }
+
     res.render(`versions/${version}/${section}/${subSection}/fee-estimate`);
   });
 
@@ -53,6 +59,11 @@ module.exports = function (router) {
 
     // Conditional routing based on fee acceptance
     if (req.session.data['low-complexity-fee-acceptance'] === 'yes') {
+      // Returning from the main check-your-answers page — go back there
+      if (req.session.data['camefromcheckanswers'] === 'true') {
+        req.session.data['camefromcheckanswers'] = false;
+        return res.redirect(`/versions/${version}/${section}/check-your-answers#fee-estimate`);
+      }
       // Go back to the task list
       res.redirect(`/versions/${version}/${section}/marine-licence-start-page`);
     } else if (req.session.data['low-complexity-fee-acceptance'] === 'no') {
@@ -77,6 +88,8 @@ module.exports = function (router) {
     // Mark fee estimate as rejected/not accepted
     req.session.data['low-complexity-fee-estimate-completed'] = "false";
     req.session.data['low-complexity-fee-estimate-rejected'] = "true";
+    // Abandoning to a draft — clear the check-your-answers return flag
+    req.session.data['camefromcheckanswers'] = false;
 
     // Redirect to projects page - the project will remain as a draft
     res.redirect(`/versions/${version}/${section}/projects`);

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/check-your-answers.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/check-your-answers.html
@@ -1543,6 +1543,36 @@ Check your answers before sending your information
 		</div>
 
 		{# ============================== #}
+		{# FEE ESTIMATE                   #}
+		{# The Change link routes to the fee estimate page. If the applicant #}
+		{# switches to not accepting the fee, the existing fee-are-you-sure   #}
+		{# warning page takes over and the application drops back to a draft  #}
+		{# that cannot be submitted (mirrors the task-list behaviour).        #}
+		{# ============================== #}
+		{% if data['low-complexity-fee-estimate-completed'] == "true" %}
+		<div class="govuk-summary-card">
+			<div class="govuk-summary-card__title-wrapper">
+				<h2 class="govuk-summary-card__title" id="fee-estimate">
+					Fee estimate
+				</h2>
+			</div>
+			<div class="govuk-summary-card__content">
+				<dl class="govuk-summary-list">
+					<div class="govuk-summary-list__row">
+						<dt class="govuk-summary-list__key">Fee estimate accepted</dt>
+						<dd class="govuk-summary-list__value">£1,400</dd>
+						<dd class="govuk-summary-list__actions">
+							<a class="govuk-link govuk-link--no-visited-state" href="fee-and-invoicing/fee-estimate?camefromcheckanswers=true">
+								Change<span class="govuk-visually-hidden"> fee estimate</span>
+							</a>
+						</dd>
+					</div>
+				</dl>
+			</div>
+		</div>
+		{% endif %}
+
+		{# ============================== #}
 		{# INVOICING                     #}
 		{# All edits happen on the invoicing check page; this card has a #}
 		{# single Change link that routes there and returns here on Continue. #}

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/projects.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/projects.html
@@ -165,7 +165,7 @@ Projects
 				<tr class="govuk-table__row" data-creator="jon-doe" data-project-name="Groyne construction, Bournemouth seafront, Dorset" data-type="Marine licence application" data-reference="MLA-10018" data-status="{% if data['withdrawn-groyne'] == 'true' %}Withdrawn{% else %}Sent{% endif %}" id="project-groyne">
 					<th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Groyne construction, Bournemouth seafront, Dorset</th>
 					<td class="govuk-table__cell">Marine licence application</td>
-					<td class="govuk-table__cell" data-sort-value="MLA-10018">MLA/2025/10018</td>
+					<td class="govuk-table__cell" data-sort-value="MLA-10018">MLA/2026/10018</td>
 					<td class="govuk-table__cell" data-sort-value="{% if data['withdrawn-groyne'] == 'true' %}001{% else %}002{% endif %}">
 						{% if data['withdrawn-groyne'] == 'true' %}
 						{{ govukTag({
@@ -179,7 +179,7 @@ Projects
 						}) }}
 						{% endif %}
 					</td>
-					<td class="govuk-table__cell" data-sort-value="251215">15 Dec 2025</td>
+					<td class="govuk-table__cell" data-sort-value="260803">3 Aug 2026</td>
 					{% if data['user_type'] === 'organisation' %}
 					<td class="govuk-table__cell">Sam Evans</td>
 					{% endif %}


### PR DESCRIPTION
Add a fee estimate summary card to check your answers with a Change link back to the fee estimate flow. Preserve a return flag so accepting the fee sends users back to check your answers, while rejecting it still drops the application back to draft. Also refresh the sample project reference and sent date shown on the projects page.