### PR TITLE
Refactor filter JS: replace mode with options

### DIFF
--- a/app/assets/javascripts/lcml-projects-filter.js
+++ b/app/assets/javascripts/lcml-projects-filter.js
@@ -9,8 +9,12 @@
   Usage:
 
     LcmlProjectsFilter.init({
-      mode: 'radios' | 'owners',
-      tagRenderer: function (categories, remove) { ... }
+      tagRenderer: function (categories, remove) { ... },
+
+      selfLabel: 'You',        // prefix on the current user's own entry
+      pinSelf: false,          // true keeps them top of the list, not sorted in
+      allowEmptyOwner: false   // true treats "by owner, nobody picked" as
+                               // everyone rather than as an error
     })
 
   Counts shown against each option are TOTALS from the rendered table. They do
@@ -27,7 +31,10 @@
   }
 
   function init (options) {
-    var mode = options.mode || 'radios'
+    var selfPrefix = options.selfLabel || 'You'
+    var pinSelf = options.pinSelf === true
+    var allowEmptyOwner = options.allowEmptyOwner === true
+
     var table = document.getElementById('projects-table')
     if (!table) return
 
@@ -41,6 +48,7 @@
 
     var orgCaption = document.querySelector('.govuk-caption-l')
     var orgName = text(orgCaption) || 'Ramsgate Marina'
+    var hasScope = document.querySelectorAll('input[name="projectFilter"]').length > 0
 
     // The Owner column is only rendered for organisation users, so find it by
     // header text rather than assuming a fixed index.
@@ -79,8 +87,6 @@
 
     // Owners present in the table. Nobody with zero projects appears, so no
     // phantom options when session data hides rows.
-    var selfPrefix = mode === 'owners' ? 'Me' : 'You'
-
     var owners = []
     if (hasOwners) {
       model.forEach(function (item) {
@@ -97,9 +103,7 @@
       })
 
       owners.sort(function (a, b) {
-        // Option C pins the current user to the top; A and B sort them in
-        // alphabetically with everyone else.
-        if (mode === 'owners') {
+        if (pinSelf) {
           if (a.value === CURRENT_USER) return -1
           if (b.value === CURRENT_USER) return 1
         }
@@ -164,31 +168,18 @@
       function (v) { return v + ' (' + countBy('status', v) + ')' }
     )
 
-    if (mode === 'owners' && hasOwners) {
-      buildCheckboxes(
-        document.getElementById('owner-checkboxes'),
-        owners.map(function (o) { return o.value }),
-        'filter-owner',
-        'owner',
-        function (v) { return ownerLabels[v] + ' (' + countBy('creator', v) + ')' }
-      )
-    }
+    var countAll = document.getElementById('count-all-projects')
+    var countMine = document.getElementById('count-my-projects')
+    if (countAll) countAll.textContent = '(' + model.length + ')'
+    if (countMine) countMine.textContent = '(' + countBy('creator', CURRENT_USER) + ')'
 
-    // Counts against the Show radios (options A and B).
-    if (mode === 'radios') {
-      var countAll = document.getElementById('count-all-projects')
-      var countMine = document.getElementById('count-my-projects')
-      if (countAll) countAll.textContent = '(' + model.length + ')'
-      if (countMine) countMine.textContent = '(' + countBy('creator', CURRENT_USER) + ')'
-
-      buildCheckboxes(
-        document.getElementById('person-checkboxes'),
-        owners.map(function (o) { return o.value }),
-        'filter-person',
-        'person',
-        function (v) { return ownerLabels[v] + ' (' + countBy('creator', v) + ')' }
-      )
-    }
+    buildCheckboxes(
+      document.getElementById('person-checkboxes'),
+      owners.map(function (o) { return o.value }),
+      'filter-person',
+      'person',
+      function (v) { return ownerLabels[v] + ' (' + countBy('creator', v) + ')' }
+    )
 
     // --------------------------------------------------------------- state
 
@@ -205,21 +196,22 @@
         name: projectNameInput ? projectNameInput.value.trim().toLowerCase() : '',
         reference: referenceInput ? referenceInput.value.trim().toLowerCase() : '',
         people: checkedValues('filter-person'),
-        ownersSelected: checkedValues('filter-owner'),
         types: checkedValues('filter-type'),
         statuses: checkedValues('filter-status')
       }
     }
 
     function matches (item, state) {
-      if (mode === 'radios') {
-        if (state.scope === 'my-projects' && item.creator !== CURRENT_USER) return false
-        if (state.scope === 'specific-person') {
-          if (state.people.length === 0) return false
-          if (state.people.indexOf(item.creator) === -1) return false
+      if (state.scope === 'my-projects' && item.creator !== CURRENT_USER) return false
+
+      if (state.scope === 'specific-person') {
+        if (state.people.length === 0) {
+          // Nobody picked yet. Either that is an error the caller wants to
+          // raise, or the scope simply has not started narrowing anything.
+          if (!allowEmptyOwner) return false
+        } else if (state.people.indexOf(item.creator) === -1) {
+          return false
         }
-      } else if (state.ownersSelected.length > 0) {
-        if (state.ownersSelected.indexOf(item.creator) === -1) return false
       }
 
       if (state.name && item.name.indexOf(state.name) === -1) return false
@@ -259,20 +251,11 @@
         })
       }
 
-      if (mode === 'radios' && state.scope === 'specific-person' && state.people.length > 0) {
+      if (state.scope === 'specific-person' && state.people.length > 0) {
         categories.push({
           heading: 'Owner',
           items: state.people.map(function (v) {
             return { text: ownerLabels[v], type: 'person', value: v }
-          })
-        })
-      }
-
-      if (mode === 'owners' && state.ownersSelected.length > 0) {
-        categories.push({
-          heading: 'Owner',
-          items: state.ownersSelected.map(function (v) {
-            return { text: ownerLabels[v], type: 'owner', value: v }
           })
         })
       }
@@ -304,7 +287,6 @@
       else if (type === 'reference') referenceInput.value = ''
       else if (type === 'type') uncheck('filter-type', value)
       else if (type === 'status') uncheck('filter-status', value)
-      else if (type === 'owner') uncheck('filter-owner', value)
       else if (type === 'person') {
         uncheck('filter-person', value)
         // Dropping the last person leaves the scope radio pointing at nothing
@@ -325,24 +307,33 @@
 
       var word = visible === 1 ? 'result' : 'results'
 
-      if (mode === 'owners') {
-        return visible + ' ' + word + ' found'
-      }
+      // Individual users have no organisation and so no scope radios. Naming
+      // an organisation they are not part of would be wrong.
+      if (!hasScope) return visible + ' ' + word + ' found'
+
+      var allProjects = visible + ' ' + word + " found in 'All " + orgName + " projects'"
 
       if (state.scope === 'my-projects') {
         return visible + ' ' + word + " found in 'My projects'"
       }
+
       if (state.scope === 'specific-person') {
         var names = state.people.map(function (v) { return ownerNames[v] }).join(', ')
-        return visible + ' ' + word + " found in 'Projects by " + (names || 'owner') + "'"
+        if (!names) {
+          // Nothing narrowed yet, so say what is actually on screen rather
+          // than naming a scope the user has not filled in.
+          return allowEmptyOwner ? allProjects : visible + ' ' + word + " found in 'Projects by owner'"
+        }
+        return visible + ' ' + word + " found in 'Projects by " + names + "'"
       }
-      return visible + ' ' + word + " found in 'All " + orgName + " projects'"
+
+      return allProjects
     }
 
     function apply (checkForErrors) {
       var state = readState()
 
-      var isError = mode === 'radios' &&
+      var isError = !allowEmptyOwner &&
         checkForErrors &&
         state.scope === 'specific-person' &&
         state.people.length === 0
@@ -415,7 +406,7 @@
         if (projectNameInput) projectNameInput.value = ''
         if (referenceInput) referenceInput.value = ''
 
-        ;['filter-type', 'filter-status', 'filter-person', 'filter-owner'].forEach(function (name) {
+        ;['filter-type', 'filter-status', 'filter-person'].forEach(function (name) {
           document.querySelectorAll('input[name="' + name + '"]').forEach(function (cb) {
             cb.checked = false
           })

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -88,6 +88,8 @@ html: ''
             class="govuk-link--no-visited-state">Projects page</a></li>
             
       <li><a href="/versions/multiple-sites-v2/low-complexity-v3/view-details/view-details-pontoon-public" class="govuk-link--no-visited-state">View details public page</a></li>
+
+      <li><a href="/versions/multiple-sites-v2/low-complexity-v3/filters/index" class="govuk-link--no-visited-state">Projects filters concepts</a></li>
         </ul>
 
     <details class="govuk-details">

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/filters/hybrid.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/filters/hybrid.html
@@ -14,9 +14,10 @@
     1. Selected filters use MOJ's moj-filter-tags markup, not a bespoke tag
     2. Selected filters are always visible, not only when the panel is collapsed
     3. The panel starts collapsed, so results are the first thing you see
-    4. The Show radios and their nested owner reveal are replaced by a single
-       Owner checkbox group. This removes the "Select an owner" error state
-       entirely — there is no longer an invalid combination to guard against.
+    4. Same Show radios and owner reveal as A, but "Projects by owner" with
+       nobody ticked shows everything instead of raising an error. Picking the
+       radio is a step towards a filter, not a mistake to correct, so there is
+       no invalid state left to guard against.
 #}
 
 {% block head %}
@@ -62,6 +63,7 @@
 
   .filter-panel .govuk-radios__label::before,
   .filter-panel .govuk-checkboxes__label::before,
+  .filter-panel .govuk-radios__input:focus + .govuk-radios__label::before,
   .filter-panel .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
     background-color: #ffffff;
   }
@@ -178,8 +180,33 @@ Projects
 				{% if data['user_type'] === 'organisation' %}
 				<div class="govuk-form-group">
 					<fieldset class="govuk-fieldset">
-						<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Owner</legend>
-						<div class="govuk-checkboxes govuk-checkboxes--small" id="owner-checkboxes"></div>
+						<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Show</legend>
+						<div class="govuk-radios govuk-radios--small" data-module="govuk-radios">
+							<div class="govuk-radios__item">
+								<input class="govuk-radios__input" id="filter-all" name="projectFilter" type="radio" value="all-projects" checked>
+								<label class="govuk-label govuk-radios__label" for="filter-all">
+									All {{ data['organisation-name'] or "Ramsgate Marina" }} projects <span id="count-all-projects"></span>
+								</label>
+							</div>
+							<div class="govuk-radios__item">
+								<input class="govuk-radios__input" id="filter-my" name="projectFilter" type="radio" value="my-projects">
+								<label class="govuk-label govuk-radios__label" for="filter-my">
+									My projects <span id="count-my-projects"></span>
+								</label>
+							</div>
+							<div class="govuk-radios__item">
+								<input class="govuk-radios__input" id="filter-specific" name="projectFilter" type="radio" value="specific-person" data-aria-controls="conditional-specific-person">
+								<label class="govuk-label govuk-radios__label" for="filter-specific">Projects by owner</label>
+							</div>
+							{# No error message here. Picking this with nobody ticked simply
+							   has not narrowed anything yet, so there is nothing to correct. #}
+							<div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-specific-person">
+								<fieldset class="govuk-fieldset">
+									<legend class="govuk-fieldset__legend govuk-visually-hidden">Select an owner</legend>
+									<div class="govuk-checkboxes govuk-checkboxes--small" id="person-checkboxes"></div>
+								</fieldset>
+							</div>
+						</div>
 					</fieldset>
 				</div>
 				{% endif %}
@@ -242,7 +269,9 @@ document.addEventListener('DOMContentLoaded', function () {
 	var container = document.getElementById('selected-filter-tags')
 
 	LcmlProjectsFilter.init({
-		mode: 'owners',
+		selfLabel: 'Me',
+		pinSelf: true,
+		allowEmptyOwner: true,
 		tagRenderer: function (categories, remove) {
 			container.innerHTML = ''
 

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/filters/index.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/filters/index.html
@@ -47,7 +47,7 @@ Projects filter options
     </p>
 
     <h2 class="govuk-heading-m govuk-!-margin-top-7">
-      <a class="govuk-link govuk-link--no-visited-state" href="filters/top-panel?user_type=organisation&organisation-name=Ramsgate Marina" target="_blank">Option A - top panel</a>
+      <a class="govuk-link govuk-link--no-visited-state" href="/versions/multiple-sites-v2/low-complexity-v3/filters/top-panel?user_type=organisation&organisation-name=Ramsgate Marina" target="_blank">Option A - top panel</a>
     </h2>
     <p class="govuk-body">
       Bespoke horizontal panel above the results. Keeps the full table width.
@@ -55,7 +55,7 @@ Projects filter options
     </p>
 
     <h2 class="govuk-heading-m govuk-!-margin-top-7">
-      <a class="govuk-link govuk-link--no-visited-state" href="filters/sidebar?user_type=organisation&organisation-name=Ramsgate Marina" target="_blank">Option B - MOJ filter</a>
+      <a class="govuk-link govuk-link--no-visited-state" href="/versions/multiple-sites-v2/low-complexity-v3/filters/sidebar?user_type=organisation&organisation-name=Ramsgate Marina" target="_blank">Option B - MOJ filter</a>
     </h2>
     <p class="govuk-body">
       The <a class="govuk-link" href="https://design-patterns.service.justice.gov.uk/components/filter/" rel="noreferrer noopener" target="_blank">MOJ Design System filter (opens in new tab)</a>
@@ -64,18 +64,18 @@ Projects filter options
     </p>
 
     <h2 class="govuk-heading-m govuk-!-margin-top-7">
-      <a class="govuk-link govuk-link--no-visited-state" href="filters/hybrid?user_type=organisation&organisation-name=Ramsgate Marina" target="_blank">Option C - top panel with MOJ mechanics</a>
+      <a class="govuk-link govuk-link--no-visited-state" href="/versions/multiple-sites-v2/low-complexity-v3/filters/hybrid?user_type=organisation&organisation-name=Ramsgate Marina" target="_blank">Option C - top panel with MOJ mechanics</a>
     </h2>
     <p class="govuk-body">
       Top panel for the table width, MOJ tags for the selected filters, summary
-      always visible, panel collapsed on load. Also replaces the Show radios and
-      their nested owner reveal with a single Owner checkbox group, which
-      removes the error state altogether.
+      always visible, panel collapsed on load. Same Show radios as A and B, but
+      picking "Projects by owner" without ticking anyone shows everything
+      instead of raising an error.
     </p>
 
     <h2 class="govuk-heading-m govuk-!-margin-top-8">Compare against</h2>
     <p class="govuk-body">
-      <a class="govuk-link govuk-link--no-visited-state" href="/versions/multiple-sites-v2/low-complexity-v3/projects.html?user_type=organisation&organisation-name=Ramsgate Marina">The current projects page</a> -
+      <a class="govuk-link govuk-link--no-visited-state" href="/versions/multiple-sites-v2/low-complexity-v3/projects?user_type=organisation&organisation-name=Ramsgate Marina">The current projects page</a> -
       no filter panel, just the Show radios and a sortable table.
     </p>
 

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/filters/sidebar.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/filters/sidebar.html
@@ -202,7 +202,6 @@ document.addEventListener('DOMContentLoaded', function () {
   var container = document.getElementById('selected-filter-tags')
 
   LcmlProjectsFilter.init({
-    mode: 'radios',
     tagRenderer: function (categories, remove) {
       container.innerHTML = ''
       categories.forEach(function (category) {

--- a/app/views/versions/multiple-sites-v2/low-complexity-v3/filters/top-panel.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v3/filters/top-panel.html
@@ -327,7 +327,6 @@ document.addEventListener('DOMContentLoaded', function () {
 	var tagsContainer = document.getElementById('filter-tags-container')
 
 	LcmlProjectsFilter.init({
-		mode: 'radios',
 		tagRenderer: function (categories, remove) {
 			tagsContainer.innerHTML = ''
 			categories.forEach(function (category) {


### PR DESCRIPTION
Replace the `mode: 'radios' | 'owners'` option with explicit `selfLabel`, `pinSelf`, and `allowEmptyOwner` flags. Option C (hybrid) now uses the same Show radios as A and B, with `allowEmptyOwner: true` instead of a separate owner checkbox group. Fix index page links to use absolute paths and update copy to reflect the behaviour change.