### PR TITLE
Add MOJ filter panel to LCML v4 projects

### DIFF
--- a/app/assets/javascripts/lcml-v4-projects-filter.js
+++ b/app/assets/javascripts/lcml-v4-projects-filter.js
@@ -1,0 +1,461 @@
+/*
+  Filter for the LCML v4 projects page (low-complexity-v4/projects).
+
+  Standalone on purpose. The three filter explorations under
+  low-complexity-v4/filters/ share lcml-projects-filter.js, and the sample plans
+  journey has its own sample-plans-v2-disposal-site-*.js. Keeping this one
+  separate means the live projects page cannot be broken by edits to either.
+
+  What it does:
+    - builds the Type, Status and Owner checkboxes from the rendered table, so
+      options and counts always match what is actually on the page
+    - filters rows on Apply, and on removing a selected-filter tag
+    - renders the MOJ selected-filter tags
+    - wires up MOJ's FilterToggleButton so the panel starts hidden
+
+  Deliberately no Project name or Reference search for this iteration - we want
+  to usability test the panel without them.
+
+  Counts against each option are TOTALS from the table. They do not respond to
+  other active filters. Facet-style counts would prevent more dead ends but
+  would move as you filter - worth a conversation with the team.
+
+  Markup it expects (all optional except the table):
+    #projects-table, #projects-caption, #no-results-message, #results-count
+    #apply-filters, #clear-filters, #selected-filter-tags
+    #type-checkboxes, #status-checkboxes, #person-checkboxes
+    #count-all-projects, #count-my-projects
+    #conditional-specific-person, #person-error-message
+    input[name="projectFilter"]
+*/
+(function (global) {
+  'use strict'
+
+  var CURRENT_USER = 'jon-doe'
+
+  function text (el) {
+    return el ? el.textContent.trim() : ''
+  }
+
+  function init () {
+    var table = document.getElementById('projects-table')
+    if (!table) return
+
+    var rows = Array.prototype.slice.call(table.querySelectorAll('tbody tr'))
+    var noResultsMessage = document.getElementById('no-results-message')
+    var resultsCount = document.getElementById('results-count')
+    var caption = document.getElementById('projects-caption')
+    var applyButton = document.getElementById('apply-filters')
+    var clearLink = document.getElementById('clear-filters')
+    var tagContainer = document.getElementById('selected-filter-tags')
+
+    var orgName = text(document.querySelector('.govuk-caption-l')) || 'Ramsgate Marina'
+    var hasScope = document.querySelectorAll('input[name="projectFilter"]').length > 0
+
+    // The Owner column is only rendered for organisation users, so find it by
+    // header text rather than assuming a fixed index.
+    var headers = Array.prototype.slice.call(table.querySelectorAll('thead th'))
+    var ownerIndex = -1
+    headers.forEach(function (th, i) {
+      if (text(th) === 'Owner') ownerIndex = i
+    })
+    var hasOwners = ownerIndex > -1
+
+    // ---------------------------------------------------------------- model
+
+    var model = rows.map(function (row) {
+      return {
+        el: row,
+        creator: row.getAttribute('data-creator') || '',
+        type: row.getAttribute('data-type') || '',
+        status: row.getAttribute('data-status') || '',
+        ownerName: hasOwners ? text(row.cells[ownerIndex]) : ''
+      }
+    })
+
+    function uniqueBy (key) {
+      var seen = []
+      model.forEach(function (item) {
+        if (item[key] && seen.indexOf(item[key]) === -1) seen.push(item[key])
+      })
+      return seen.sort(function (a, b) { return a.localeCompare(b) })
+    }
+
+    function countBy (key, value) {
+      return model.filter(function (item) { return item[key] === value }).length
+    }
+
+    // Owners present in the table. Nobody with zero projects appears, so no
+    // phantom options when session data hides rows.
+    var owners = []
+    if (hasOwners) {
+      model.forEach(function (item) {
+        var known = owners.some(function (o) { return o.value === item.creator })
+        if (!known && item.creator) {
+          owners.push({
+            value: item.creator,
+            name: item.ownerName,
+            label: item.creator === CURRENT_USER
+              ? 'You (' + item.ownerName + ')'
+              : item.ownerName
+          })
+        }
+      })
+
+      owners.sort(function (a, b) { return a.label.localeCompare(b.label) })
+    }
+
+    // Plain names read better in prose ("Projects by Sam Evans"); labels carry
+    // the You prefix and are what the controls and tags show.
+    var ownerNames = {}
+    var ownerLabels = {}
+    owners.forEach(function (o) {
+      ownerNames[o.value] = o.name
+      ownerLabels[o.value] = o.label
+    })
+
+    // ------------------------------------------------------- build controls
+
+    function buildCheckboxes (container, values, name, idPrefix, labelFor) {
+      if (!container) return
+      container.innerHTML = ''
+      values.forEach(function (value, index) {
+        var id = idPrefix + '-' + index
+
+        var item = document.createElement('div')
+        item.className = 'govuk-checkboxes__item'
+
+        var input = document.createElement('input')
+        input.className = 'govuk-checkboxes__input'
+        input.id = id
+        input.name = name
+        input.type = 'checkbox'
+        input.value = value
+
+        var label = document.createElement('label')
+        label.className = 'govuk-label govuk-checkboxes__label'
+        label.setAttribute('for', id)
+        label.textContent = labelFor(value)
+
+        item.appendChild(input)
+        item.appendChild(label)
+        container.appendChild(item)
+      })
+    }
+
+    buildCheckboxes(
+      document.getElementById('type-checkboxes'),
+      uniqueBy('type'),
+      'filter-type',
+      'type',
+      function (v) { return v + ' (' + countBy('type', v) + ')' }
+    )
+
+    buildCheckboxes(
+      document.getElementById('status-checkboxes'),
+      uniqueBy('status'),
+      'filter-status',
+      'status',
+      function (v) { return v + ' (' + countBy('status', v) + ')' }
+    )
+
+    buildCheckboxes(
+      document.getElementById('person-checkboxes'),
+      owners.map(function (o) { return o.value }),
+      'filter-person',
+      'person',
+      function (v) { return ownerLabels[v] + ' (' + countBy('creator', v) + ')' }
+    )
+
+    var countAll = document.getElementById('count-all-projects')
+    var countMine = document.getElementById('count-my-projects')
+    if (countAll) countAll.textContent = '(' + model.length + ')'
+    if (countMine) countMine.textContent = '(' + countBy('creator', CURRENT_USER) + ')'
+
+    // --------------------------------------------------------------- state
+
+    function checkedValues (name) {
+      return Array.prototype.slice
+        .call(document.querySelectorAll('input[name="' + name + '"]:checked'))
+        .map(function (cb) { return cb.value })
+    }
+
+    function readState () {
+      var scopeRadio = document.querySelector('input[name="projectFilter"]:checked')
+      return {
+        scope: scopeRadio ? scopeRadio.value : 'all-projects',
+        people: checkedValues('filter-person'),
+        types: checkedValues('filter-type'),
+        statuses: checkedValues('filter-status')
+      }
+    }
+
+    function matches (item, state) {
+      if (state.scope === 'my-projects' && item.creator !== CURRENT_USER) return false
+
+      if (state.scope === 'specific-person') {
+        // Nobody picked yet is an error state, handled in apply(), so nothing
+        // matches until an owner is ticked.
+        if (state.people.length === 0) return false
+        if (state.people.indexOf(item.creator) === -1) return false
+      }
+
+      if (state.types.length > 0 && state.types.indexOf(item.type) === -1) return false
+      if (state.statuses.length > 0 && state.statuses.indexOf(item.status) === -1) return false
+
+      return true
+    }
+
+    // ---------------------------------------------------------- error state
+
+    function setErrorState (on) {
+      var panel = document.getElementById('conditional-specific-person')
+      var message = document.getElementById('person-error-message')
+      if (panel) panel.classList.toggle('error-state', on)
+      if (message) message.style.display = on ? 'block' : 'none'
+      if (resultsCount) resultsCount.classList.toggle('error-message', on)
+    }
+
+    // ---------------------------------------------------------------- tags
+
+    function buildCategories (state) {
+      var categories = []
+
+      if (state.scope === 'specific-person' && state.people.length > 0) {
+        categories.push({
+          heading: 'Owner',
+          items: state.people.map(function (v) {
+            return { text: ownerLabels[v], type: 'person', value: v }
+          })
+        })
+      }
+
+      if (state.types.length > 0) {
+        categories.push({
+          heading: 'Type',
+          items: state.types.map(function (v) { return { text: v, type: 'type', value: v } })
+        })
+      }
+
+      if (state.statuses.length > 0) {
+        categories.push({
+          heading: 'Status',
+          items: state.statuses.map(function (v) { return { text: v, type: 'status', value: v } })
+        })
+      }
+
+      return categories
+    }
+
+    function renderTags (categories) {
+      if (!tagContainer) return
+      tagContainer.innerHTML = ''
+
+      categories.forEach(function (category) {
+        var heading = document.createElement('h3')
+        heading.className = 'govuk-heading-s govuk-!-margin-bottom-0'
+        heading.textContent = category.heading
+        tagContainer.appendChild(heading)
+
+        var list = document.createElement('ul')
+        list.className = 'moj-filter-tags'
+
+        category.items.forEach(function (item) {
+          var li = document.createElement('li')
+          var link = document.createElement('a')
+          link.className = 'moj-filter__tag'
+          link.href = '#'
+          link.innerHTML = '<span class="govuk-visually-hidden">Remove this filter</span> ' + item.text
+          link.addEventListener('click', function (e) {
+            e.preventDefault()
+            removeFilter(item.type, item.value)
+          })
+          li.appendChild(link)
+          list.appendChild(li)
+        })
+
+        tagContainer.appendChild(list)
+      })
+    }
+
+    function uncheck (name, value) {
+      var cb = document.querySelector('input[name="' + name + '"][value="' + value + '"]')
+      if (cb) cb.checked = false
+    }
+
+    function removeFilter (type, value) {
+      if (type === 'type') uncheck('filter-type', value)
+      else if (type === 'status') uncheck('filter-status', value)
+      else if (type === 'person') {
+        uncheck('filter-person', value)
+        // Dropping the last person leaves the scope radio pointing at nothing
+        // meaningful, so fall back to showing everything.
+        if (checkedValues('filter-person').length === 0) {
+          selectAllProjects()
+          hideConditional()
+        }
+      }
+      apply(false)
+    }
+
+    // ------------------------------------------------------------- results
+
+    function scopeName (state) {
+      if (state.scope === 'my-projects') return 'My projects'
+
+      if (state.scope === 'specific-person') {
+        var names = state.people.map(function (v) { return ownerNames[v] }).join(', ')
+        return names ? 'Projects by ' + names : 'Projects by owner'
+      }
+
+      return 'All ' + orgName + ' projects'
+    }
+
+    function resultsMessage (state, visible, isError) {
+      if (isError) return 'Select an owner to view their projects'
+
+      var word = visible === 1 ? 'result' : 'results'
+
+      // Individual users have no organisation and so no scope radios. Naming
+      // an organisation they are not part of would be wrong.
+      if (!hasScope) return visible + ' ' + word + ' found'
+
+      return visible + ' ' + word + " found in '" + scopeName(state) + "'"
+    }
+
+    function apply (checkForErrors) {
+      var state = readState()
+
+      var isError = checkForErrors &&
+        state.scope === 'specific-person' &&
+        state.people.length === 0
+
+      setErrorState(isError)
+      renderTags(buildCategories(state))
+      if (caption && hasScope) caption.textContent = scopeName(state)
+
+      if (isError) {
+        if (resultsCount) {
+          resultsCount.innerHTML = '<strong>' + resultsMessage(state, 0, true) + '</strong>'
+        }
+        table.style.display = 'none'
+        if (noResultsMessage) noResultsMessage.style.display = 'none'
+        return
+      }
+
+      var visible = 0
+      model.forEach(function (item) {
+        var show = matches(item, state)
+        item.el.style.display = show ? '' : 'none'
+        if (show) visible++
+      })
+
+      if (resultsCount) {
+        resultsCount.innerHTML = '<strong>' + resultsMessage(state, visible, false) + '</strong>'
+      }
+
+      table.style.display = visible === 0 ? 'none' : 'table'
+      if (noResultsMessage) noResultsMessage.style.display = visible === 0 ? 'block' : 'none'
+    }
+
+    // --------------------------------------------------------- conditional
+
+    function conditionalPanel () {
+      return document.getElementById('conditional-specific-person')
+    }
+
+    function hideConditional () {
+      var panel = conditionalPanel()
+      if (panel) panel.classList.add('govuk-radios__conditional--hidden')
+    }
+
+    function showConditional () {
+      var panel = conditionalPanel()
+      if (panel) panel.classList.remove('govuk-radios__conditional--hidden')
+    }
+
+    function selectAllProjects () {
+      var all = document.querySelector('input[name="projectFilter"][value="all-projects"]')
+      if (all) all.checked = true
+    }
+
+    // -------------------------------------------------------------- events
+
+    if (applyButton) {
+      applyButton.addEventListener('click', function (e) {
+        e.preventDefault()
+        apply(true)
+      })
+    }
+
+    if (clearLink) {
+      clearLink.addEventListener('click', function (e) {
+        e.preventDefault()
+
+        selectAllProjects()
+        hideConditional()
+
+        ;['filter-type', 'filter-status', 'filter-person'].forEach(function (name) {
+          document.querySelectorAll('input[name="' + name + '"]').forEach(function (cb) {
+            cb.checked = false
+          })
+        })
+
+        apply(false)
+      })
+    }
+
+    document.querySelectorAll('input[name="projectFilter"]').forEach(function (radio) {
+      radio.addEventListener('change', function () {
+        if (this.value === 'specific-person') {
+          showConditional()
+        } else {
+          hideConditional()
+          document.querySelectorAll('input[name="filter-person"]').forEach(function (cb) {
+            cb.checked = false
+          })
+          setErrorState(false)
+        }
+      })
+    })
+
+    // Initial paint, then make the count a live region so later updates are
+    // announced but the page does not announce itself on load.
+    apply(false)
+    if (resultsCount) resultsCount.setAttribute('aria-live', 'polite')
+  }
+
+  /*
+    Hand the show/hide behaviour to MOJ's own FilterToggleButton rather than
+    reimplementing it. It creates the Show filter button, moves focus into the
+    panel when opened, and swaps in a Close button below 48.0625em. Its default
+    startHidden: true is what we want - the panel is collapsed on load.
+
+    MOJ ships pure ES modules and sets no window.MOJFrontend global, and its
+    initAll does not cover this component (it needs a root element passed in).
+    So import it directly from the plugin asset the kit already serves. It is
+    dynamic and wrapped, so if that path ever moves we lose the toggle button
+    and the panel stays open - the filtering itself keeps working.
+  */
+  var MOJ_FRONTEND = '/plugin-assets/%40ministryofjustice%2Ffrontend/moj/moj-frontend.min.js'
+
+  function initToggleButton () {
+    var filter = document.querySelector('.moj-filter')
+    if (!filter) return
+
+    import(MOJ_FRONTEND)
+      .then(function (moj) { new moj.FilterToggleButton(filter) })
+      .catch(function () { /* panel stays visible */ })
+  }
+
+  function start () {
+    init()
+    initToggleButton()
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start)
+  } else {
+    start()
+  }
+})(window)

