### PR TITLE
Limit submissions filter to organisations

### DIFF
--- a/app/assets/javascripts/lcml-v4-projects-filter.js
+++ b/app/assets/javascripts/lcml-v4-projects-filter.js
@@ -8,7 +8,7 @@
 
   What it does:
     - builds the Submission type, Status and Owner checkboxes from the
-      rendered table, so options and counts always match what is on the page
+      rendered table, so options always match what is on the page
     - filters rows on Apply, and on removing a selected-filter tag
     - renders the MOJ selected-filter tags
     - wires up MOJ's FilterToggleButton so the panel starts hidden
@@ -16,15 +16,10 @@
   Deliberately no Project name or Reference search for this iteration - we want
   to usability test the panel without them.
 
-  Counts against each option are TOTALS from the table. They do not respond to
-  other active filters. Facet-style counts would prevent more dead ends but
-  would move as you filter - worth a conversation with the team.
-
   Markup it expects (all optional except the table):
     #projects-table, #projects-caption, #no-results-message, #results-count
     #apply-filters, #clear-filters, #selected-filter-tags
     #type-checkboxes, #status-checkboxes, #person-checkboxes
-    #count-all-projects, #count-my-projects
     #conditional-specific-person, #person-error-message
     input[name="projectFilter"]
 */
@@ -79,10 +74,6 @@
         if (item[key] && seen.indexOf(item[key]) === -1) seen.push(item[key])
       })
       return seen.sort(function (a, b) { return a.localeCompare(b) })
-    }
-
-    function countBy (key, value) {
-      return model.filter(function (item) { return item[key] === value }).length
     }
 
     // Owners present in the table. Nobody with zero projects appears, so no
@@ -152,7 +143,7 @@
       uniqueBy('type'),
       'filter-type',
       'type',
-      function (v) { return v + ' (' + countBy('type', v) + ')' }
+      function (v) { return v }
     )
 
     buildCheckboxes(
@@ -160,7 +151,7 @@
       uniqueBy('status'),
       'filter-status',
       'status',
-      function (v) { return v + ' (' + countBy('status', v) + ')' }
+      function (v) { return v }
     )
 
     buildCheckboxes(
@@ -168,13 +159,8 @@
       owners.map(function (o) { return o.value }),
       'filter-person',
       'person',
-      function (v) { return ownerLabels[v] + ' (' + countBy('creator', v) + ')' }
+      function (v) { return ownerLabels[v] }
     )
-
-    var countAll = document.getElementById('count-all-projects')
-    var countMine = document.getElementById('count-my-projects')
-    if (countAll) countAll.textContent = '(' + model.length + ')'
-    if (countMine) countMine.textContent = '(' + countBy('creator', CURRENT_USER) + ')'
 
     // --------------------------------------------------------------- state
 

--- a/app/views/versions/multiple-sites-v2/low-complexity-v4/submissions.html
+++ b/app/views/versions/multiple-sites-v2/low-complexity-v4/submissions.html
@@ -44,8 +44,10 @@
 
 {% block bodyEnd %}
   {{ super() }}
