### PR TITLE
Add postcode lookup for invoice addresses

### DIFF
--- a/app/routes/versions/multiple-sites-v2/low-complexity-v4-fee-and-invoicing.js
+++ b/app/routes/versions/multiple-sites-v2/low-complexity-v4-fee-and-invoicing.js
@@ -119,8 +119,94 @@ module.exports = function (router) {
     'invoice-phone',
     'invoice-email',
     'invoice-po-required',
-    'invoice-po-number'
+    'invoice-po-number',
+    // Postcode lookup
+    'invoice-postcode-search',
+    'invoice-property-name-number',
+    'invoice-lookup-results',
+    'invoice-selected-address',
+    'invoice-address-source'
   ];
+
+  ///////////////////////////////////////////
+  // Mock address lookup
+  //
+  // There is no address service in the prototype, so the lookup is faked
+  // against a single made-up Exmouth postcode:
+  //
+  //   EX8 1AN                 -> 5 results, so the address picker is shown
+  //   EX8 1AN + a property    -> 1 result, so Review and confirm is shown
+  //   anything else           -> 0 results, so the "not found" error is shown
+  //
+  // Fields mirror the shape the real lookup returns (ML-1501 AC2).
+  ///////////////////////////////////////////
+
+  const MOCK_POSTCODE = 'EX81AN';
+
+  const mockAddresses = [
+    { buildingNumber: '1', street: 'Marine Parade', locality: '', town: 'Exmouth', ceremonialCounty: 'Devon', postcode: 'EX8 1AN' },
+    { buildingNumber: '2', street: 'Marine Parade', locality: '', town: 'Exmouth', ceremonialCounty: 'Devon', postcode: 'EX8 1AN' },
+    { buildingNumber: '3', street: 'Marine Parade', locality: '', town: 'Exmouth', ceremonialCounty: 'Devon', postcode: 'EX8 1AN' },
+    { subBuildingName: 'Flat 2', buildingNumber: '4', street: 'Marine Parade', locality: '', town: 'Exmouth', ceremonialCounty: 'Devon', postcode: 'EX8 1AN' },
+    { buildingName: 'The Boathouse', buildingNumber: '5', street: 'Marine Parade', locality: 'Point in View', town: 'Exmouth', ceremonialCounty: 'Devon', postcode: 'EX8 1AN' }
+  ];
+
+  // Postcodes are compared with spaces and case removed so "ex8 1an" matches.
+  function normalisePostcode(value) {
+    return (value || '').replace(/\s+/g, '').toUpperCase();
+  }
+
+  // The single line shown on the address picker and confirm pages, built from
+  // whichever of the building fields the address actually has.
+  function buildAddressLine(address) {
+    const parts = [address.subBuildingName, address.buildingName, address.buildingNumber, address.street]
+      .filter(function (part) { return part; })
+      .join(' ');
+    return `${parts}, ${address.town} ${address.postcode}`;
+  }
+
+  // Runs the fake search. Returns every address for the postcode, narrowed to
+  // a single match when a property name or number is given.
+  function lookupAddresses(postcode, property) {
+    if (normalisePostcode(postcode) !== MOCK_POSTCODE) {
+      return [];
+    }
+
+    const results = mockAddresses.map(function (address) {
+      return Object.assign({}, address, { addressLine: buildAddressLine(address) });
+    });
+
+    const search = (property || '').trim().toLowerCase();
+    if (search === '') {
+      return results;
+    }
+
+    return results.filter(function (address) {
+      return [address.buildingNumber, address.buildingName, address.subBuildingName]
+        .filter(function (part) { return part; })
+        .some(function (part) { return part.toLowerCase().indexOf(search) !== -1; });
+    });
+  }
+
+  // Copies a looked-up address into the same session keys a manually entered
+  // address uses, so everything downstream is unaware of where it came from
+  // (ML-1501 AC4b).
+  function storeAddress(req, address) {
+    req.session.data['invoice-address-line-1'] = [address.subBuildingName, address.buildingName, address.buildingNumber, address.street]
+      .filter(function (part) { return part; })
+      .join(' ');
+    req.session.data['invoice-address-line-2'] = address.locality || '';
+    req.session.data['invoice-town-city'] = address.town || '';
+    req.session.data['invoice-county'] = address.ceremonialCounty || '';
+    req.session.data['invoice-postcode'] = address.postcode || '';
+    req.session.data['invoice-address-source'] = 'lookup';
+  }
+
+  // Query string used to carry the "returning to the check page" state through
+  // each step of the lookup.
+  function returnToQuery(returnTo) {
+    return returnTo ? `?returnTo=${returnTo}` : '';
+  }
 
   // Helper: render an invoicing page with locals
   function renderInvoicing(res, req, page, locals) {
@@ -201,14 +287,114 @@ module.exports = function (router) {
       if (!typeChanged && ukAddressCaptured) {
         return res.redirect('check-invoicing-details');
       }
-      return res.redirect(`uk-invoice-address?returnTo=${addressReturnTo}`);
+      return res.redirect(`postcode-search?returnTo=${addressReturnTo}`);
     }
 
     // Forward flow
     if (addressType === 'international') {
       return res.redirect('international-invoice-address');
     }
-    res.redirect('uk-invoice-address');
+    // UK addresses now start with the postcode lookup rather than manual entry
+    res.redirect('postcode-search');
+  });
+
+  ///////////////////////////////////////////
+  // Postcode lookup (UK addresses only)
+  ///////////////////////////////////////////
+
+  // ---- 2a-i. Postcode search ----
+  router.get(`/versions/${version}/${section}/${subSection}/postcode-search`, function (req, res) {
+    renderInvoicing(res, req, 'postcode-search');
+  });
+
+  router.post(`/versions/${version}/${section}/${subSection}/postcode-search-router`, function (req, res) {
+    const returnTo = req.query.returnTo;
+    const postcode = req.body['invoice-postcode-search'] || '';
+    const property = req.body['invoice-property-name-number'] || '';
+    const errors = {};
+
+    if (postcode.trim() === '') {
+      errors.postcode = 'Enter the postcode';
+    } else if (!/^[A-Z]{1,2}\d[A-Z\d]?\s*\d[A-Z]{2}$/i.test(postcode.trim())) {
+      errors.postcode = 'Enter a valid postcode';
+    }
+
+    if (property.trim().length > 50) {
+      errors.property = 'The property name or number must be 50 characters or fewer';
+    }
+
+    if (Object.keys(errors).length > 0) {
+      return renderInvoicing(res, req, 'postcode-search', { errors: errors });
+    }
+
+    const results = lookupAddresses(postcode, property);
+
+    // No matches — stay on the page with the "not found" error
+    if (results.length === 0) {
+      return renderInvoicing(res, req, 'postcode-search', {
+        errors: { postcode: 'We could not find any addresses for that postcode. Enter a known postcode, or enter the address manually.' }
+      });
+    }
+
+    // Exactly one match — skip the picker and go straight to confirmation
+    if (results.length === 1) {
+      req.session.data['invoice-selected-address'] = results[0];
+      return res.redirect(`confirm-address${returnToQuery(returnTo)}`);
+    }
+
+    req.session.data['invoice-lookup-results'] = results;
+    res.redirect(`address-picker${returnToQuery(returnTo)}`);
+  });
+
+  // ---- 2a-ii. Address picker ----
+  router.get(`/versions/${version}/${section}/${subSection}/address-picker`, function (req, res) {
+    renderInvoicing(res, req, 'address-picker');
+  });
+
+  router.post(`/versions/${version}/${section}/${subSection}/address-picker-router`, function (req, res) {
+    const returnTo = req.query.returnTo;
+    const selected = req.body['invoice-selected-address-index'];
+
+    if (selected === undefined || selected === '') {
+      return renderInvoicing(res, req, 'address-picker', {
+        errors: { selectedAddress: 'Select an address, or select "None of these"' }
+      });
+    }
+
+    // "None of these" — fall back to manual entry with the searched postcode
+    // already filled in (ML-1492 AC4c).
+    if (selected === 'none') {
+      req.session.data['invoice-postcode'] = req.session.data['invoice-postcode-search'];
+      req.session.data['invoice-address-source'] = 'manual';
+      return res.redirect(`uk-invoice-address${returnToQuery(returnTo)}`);
+    }
+
+    const results = req.session.data['invoice-lookup-results'] || [];
+    req.session.data['invoice-selected-address'] = results[Number(selected)];
+    res.redirect(`confirm-address${returnToQuery(returnTo)}`);
+  });
+
+  // ---- 2a-iii. Review and confirm ----
+  router.get(`/versions/${version}/${section}/${subSection}/confirm-address`, function (req, res) {
+    renderInvoicing(res, req, 'confirm-address');
+  });
+
+  router.post(`/versions/${version}/${section}/${subSection}/confirm-address-router`, function (req, res) {
+    const returnTo = req.query.returnTo;
+    const address = req.session.data['invoice-selected-address'];
+
+    if (!address) {
+      return res.redirect(`postcode-search${returnToQuery(returnTo)}`);
+    }
+
+    storeAddress(req, address);
+
+    // Changing the address from the check page returns there rather than
+    // continuing through contact details (ML-1508 AC2c).
+    if (returnTo === 'check') {
+      return res.redirect('check-invoicing-details');
+    }
+    res.redirect('invoice-contact-details');
   });
 
   // ---- 2b. International invoice address ----