--- a/app/views/versions/multiple-sites-v2/low-complexity-v4/projects.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v4/projects.html
@@ -1,15 +1,51 @@
 {% extends "../layouts/low-complexity-v4.html" %}
 
 {% from "govuk/components/tag/macro.njk" import govukTag %}
-{% from "govuk/components/radios/macro.njk" import govukRadios %}
 
 {% block head %}
   {{ super() }}
   <style>
-  .govuk-radios--inline .govuk-radios__label {
-    white-space: nowrap;
+  /* ------------------------------------------------------------------
+     FILTER COLUMN WIDTH
+
+     MOJ's default is min-width 260px / max-width 385px, so the panel is
+     usually ~385px wide. Set all three properties to the same value:
+     min-width has to be included or it wins over width and max-width and
+     nothing below 260px has any effect.
+
+     Only applies from 48.0625em up. Below that the panel is a full-screen
+     overlay, which is MOJ's own behaviour and shouldn't be overridden.
+     ------------------------------------------------------------------ */
+  @media (min-width: 48.0625em) {
+    .moj-filter-layout--narrow .moj-filter-layout__filter {
+      width: 260px;
+      min-width: 260px;
+      max-width: 260px;
+    }
+  }
+
+  /* Error state for "Projects by owner" with nobody ticked */
+  .govuk-radios__conditional.error-state {
+    border-left-color: #d4351c;
+  }
+
+  .person-error-message {
+    display: none;
+    color: #d4351c;
+    font-weight: 700;
+    margin-bottom: 15px;
+  }
+
+  #results-count.error-message {
+    color: #d4351c;
   }
   </style>