+  {% if data['user_type'] === 'organisation' %}
   {# Pulls in MOJ's FilterToggleButton itself - see the notes in the file. #}
   <script src="/public/javascripts/lcml-v4-projects-filter.js"></script>
+  {% endif %}
 {% endblock %}
 
 <!-- Set a variable to identify this specific page -->
@@ -92,6 +94,9 @@ Submissions
 </div>
 
 {#
+  Filter is organisation users only. Individuals see the table with no
+  panel, no Show filter button, and no results count.
+
   MOJ Design System "Filter a list" pattern.
   https://design-patterns.service.justice.gov.uk/patterns/filter-a-list/
 
@@ -99,6 +104,7 @@ Submissions
   as it does in the MOJ pattern. The panel starts collapsed - MOJ's
   FilterToggleButton adds the Show filter button into .moj-action-bar__filter.
 #}
+{% if data['user_type'] === 'organisation' %}
 <div class="moj-filter-layout moj-filter-layout--narrow">
 	<div class="moj-filter-layout__filter">
 		<div class="moj-filter" data-module="moj-filter">
@@ -127,7 +133,6 @@ Submissions
 						Apply filters
 					</button>
 
-					{% if data['user_type'] === 'organisation' %}
 					<div class="govuk-form-group">
 						<fieldset class="govuk-fieldset">
 							<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Show</legend>
@@ -135,13 +140,13 @@ Submissions
 								<div class="govuk-radios__item">
 									<input class="govuk-radios__input" id="filter-all" name="projectFilter" type="radio" value="all-projects">
 									<label class="govuk-label govuk-radios__label" for="filter-all">
-										All {{ data['organisation-name'] or "Ramsgate Marina" }} submissions <span id="count-all-projects"></span>
+										All {{ data['organisation-name'] or "Ramsgate Marina" }} submissions
 									</label>
 								</div>
 								<div class="govuk-radios__item">
 									<input class="govuk-radios__input" id="filter-my" name="projectFilter" type="radio" value="my-projects" checked>
 									<label class="govuk-label govuk-radios__label" for="filter-my">
-										My submissions <span id="count-my-projects"></span>
+										My submissions
 									</label>
 								</div>
 								<div class="govuk-radios__item">
@@ -160,7 +165,6 @@ Submissions
 							</div>
 						</fieldset>
 					</div>
-					{% endif %}
 
 					<div class="govuk-form-group">
 						<fieldset class="govuk-fieldset">
@@ -187,6 +191,7 @@ Submissions
 		</div>
 
 		<p id="results-count" class="govuk-body"></p>
+{% endif %}
 
 		{#
 		  Status column sorts on data-sort-value, not the tag text, so the order is
@@ -439,6 +444,7 @@ Submissions
 					</td>
 				</tr>
 
+				{% if data['user_type'] === 'organisation' %}
 				<tr class="govuk-table__row" data-creator="alex-williams" data-project-name="Plymouth harbour core samples" data-type="Exempt activity notification" data-reference="EXE-10023" data-status="Active">
 					<th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Plymouth harbour core samples</th>
 					<td class="govuk-table__cell">Exempt activity notification</td>
@@ -495,6 +501,7 @@ Submissions
 						<a href="#" class="govuk-link--no-visited-state">View details</a>
 					</td>
 				</tr>
+				{% endif %}
 
 				{% if data['deleted-whitstable'] != 'true' %}
 				<tr class="govuk-table__row" data-creator="jon-doe" data-project-name="Whitstable intertidal survey pits" data-type="Exempt activity notification" data-reference="-" data-status="Draft" id="project-whitstable">
@@ -517,6 +524,7 @@ Submissions
 				</tr>
 				{% endif %}
 
+				{% if data['user_type'] === 'organisation' %}
 				<tr class="govuk-table__row" data-creator="alex-williams" data-project-name="Scarborough seabed grab samples" data-type="Exempt activity notification" data-reference="-" data-status="Draft">
 					<th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Scarborough seabed grab samples</th>
 					<td class="govuk-table__cell">Exempt activity notification</td>
@@ -535,13 +543,16 @@ Submissions
 						
 					</td>
 				</tr>
+				{% endif %}
 
 			</tbody>
 		</table>
 
+		{% if data['user_type'] === 'organisation' %}
 		<p id="no-results-message" class="govuk-body" style="display: none;">There are no submissions to display.</p>
 	</div>
 </div>
+		{% endif %}
 
 {% endblock %}
 


### PR DESCRIPTION
Restricts the submissions filtering experience to organisation users by conditionally rendering the filter panel, results-count/no-results UI, and loading the filter JavaScript only for that user type. It also simplifies filter option labels by removing dynamic per-option and project total counts from both the template and client-side filter script.