@@ -259,6 +445,10 @@ module.exports = function (router) {
     if (Object.keys(errors).length > 0) {
       return renderInvoicing(res, req, 'uk-invoice-address', { errors: errors });
     }
+
+    // Remember that this address was typed rather than looked up, so the
+    // check page sends the "Change" link back to the right place (ML-1508 AC3).
+    req.session.data['invoice-address-source'] = 'manual';
 
     if (returnTo === 'check') {
       return res.redirect('check-invoicing-details');

--- a/app/views/versions/multiple-sites-v2/low-complexity-v4/fee-and-invoicing/address-picker.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v4/fee-and-invoicing/address-picker.html
@@ -1,0 +1,78 @@
+{% extends "../../layouts/low-complexity-v4.html" %}
+
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+
+{% block beforeContent %}
+	{% include "../../includes/phase-banner.html" %}
+	{% if data['organisation-name'] %}
+		{% include "../../includes/organisation-switcher.html" %}
+	{% endif %}
+	<a class="govuk-back-link govuk-link--no-visited-state" href="postcode-search{% if returnTo %}?returnTo={{ returnTo }}{% endif %}">Back</a>
+{% endblock %}
+
+{% set pageHeadingTextHTML %}
+Choose your address
+{% endset %}
+
+{% block pageTitle %}
+	{% if errors.selectedAddress %}Error: {% endif %}{{ pageHeadingTextHTML }} - {{ data['headerNameExemption'] }}
+{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+	<div class="govuk-grid-column-two-thirds">
+
+		{% if errors.selectedAddress %}
+		{{ govukErrorSummary({
+			titleText: "There is a problem",
+			errorList: [
+				{
+					text: errors.selectedAddress,
+					href: "#invoice-selected-address-index"
+				}
+			]
+		}) }}
+		{% endif %}
+
+		{# Addresses are listed in the order the lookup returned them, followed
+		   by a divider and the "None of these" fallback. #}
+		{% set addressItems = [] %}
+		{% for address in data['invoice-lookup-results'] %}
+			{% set addressItems = (addressItems.push({
+				value: loop.index0 | string,
+				text: address.addressLine
+			}), addressItems) %}
+		{% endfor %}
+		{% set addressItems = (addressItems.push({ divider: "or" }), addressItems) %}
+		{% set addressItems = (addressItems.push({ value: "none", text: "None of these" }), addressItems) %}
+
+		<form action="address-picker-router{% if returnTo %}?returnTo={{ returnTo }}{% endif %}" method="post" novalidate>
+
+			{{ govukRadios({
+				name: "invoice-selected-address-index",
+				id: "invoice-selected-address-index",
+				fieldset: {
+					legend: {
+						html: '<span class="govuk-caption-l">' + data['low-complexity-project-name-text-input'] + '</span>' + pageHeadingTextHTML,
+						isPageHeading: true,
+						classes: "govuk-fieldset__legend--l"
+					}
+				},
+				items: addressItems,
+				errorMessage: {
+					text: errors.selectedAddress
+				} if errors.selectedAddress
+			}) }}
+
+			<div class="govuk-button-group">
+				{{ govukButton({ text: "Continue" }) }}
+				<a class="govuk-link govuk-link--no-visited-state" href="../marine-licence-start-page">Cancel</a>
+			</div>
+
+		</form>
+
+	</div>
+</div>
+{% endblock %}

--- a/app/views/versions/multiple-sites-v2/low-complexity-v4/fee-and-invoicing/check-invoicing-details.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v4/fee-and-invoicing/check-invoicing-details.html
@@ -56,7 +56,9 @@ Check your invoicing details
 					{% endif %}
 				</dd>
 				<dd class="govuk-summary-list__actions">
-					<a class="govuk-link govuk-link--no-visited-state" href="{% if data['invoice-address-type'] == 'international' %}international-invoice-address{% else %}uk-invoice-address{% endif %}?returnTo=check">
+					{# Addresses found by postcode lookup are changed by searching
+					   again; manually entered ones go back to the entry form. #}
+					<a class="govuk-link govuk-link--no-visited-state" href="{% if data['invoice-address-type'] == 'international' %}international-invoice-address{% elif data['invoice-address-source'] == 'lookup' %}postcode-search{% else %}uk-invoice-address{% endif %}?returnTo=check">
 						Change<span class="govuk-visually-hidden"> address</span>
 					</a>
 				</dd>
@@ -81,7 +83,7 @@ Check your invoicing details
 			{% endif %}
 
 			<div class="govuk-summary-list__row govuk-summary-list__row--no-border">
-				<dt class="govuk-summary-list__key">Phone number</dt>
+				<dt class="govuk-summary-list__key">UK phone number</dt>
 				<dd class="govuk-summary-list__value">{{ data['invoice-phone'] }}</dd>
 				<dd class="govuk-summary-list__actions"></dd>
 			</div>

--- a/app/views/versions/multiple-sites-v2/low-complexity-v4/fee-and-invoicing/confirm-address.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v4/fee-and-invoicing/confirm-address.html
@@ -1,0 +1,54 @@
+{% extends "../../layouts/low-complexity-v4.html" %}
+
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block beforeContent %}
+	{% include "../../includes/phase-banner.html" %}
+	{% if data['organisation-name'] %}
+		{% include "../../includes/organisation-switcher.html" %}
+	{% endif %}
+	<a class="govuk-back-link govuk-link--no-visited-state" href="postcode-search{% if returnTo %}?returnTo={{ returnTo }}{% endif %}">Back</a>
+{% endblock %}
+
+{% set pageHeadingTextHTML %}
+Review and confirm
+{% endset %}
+
+{% block pageTitle %}
+	{{ pageHeadingTextHTML }} - {{ data['headerNameExemption'] }}
+{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+	<div class="govuk-grid-column-two-thirds">
+
+		{% set address = data['invoice-selected-address'] %}
+
+		<span class="govuk-caption-l">{{ data['low-complexity-project-name-text-input'] }}</span>
+		<h1 class="govuk-heading-l">{{ pageHeadingTextHTML }}</h1>
+
+		{# The building fields are shown as one line; not every address has
+		   all of them. #}
+		<p class="govuk-body">
+			{{ [address.subBuildingName, address.buildingName, address.buildingNumber, address.street] | select() | join(" ") }}<br>
+			{% if address.locality %}{{ address.locality }}<br>{% endif %}
+			{{ address.town }}<br>
+			{% if address.ceremonialCounty %}{{ address.ceremonialCounty }}<br>{% endif %}
+			{{ address.postcode }}<br>
+			United Kingdom
+		</p>
+
+		<p class="govuk-body">
+			<a class="govuk-link govuk-link--no-visited-state" href="postcode-search{% if returnTo %}?returnTo={{ returnTo }}{% endif %}">Edit address</a>
+		</p>
+
+		<form action="confirm-address-router{% if returnTo %}?returnTo={{ returnTo }}{% endif %}" method="post">
+			<div class="govuk-button-group">
+				{{ govukButton({ text: "Confirm address" }) }}
+				<a class="govuk-link govuk-link--no-visited-state" href="../marine-licence-start-page">Cancel</a>
+			</div>
+		</form>
+
+	</div>
+</div>
+{% endblock %}

--- a/app/views/versions/multiple-sites-v2/low-complexity-v4/fee-and-invoicing/postcode-search.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v4/fee-and-invoicing/postcode-search.html
@@ -1,0 +1,74 @@
+{% extends "../../layouts/low-complexity-v4.html" %}
+
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+
+{% block beforeContent %}
+	{% include "../../includes/phase-banner.html" %}
+	{% if data['organisation-name'] %}
+		{% include "../../includes/organisation-switcher.html" %}
+	{% endif %}
+	<a class="govuk-back-link govuk-link--no-visited-state" href="is-invoice-address-uk-or-international{% if returnTo %}?returnTo={{ returnTo }}{% endif %}">Back</a>
+{% endblock %}
+
+{% set pageHeadingTextHTML %}
+What is the invoice contact's UK address?
+{% endset %}
+
+{% block pageTitle %}
+	{% if errors.postcode or errors.property %}Error: {% endif %}{{ pageHeadingTextHTML }} - {{ data['headerNameExemption'] }}
+{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+	<div class="govuk-grid-column-two-thirds">
+
+		{% if errors.postcode or errors.property %}
+		{% set errorList = [] %}
+		{% if errors.postcode %}{% set errorList = (errorList.push({ text: errors.postcode, href: "#invoice-postcode-search" }), errorList) %}{% endif %}
+		{% if errors.property %}{% set errorList = (errorList.push({ text: errors.property, href: "#invoice-property-name-number" }), errorList) %}{% endif %}
+		{{ govukErrorSummary({
+			titleText: "There is a problem",
+			errorList: errorList
+		}) }}
+		{% endif %}
+
+		<span class="govuk-caption-l">{{ data['low-complexity-project-name-text-input'] }}</span>
+		<h1 class="govuk-heading-l">{{ pageHeadingTextHTML }}</h1>
+
+		<form action="postcode-search-router{% if returnTo %}?returnTo={{ returnTo }}{% endif %}" method="post" novalidate>
+
+			{{ govukInput({
+				label: { text: "Postcode", classes: "govuk-label--s" },
+				classes: "govuk-input--width-10",
+				id: "invoice-postcode-search",
+				name: "invoice-postcode-search",
+				value: data['invoice-postcode-search'],
+				autocomplete: "postal-code",
+				errorMessage: { text: errors.postcode } if errors.postcode
+			}) }}
+
+			{{ govukInput({
+				label: { text: "Property name or number (optional)", classes: "govuk-label--s" },
+				hint: { text: "For example, The Mill, 116 or Flat 37a." },
+				id: "invoice-property-name-number",
+				name: "invoice-property-name-number",
+				value: data['invoice-property-name-number'],
+				errorMessage: { text: errors.property } if errors.property
+			}) }}
+
+			<p class="govuk-body">
+				<a class="govuk-link govuk-link--no-visited-state" href="uk-invoice-address{% if returnTo %}?returnTo={{ returnTo }}{% endif %}">Enter the address manually</a>
+			</p>
+
+			<div class="govuk-button-group">
+				{{ govukButton({ text: "Continue" }) }}
+				<a class="govuk-link govuk-link--no-visited-state" href="../marine-licence-start-page">Cancel</a>
+			</div>
+
+		</form>
+
+	</div>
+</div>
+{% endblock %}

--- a/app/views/versions/multiple-sites-v2/low-complexity-v4/fee-and-invoicing/uk-invoice-address.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v4/fee-and-invoicing/uk-invoice-address.html
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% set pageHeadingTextHTML %}
-UK invoice address
+What is the invoice contact's UK address?
 {% endset %}
 
 {% block pageTitle %}
@@ -91,6 +91,10 @@ UK invoice address
 				<a class="govuk-link govuk-link--no-visited-state" href="../marine-licence-start-page">Cancel</a>
 				{% endif %}
 			</div>
+
+			<p class="govuk-body">
+				<a class="govuk-link govuk-link--no-visited-state" href="postcode-search{% if returnTo %}?returnTo={{ returnTo }}{% endif %}">Back to postcode lookup</a>
+			</p>
 
 		</form>
 

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/tom/Documents/Prototypes/defra/marine-licensing-prototype/node_modules


### PR DESCRIPTION
Introduce a mocked UK postcode lookup flow for fee and invoicing, including search, address selection, and confirmation pages. Route UK address entry through the lookup first, preserve manual entry as a fallback, and track whether an address came from lookup or manual entry so the check details page sends users back to the right change flow.