+{% endblock %}
+
+{% block bodyEnd %}
+  {{ super() }}
+  {# Pulls in MOJ's FilterToggleButton itself - see the notes in the file. #}
+  <script src="/public/javascripts/lcml-v4-projects-filter.js"></script>
 {% endblock %}
 
 <!-- Set a variable to identify this specific page -->
@@ -82,33 +118,108 @@ Projects
 		<h1 class="govuk-heading-l">
 			{{ pageHeadingTextHTML }}
 		</h1>
-		
-		{% if data['user_type'] === 'organisation' %}
-		{{ govukRadios({
-			name: "projectFilter",
-			fieldset: {
-				legend: {
-					text: "Show",
-					classes: "govuk-fieldset__legend--s"
-				}
-			},
-			classes: "govuk-radios--small govuk-radios--inline",
-			items: [
-				{
-					value: "my-projects",
-					text: "My projects",
-					checked: true
-				},
-				{
-					value: "all-projects",
-					text: "All " + (data['organisation-name'] or "Ramsgate Marina") + " projects"
-				}
-			]
-		}) }}
-		{% endif %}
-		
+	</div>
+</div>
+
+{#
+  MOJ Design System "Filter a list" pattern.
+  https://design-patterns.service.justice.gov.uk/patterns/filter-a-list/
+
+  Apply filters sits at the top of the options, above the fields it submits,
+  as it does in the MOJ pattern. The panel starts collapsed - MOJ's
+  FilterToggleButton adds the Show filter button into .moj-action-bar__filter.
+#}
+<div class="moj-filter-layout moj-filter-layout--narrow">
+	<div class="moj-filter-layout__filter">
+		<div class="moj-filter" data-module="moj-filter">
+			<div class="moj-filter__header">
+				<div class="moj-filter__header-title">
+					<h2 class="govuk-heading-m">Filter</h2>
+				</div>
+				<div class="moj-filter__header-action"></div>
+			</div>
+
+			<div class="moj-filter__content">
+				<div class="moj-filter__selected">
+					<div class="moj-filter__selected-heading">
+						<div class="moj-filter__heading-title">
+							<h2 class="govuk-heading-m">Selected filters</h2>
+						</div>
+						<div class="moj-filter__heading-action">
+							<p><a class="govuk-link govuk-link--no-visited-state" href="#" id="clear-filters">Clear filters</a></p>
+						</div>
+					</div>
+					<div id="selected-filter-tags"></div>
+				</div>
+
+				<div class="moj-filter__options">
+					<button type="button" class="govuk-button govuk-!-margin-bottom-6" data-module="govuk-button" id="apply-filters">
+						Apply filters
+					</button>
+
+					{% if data['user_type'] === 'organisation' %}
+					<div class="govuk-form-group">
+						<fieldset class="govuk-fieldset">
+							<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Show</legend>
+							<div class="govuk-radios govuk-radios--small" data-module="govuk-radios">
+								<div class="govuk-radios__item">
+									<input class="govuk-radios__input" id="filter-all" name="projectFilter" type="radio" value="all-projects" checked>
+									<label class="govuk-label govuk-radios__label" for="filter-all">
+										All {{ data['organisation-name'] or "Ramsgate Marina" }} projects <span id="count-all-projects"></span>
+									</label>
+								</div>
+								<div class="govuk-radios__item">
+									<input class="govuk-radios__input" id="filter-my" name="projectFilter" type="radio" value="my-projects">
+									<label class="govuk-label govuk-radios__label" for="filter-my">
+										My projects <span id="count-my-projects"></span>
+									</label>
+								</div>
+								<div class="govuk-radios__item">
+									<input class="govuk-radios__input" id="filter-specific" name="projectFilter" type="radio" value="specific-person" data-aria-controls="conditional-specific-person">
+									<label class="govuk-label govuk-radios__label" for="filter-specific">Projects by owner</label>
+								</div>
+								<div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-specific-person">
+									<fieldset class="govuk-fieldset">
+										<legend class="govuk-fieldset__legend govuk-visually-hidden">Select an owner</legend>
+										<p class="person-error-message" id="person-error-message">
+											<span class="govuk-visually-hidden">Error:</span> Select an owner to view their projects
+										</p>
+										<div class="govuk-checkboxes govuk-checkboxes--small" id="person-checkboxes"></div>
+									</fieldset>
+								</div>
+							</div>
+						</fieldset>
+					</div>
+					{% endif %}
+
+					<div class="govuk-form-group">
+						<fieldset class="govuk-fieldset">
+							<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Type</legend>
+							<div class="govuk-checkboxes govuk-checkboxes--small" id="type-checkboxes"></div>
+						</fieldset>
+					</div>
+
+					<div class="govuk-form-group">
+						<fieldset class="govuk-fieldset">
+							<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Status</legend>
+							<div class="govuk-checkboxes govuk-checkboxes--small" id="status-checkboxes"></div>
+						</fieldset>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<div class="moj-filter-layout__content">
+		{# FilterToggleButton appends the Show/Hide filter button here. Leave empty. #}
+		<div class="moj-action-bar">
+			<div class="moj-action-bar__filter"></div>
+		</div>
+
+		<p id="results-count" class="govuk-body"></p>
+
 		<table class="govuk-table" data-module="moj-sortable-table" id="projects-table">
-			<caption class="govuk-table__caption govuk-table__caption--m govuk-visually-hidden" id="projects-caption">My projects</caption>
+			<caption class="govuk-table__caption govuk-table__caption--m govuk-visually-hidden" id="projects-caption">All {{ data['organisation-name'] or "Ramsgate Marina" }} projects</caption>
 			<thead class="govuk-table__head">
 				<tr class="govuk-table__row">
 				  <th scope="col" class="govuk-table__header" aria-sort="none">Project&nbsp;name</th>
@@ -240,7 +351,7 @@ Projects
 				<!-- Marine licence (dynamic based on session data) -->
 				<!-- Requires low-complexity-application-status so a project name captured from a query param (e.g. the Reject email link) does not, on its own, render a draft row. -->
 				{% if data['low-complexity-project-name-text-input'] and data['low-complexity-application-status'] and not data['resubmit-draft-created'] %}
-				<tr class="govuk-table__row" data-creator="jon-doe" data-project-name="{{ data['low-complexity-project-name-text-input'] }}" data-type="Marine licence" data-reference="{% if data['low-complexity-application-status'] == 'sent' %}MLA-10025{% else %}-{% endif %}" data-status="{% if data['low-complexity-application-status'] == 'sent' %}{% if data['withdrawn-mla-submitted'] == 'true' %}Withdrawn{% else %}Submitted{% endif %}{% else %}Draft{% endif %}">
+				<tr class="govuk-table__row" data-creator="jon-doe" data-project-name="{{ data['low-complexity-project-name-text-input'] }}" data-type="Marine licence application" data-reference="{% if data['low-complexity-application-status'] == 'sent' %}MLA-10025{% else %}-{% endif %}" data-status="{% if data['low-complexity-application-status'] == 'sent' %}{% if data['withdrawn-mla-submitted'] == 'true' %}Withdrawn{% else %}Submitted{% endif %}{% else %}Draft{% endif %}">
 					<th scope="row" class="govuk-table__header govuk-!-font-weight-regular">{{ data['low-complexity-project-name-text-input'] }}</th>
 					<td class="govuk-table__cell">Marine licence application</td>
 					<td class="govuk-table__cell" data-sort-value="{% if data['low-complexity-application-status'] == 'sent' %}MLA-10025{% else %}-{% endif %}">{% if data['low-complexity-application-status'] == 'sent' %}MLA/2025/10025{% else %}-{% endif %}</td>
@@ -444,84 +555,8 @@ Projects
 		</table>
 
 		<p id="no-results-message" class="govuk-body" style="display: none;">There are no projects to display.</p>
-
 	</div>
 </div>
-
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-	const projectFilterRadios = document.querySelectorAll('input[name="projectFilter"]');
-	const tableRows = document.querySelectorAll('#projects-table tbody tr');
-	const projectsTable = document.getElementById('projects-table');
-	const noResultsMessage = document.getElementById('no-results-message');
-	const projectsCaption = document.getElementById('projects-caption');
-	
-	// Get organization name from page (from session data)
-	const orgCaption = document.querySelector('.govuk-caption-l');
-	const orgName = orgCaption ? orgCaption.textContent.trim() : 'Ramsgate Marina';
-	
-	// Update caption display
-	function updateCaption(selectedFilter) {
-		if (!projectsCaption) return;
-		
-		if (selectedFilter === 'all-projects') {
-			projectsCaption.textContent = `All ${orgName} projects`;
-		} else {
-			projectsCaption.textContent = 'My projects';
-		}
-	}
-	
-	// Function to filter projects
-	function filterProjects() {
-		const selectedFilter = document.querySelector('input[name="projectFilter"]:checked');
-		const filterValue = selectedFilter ? selectedFilter.value : 'my-projects';
-		let visibleCount = 0;
-		
-		tableRows.forEach(function(row) {
-			const creator = row.getAttribute('data-creator');
-			let show = true;
-			
-			// If showing my projects, only show Sam Evans's projects (current user)
-			if (filterValue === 'my-projects') {
-				if (!creator || !creator.includes('jon-doe')) {
-					show = false;
-				}
-			}
-			// If filterValue is 'all-projects', show all projects (no filtering needed)
-			
-			// Show/hide row
-			if (show) {
-				row.style.display = '';
-				visibleCount++;
-			} else {
-				row.style.display = 'none';
-			}
-		});
-		
-		// Update caption
-		updateCaption(filterValue);
-		
-		// Show/hide table and no results message based on visible count
-		if (visibleCount === 0) {
-			projectsTable.style.display = 'none';
-			noResultsMessage.style.display = 'block';
-		} else {
-			projectsTable.style.display = 'table';
-			noResultsMessage.style.display = 'none';
-		}
-	}
-	
-	// Add change listener to radio buttons
-	projectFilterRadios.forEach(function(radio) {
-		radio.addEventListener('change', function() {
-			filterProjects();
-		});
-	});
-	
-	// Initialize: run initial filter (default to My projects)
-	filterProjects();
-});
-</script>
 
 {% endblock %}
 


### PR DESCRIPTION
Replaces the basic inline my/all project toggle with a full MOJ filter-layout implementation on the projects page, including Apply/Clear actions, selected-filter tags, results messaging, and empty/error states. Adds a dedicated `lcml-v4-projects-filter.js` that builds Type/Status/Owner checkbox options from table data, supports scope filtering (all, mine, specific owner), wires MOJ `FilterToggleButton`, and removes the old embedded filtering script. Also aligns the dynamic row `data-type` value with “Marine licence application” for consistent filtering.